### PR TITLE
Add multi-type MIDI button support: CC, Note, PC, PC+, PC− (integrates #51, #53, #56)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,8 @@ git push origin v1.0.0-alpha.1
 
 ## CircuitPython Practices
 
+This project uses CircuitPython firmware deployed to hardware devices (Mini6, MCM, STD10). Always verify changes work with the target hardware constraints. For mpy-cross, use Adafruit's CircuitPython builds, NOT MicroPython pip packages.
+
 - Target **CircuitPython 7.x** (7.3.1 verified on devices)
 - Board identifies as `raspberry_pi_pico` (RP2040 MCU)
 - USB CDC disconnects on reset — use auto-reconnect serial workflows

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import ColorSelect from './ColorSelect.svelte';
-  import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType, StateOverride } from '$lib/types';
+  import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType } from '$lib/types';
   import { validationErrors, syncButtonStates } from '$lib/formStore';
 
   interface Props {
@@ -106,7 +106,7 @@
 
   function handleKeytimesChange(e: Event) {
     const target = e.target as HTMLInputElement;
-    const value = target.value === '' ? 1 : Math.max(1, parseInt(target.value) || 1);
+    const value = target.value === '' ? 1 : Math.min(99, Math.max(1, parseInt(target.value) || 1));
     syncButtonStates(index, value);
   }
 
@@ -123,6 +123,10 @@
   function handleStateLabelChange(si: number, e: Event) {
     const target = e.target as HTMLInputElement;
     onUpdate(`states[${si}].label`, target.value === '' ? undefined : target.value);
+  }
+
+  function stateError(si: number, field: string): string | undefined {
+    return $validationErrors.get(`${basePath}.states[${si}].${field}`);
   }
 
   let labelError = $derived($validationErrors.get(`${basePath}.label`));
@@ -314,62 +318,70 @@
           {#if isCC}
             <div class="field">
               <label class="field-label">CC:</label>
-              <input type="number" class="input-cc"
+              <input type="number" class="input-cc" class:error={!!stateError(si, 'cc')}
                 value={state.cc !== undefined ? state.cc : ''}
                 onblur={(e) => handleStateFieldChange(si, 'cc', e)}
                 min="0" max="127" placeholder={String(button.cc ?? '')} />
+              {#if stateError(si, 'cc')}<span class="error-text">{stateError(si, 'cc')}</span>{/if}
             </div>
             <div class="field">
               <label class="field-label">ON Val:</label>
-              <input type="number" class="input-cc-value"
+              <input type="number" class="input-cc-value" class:error={!!stateError(si, 'cc_on')}
                 value={state.cc_on !== undefined ? state.cc_on : ''}
                 onblur={(e) => handleStateFieldChange(si, 'cc_on', e)}
                 min="0" max="127" placeholder={String(button.cc_on ?? 127)} />
+              {#if stateError(si, 'cc_on')}<span class="error-text">{stateError(si, 'cc_on')}</span>{/if}
             </div>
             <div class="field">
               <label class="field-label">OFF Val:</label>
-              <input type="number" class="input-cc-value"
+              <input type="number" class="input-cc-value" class:error={!!stateError(si, 'cc_off')}
                 value={state.cc_off !== undefined ? state.cc_off : ''}
                 onblur={(e) => handleStateFieldChange(si, 'cc_off', e)}
                 min="0" max="127" placeholder={String(button.cc_off ?? 0)} />
+              {#if stateError(si, 'cc_off')}<span class="error-text">{stateError(si, 'cc_off')}</span>{/if}
             </div>
           {:else if isNote}
             <div class="field">
               <label class="field-label">Note:</label>
-              <input type="number" class="input-cc"
+              <input type="number" class="input-cc" class:error={!!stateError(si, 'note')}
                 value={state.note !== undefined ? state.note : ''}
                 onblur={(e) => handleStateFieldChange(si, 'note', e)}
                 min="0" max="127" placeholder={String(button.note ?? 60)} />
+              {#if stateError(si, 'note')}<span class="error-text">{stateError(si, 'note')}</span>{/if}
             </div>
             <div class="field">
               <label class="field-label">Vel ON:</label>
-              <input type="number" class="input-cc-value"
+              <input type="number" class="input-cc-value" class:error={!!stateError(si, 'velocity_on')}
                 value={state.velocity_on !== undefined ? state.velocity_on : ''}
                 onblur={(e) => handleStateFieldChange(si, 'velocity_on', e)}
                 min="0" max="127" placeholder={String(button.velocity_on ?? 127)} />
+              {#if stateError(si, 'velocity_on')}<span class="error-text">{stateError(si, 'velocity_on')}</span>{/if}
             </div>
             <div class="field">
               <label class="field-label">Vel OFF:</label>
-              <input type="number" class="input-cc-value"
+              <input type="number" class="input-cc-value" class:error={!!stateError(si, 'velocity_off')}
                 value={state.velocity_off !== undefined ? state.velocity_off : ''}
                 onblur={(e) => handleStateFieldChange(si, 'velocity_off', e)}
                 min="0" max="127" placeholder={String(button.velocity_off ?? 0)} />
+              {#if stateError(si, 'velocity_off')}<span class="error-text">{stateError(si, 'velocity_off')}</span>{/if}
             </div>
           {:else if isPC}
             <div class="field">
               <label class="field-label">Program:</label>
-              <input type="number" class="input-cc"
+              <input type="number" class="input-cc" class:error={!!stateError(si, 'program')}
                 value={state.program !== undefined ? state.program : ''}
                 onblur={(e) => handleStateFieldChange(si, 'program', e)}
                 min="0" max="127" placeholder={String(button.program ?? 0)} />
+              {#if stateError(si, 'program')}<span class="error-text">{stateError(si, 'program')}</span>{/if}
             </div>
           {:else if isPCIncDec}
             <div class="field">
               <label class="field-label">Step:</label>
-              <input type="number" class="input-cc"
+              <input type="number" class="input-cc" class:error={!!stateError(si, 'pc_step')}
                 value={state.pc_step !== undefined ? state.pc_step : ''}
                 onblur={(e) => handleStateFieldChange(si, 'pc_step', e)}
                 min="1" max="127" placeholder={String(button.pc_step ?? 1)} />
+              {#if stateError(si, 'pc_step')}<span class="error-text">{stateError(si, 'pc_step')}</span>{/if}
             </div>
           {/if}
 
@@ -382,11 +394,12 @@
           </div>
           <div class="field">
             <label class="field-label">Label:</label>
-            <input type="text" class="input-label"
+            <input type="text" class="input-label" class:error={!!stateError(si, 'label')}
               value={state.label ?? ''}
               onblur={(e) => handleStateLabelChange(si, e)}
               maxlength="6"
               placeholder={button.label} />
+            {#if stateError(si, 'label')}<span class="error-text">{stateError(si, 'label')}</span>{/if}
           </div>
         </div>
       {/each}

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import ColorSelect from './ColorSelect.svelte';
-  import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType } from '$lib/types';
-  import { validationErrors } from '$lib/formStore';
+  import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType, StateOverride } from '$lib/types';
+  import { validationErrors, syncButtonStates } from '$lib/formStore';
 
   interface Props {
     button: ButtonConfig;
@@ -99,6 +99,30 @@
   function handlePCStepChange(e: Event) {
     const target = e.target as HTMLInputElement;
     onUpdate('pc_step', parseInt(target.value));
+  }
+
+  let hasKeytimes = $derived((button.keytimes ?? 1) > 1);
+  let keytimesError = $derived($validationErrors.get(`${basePath}.keytimes`));
+
+  function handleKeytimesChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const value = target.value === '' ? 1 : Math.max(1, parseInt(target.value) || 1);
+    syncButtonStates(index, value);
+  }
+
+  function handleStateFieldChange(si: number, field: string, e: Event) {
+    const target = e.target as HTMLInputElement;
+    const value = target.value === '' ? undefined : parseInt(target.value);
+    onUpdate(`states[${si}].${field}`, value);
+  }
+
+  function handleStateColorChange(si: number, color: ButtonColor) {
+    onUpdate(`states[${si}].color`, color);
+  }
+
+  function handleStateLabelChange(si: number, e: Event) {
+    const target = e.target as HTMLInputElement;
+    onUpdate(`states[${si}].label`, target.value === '' ? undefined : target.value);
   }
 
   let labelError = $derived($validationErrors.get(`${basePath}.label`));
@@ -241,6 +265,21 @@
   {/if}
 
   <div class="field">
+    <label class="field-label">Keytimes:</label>
+    <input
+      type="number"
+      class="input-cc"
+      class:error={!!keytimesError}
+      value={button.keytimes ?? 1}
+      onblur={handleKeytimesChange}
+      disabled={disabled}
+      min="1"
+      max="99"
+    />
+    {#if keytimesError}<span class="error-text">{keytimesError}</span>{/if}
+  </div>
+
+  <div class="field">
     <label class="field-label">LED Color:</label>
     <ColorSelect
       value={button.color}
@@ -262,6 +301,95 @@
         <option value="dim">Dim</option>
         <option value="off">Off</option>
       </select>
+    </div>
+  {/if}
+
+  {#if hasKeytimes && !disabled}
+    <div class="states-section">
+      <span class="states-label">States ({button.states?.length ?? 0}):</span>
+      {#each (button.states ?? []) as state, si}
+        <div class="state-row">
+          <span class="state-num">S{si + 1}:</span>
+
+          {#if isCC}
+            <div class="field">
+              <label class="field-label">CC:</label>
+              <input type="number" class="input-cc"
+                value={state.cc !== undefined ? state.cc : ''}
+                onblur={(e) => handleStateFieldChange(si, 'cc', e)}
+                min="0" max="127" placeholder={String(button.cc ?? '')} />
+            </div>
+            <div class="field">
+              <label class="field-label">ON Val:</label>
+              <input type="number" class="input-cc-value"
+                value={state.cc_on !== undefined ? state.cc_on : ''}
+                onblur={(e) => handleStateFieldChange(si, 'cc_on', e)}
+                min="0" max="127" placeholder={String(button.cc_on ?? 127)} />
+            </div>
+            <div class="field">
+              <label class="field-label">OFF Val:</label>
+              <input type="number" class="input-cc-value"
+                value={state.cc_off !== undefined ? state.cc_off : ''}
+                onblur={(e) => handleStateFieldChange(si, 'cc_off', e)}
+                min="0" max="127" placeholder={String(button.cc_off ?? 0)} />
+            </div>
+          {:else if isNote}
+            <div class="field">
+              <label class="field-label">Note:</label>
+              <input type="number" class="input-cc"
+                value={state.note !== undefined ? state.note : ''}
+                onblur={(e) => handleStateFieldChange(si, 'note', e)}
+                min="0" max="127" placeholder={String(button.note ?? 60)} />
+            </div>
+            <div class="field">
+              <label class="field-label">Vel ON:</label>
+              <input type="number" class="input-cc-value"
+                value={state.velocity_on !== undefined ? state.velocity_on : ''}
+                onblur={(e) => handleStateFieldChange(si, 'velocity_on', e)}
+                min="0" max="127" placeholder={String(button.velocity_on ?? 127)} />
+            </div>
+            <div class="field">
+              <label class="field-label">Vel OFF:</label>
+              <input type="number" class="input-cc-value"
+                value={state.velocity_off !== undefined ? state.velocity_off : ''}
+                onblur={(e) => handleStateFieldChange(si, 'velocity_off', e)}
+                min="0" max="127" placeholder={String(button.velocity_off ?? 0)} />
+            </div>
+          {:else if isPC}
+            <div class="field">
+              <label class="field-label">Program:</label>
+              <input type="number" class="input-cc"
+                value={state.program !== undefined ? state.program : ''}
+                onblur={(e) => handleStateFieldChange(si, 'program', e)}
+                min="0" max="127" placeholder={String(button.program ?? 0)} />
+            </div>
+          {:else if isPCIncDec}
+            <div class="field">
+              <label class="field-label">Step:</label>
+              <input type="number" class="input-cc"
+                value={state.pc_step !== undefined ? state.pc_step : ''}
+                onblur={(e) => handleStateFieldChange(si, 'pc_step', e)}
+                min="1" max="127" placeholder={String(button.pc_step ?? 1)} />
+            </div>
+          {/if}
+
+          <div class="field">
+            <label class="field-label">Color:</label>
+            <ColorSelect
+              value={state.color ?? button.color}
+              onchange={(color) => handleStateColorChange(si, color)}
+            />
+          </div>
+          <div class="field">
+            <label class="field-label">Label:</label>
+            <input type="text" class="input-label"
+              value={state.label ?? ''}
+              onblur={(e) => handleStateLabelChange(si, e)}
+              maxlength="6"
+              placeholder={button.label} />
+          </div>
+        </div>
+      {/each}
     </div>
   {/if}
 
@@ -363,6 +491,41 @@
     color: #dc3545;
     white-space: nowrap;
     margin-top: 2px;
+  }
+
+  .states-section {
+    width: 100%;
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px dashed #e0e0e0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .states-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #555;
+    margin-bottom: 0.25rem;
+  }
+
+  .state-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    padding: 0.25rem 0.5rem;
+    background: #fafafa;
+    border: 1px solid #eee;
+    border-radius: 4px;
+  }
+
+  .state-num {
+    font-size: 0.75rem;
+    color: #888;
+    min-width: 28px;
+    padding-top: 1.5rem;
   }
 
   .disabled-overlay {

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import ColorSelect from './ColorSelect.svelte';
-  import type { ButtonConfig, ButtonColor, ButtonMode, OffMode } from '$lib/types';
+  import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType } from '$lib/types';
   import { validationErrors } from '$lib/formStore';
-  
+
   interface Props {
     button: ButtonConfig;
     index: number;
@@ -10,35 +10,42 @@
     globalChannel?: number;
     onUpdate: (field: string, value: any) => void;
   }
-  
+
   let { button, index, disabled = false, globalChannel = 0, onUpdate }: Props = $props();
-  
+
   const basePath = `buttons[${index}]`;
-  
+
+  let msgType = $derived((button.type ?? 'cc') as MessageType);
+  let isCC = $derived(msgType === 'cc');
+  let isNote = $derived(msgType === 'note');
+  let isPC = $derived(msgType === 'pc');
+  let isPCIncDec = $derived(msgType === 'pc_inc' || msgType === 'pc_dec');
+  let showMode = $derived(isCC || isNote);
+
   function handleLabelChange(e: Event) {
     const target = e.target as HTMLInputElement;
     onUpdate('label', target.value);
   }
-  
+
   function handleCCChange(e: Event) {
     const target = e.target as HTMLInputElement;
     onUpdate('cc', parseInt(target.value));
   }
-  
+
   function handleColorChange(color: ButtonColor) {
     onUpdate('color', color);
   }
-  
+
   function handleModeChange(e: Event) {
     const target = e.target as HTMLSelectElement;
     onUpdate('mode', target.value as ButtonMode);
   }
-  
+
   function handleOffModeChange(e: Event) {
     const target = e.target as HTMLSelectElement;
     onUpdate('off_mode', target.value as OffMode);
   }
-  
+
   function handleChannelChange(e: Event) {
     const target = e.target as HTMLInputElement;
     if (target.value === '') {
@@ -49,30 +56,67 @@
       onUpdate('channel', value - 1);
     }
   }
-  
+
   function handleCCOnChange(e: Event) {
     const target = e.target as HTMLInputElement;
     const value = target.value === '' ? undefined : parseInt(target.value);
     onUpdate('cc_on', value);
   }
-  
+
   function handleCCOffChange(e: Event) {
     const target = e.target as HTMLInputElement;
     const value = target.value === '' ? undefined : parseInt(target.value);
     onUpdate('cc_off', value);
   }
-  
+
+  function handleTypeChange(e: Event) {
+    const target = e.target as HTMLSelectElement;
+    onUpdate('type', target.value as MessageType);
+  }
+
+  function handleNoteChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    onUpdate('note', parseInt(target.value));
+  }
+
+  function handleVelocityOnChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const value = target.value === '' ? undefined : parseInt(target.value);
+    onUpdate('velocity_on', value);
+  }
+
+  function handleVelocityOffChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const value = target.value === '' ? undefined : parseInt(target.value);
+    onUpdate('velocity_off', value);
+  }
+
+  function handleProgramChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    onUpdate('program', parseInt(target.value));
+  }
+
+  function handlePCStepChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    onUpdate('pc_step', parseInt(target.value));
+  }
+
   let labelError = $derived($validationErrors.get(`${basePath}.label`));
   let ccError = $derived($validationErrors.get(`${basePath}.cc`));
   let channelError = $derived($validationErrors.get(`${basePath}.channel`));
   let ccOnError = $derived($validationErrors.get(`${basePath}.cc_on`));
   let ccOffError = $derived($validationErrors.get(`${basePath}.cc_off`));
-  
+  let noteError = $derived($validationErrors.get(`${basePath}.note`));
+  let velocityOnError = $derived($validationErrors.get(`${basePath}.velocity_on`));
+  let velocityOffError = $derived($validationErrors.get(`${basePath}.velocity_off`));
+  let programError = $derived($validationErrors.get(`${basePath}.program`));
+  let pcStepError = $derived($validationErrors.get(`${basePath}.pc_step`));
+
   // Display effective channel as 1-16 (stored internally as 0-15)
   let effectiveChannel = $derived(
     button.channel !== undefined ? button.channel + 1 : globalChannel + 1
   );
-  
+
   // Display button channel as 1-16 if set (stored as 0-15)
   let displayChannel = $derived(
     button.channel !== undefined ? button.channel + 1 : undefined
@@ -82,10 +126,10 @@
 
 <div class="button-row" class:disabled>
   <span class="button-num">Button {index + 1}:</span>
-  
+
   <div class="field">
-    <input 
-      type="text" 
+    <input
+      type="text"
       class="input-label"
       class:error={!!labelError}
       value={button.label}
@@ -100,9 +144,25 @@
   </div>
 
   <div class="field">
+    <label class="field-label">Type:</label>
+    <select
+      class="select"
+      value={button.type ?? 'cc'}
+      onchange={handleTypeChange}
+      disabled={disabled}
+    >
+      <option value="cc">CC</option>
+      <option value="note">Note</option>
+      <option value="pc">PC Fixed</option>
+      <option value="pc_inc">PC+</option>
+      <option value="pc_dec">PC-</option>
+    </select>
+  </div>
+
+  <div class="field">
     <label class="field-label">Channel:</label>
-    <input 
-      type="number" 
+    <input
+      type="number"
       class="input-channel"
       class:error={!!channelError}
       value={displayChannel !== undefined ? displayChannel : ''}
@@ -117,94 +177,94 @@
       <span class="error-text">{channelError}</span>
     {/if}
   </div>
-  
-  <div class="field">
-    <label class="field-label">CC:</label>
-    <input 
-      type="number" 
-      class="input-cc"
-      class:error={!!ccError}
-      value={button.cc}
-      onblur={handleCCChange}
-      disabled={disabled}
-      min="0"
-      max="127"
-    />
-    {#if ccError}
-      <span class="error-text">{ccError}</span>
-    {/if}
-  </div>
-  
-  <div class="field">
-    <label class="field-label">ON Value:</label>
-    <input 
-      type="number" 
-      class="input-cc-value"
-      class:error={!!ccOnError}
-      value={button.cc_on !== undefined ? button.cc_on : ''}
-      onblur={handleCCOnChange}
-      disabled={disabled}
-      min="0"
-      max="127"
-      placeholder="127"
-    />
-    {#if ccOnError}
-      <span class="error-text">{ccOnError}</span>
-    {/if}
-  </div>
-  
-  <div class="field">
-    <label class="field-label">OFF Value:</label>
-    <input 
-      type="number" 
-      class="input-cc-value"
-      class:error={!!ccOffError}
-      value={button.cc_off !== undefined ? button.cc_off : ''}
-      onblur={handleCCOffChange}
-      disabled={disabled}
-      min="0"
-      max="127"
-      placeholder="0"
-    />
-    {#if ccOffError}
-      <span class="error-text">{ccOffError}</span>
-    {/if}
-  </div>
-  
+
+  {#if isCC}
+    <div class="field">
+      <label class="field-label">CC:</label>
+      <input type="number" class="input-cc" class:error={!!ccError}
+        value={button.cc ?? ''} onblur={handleCCChange} disabled={disabled}
+        min="0" max="127" />
+      {#if ccError}<span class="error-text">{ccError}</span>{/if}
+    </div>
+    <div class="field">
+      <label class="field-label">ON Value:</label>
+      <input type="number" class="input-cc-value" class:error={!!ccOnError}
+        value={button.cc_on !== undefined ? button.cc_on : ''} onblur={handleCCOnChange}
+        disabled={disabled} min="0" max="127" placeholder="127" />
+      {#if ccOnError}<span class="error-text">{ccOnError}</span>{/if}
+    </div>
+    <div class="field">
+      <label class="field-label">OFF Value:</label>
+      <input type="number" class="input-cc-value" class:error={!!ccOffError}
+        value={button.cc_off !== undefined ? button.cc_off : ''} onblur={handleCCOffChange}
+        disabled={disabled} min="0" max="127" placeholder="0" />
+      {#if ccOffError}<span class="error-text">{ccOffError}</span>{/if}
+    </div>
+  {:else if isNote}
+    <div class="field">
+      <label class="field-label">Note:</label>
+      <input type="number" class="input-cc" class:error={!!noteError}
+        value={button.note ?? 60} onblur={handleNoteChange} disabled={disabled}
+        min="0" max="127" />
+      {#if noteError}<span class="error-text">{noteError}</span>{/if}
+    </div>
+    <div class="field">
+      <label class="field-label">Vel ON:</label>
+      <input type="number" class="input-cc-value" class:error={!!velocityOnError}
+        value={button.velocity_on !== undefined ? button.velocity_on : ''} onblur={handleVelocityOnChange}
+        disabled={disabled} min="0" max="127" placeholder="127" />
+      {#if velocityOnError}<span class="error-text">{velocityOnError}</span>{/if}
+    </div>
+    <div class="field">
+      <label class="field-label">Vel OFF:</label>
+      <input type="number" class="input-cc-value" class:error={!!velocityOffError}
+        value={button.velocity_off !== undefined ? button.velocity_off : ''} onblur={handleVelocityOffChange}
+        disabled={disabled} min="0" max="127" placeholder="0" />
+      {#if velocityOffError}<span class="error-text">{velocityOffError}</span>{/if}
+    </div>
+  {:else if isPC}
+    <div class="field">
+      <label class="field-label">Program:</label>
+      <input type="number" class="input-cc" class:error={!!programError}
+        value={button.program ?? 0} onblur={handleProgramChange} disabled={disabled}
+        min="0" max="127" />
+      {#if programError}<span class="error-text">{programError}</span>{/if}
+    </div>
+  {:else if isPCIncDec}
+    <div class="field">
+      <label class="field-label">Step:</label>
+      <input type="number" class="input-cc" class:error={!!pcStepError}
+        value={button.pc_step ?? 1} onblur={handlePCStepChange} disabled={disabled}
+        min="1" max="127" />
+      {#if pcStepError}<span class="error-text">{pcStepError}</span>{/if}
+    </div>
+  {/if}
+
   <div class="field">
     <label class="field-label">LED Color:</label>
-    <ColorSelect 
-      value={button.color} 
+    <ColorSelect
+      value={button.color}
       onchange={handleColorChange}
     />
   </div>
-  
-  <div class="field">
-    <label class="field-label">Switch Mode:</label>
-    <select 
-      class="select"
-      value={button.mode || 'toggle'}
-      onchange={handleModeChange}
-      disabled={disabled}
-    >
-      <option value="toggle">Toggle</option>
-      <option value="momentary">Momentary</option>
-    </select>
-  </div>
-  
-  <div class="field">
-    <label class="field-label">LED Off Mode:</label>
-    <select 
-      class="select"
-      value={button.off_mode || 'dim'}
-      onchange={handleOffModeChange}
-      disabled={disabled}
-    >
-      <option value="dim">Dim</option>
-      <option value="off">Off</option>
-    </select>
-  </div>
-  
+
+  {#if showMode}
+    <div class="field">
+      <label class="field-label">Switch Mode:</label>
+      <select class="select" value={button.mode || 'toggle'} onchange={handleModeChange} disabled={disabled}>
+        <option value="toggle">Toggle</option>
+        <option value="momentary">Momentary</option>
+      </select>
+    </div>
+    <div class="field">
+      <label class="field-label">LED Off Mode:</label>
+      <select class="select" value={button.off_mode || 'dim'} onchange={handleOffModeChange} disabled={disabled}>
+        <option value="dim">Dim</option>
+        <option value="off">Off</option>
+      </select>
+    </div>
+  {/if}
+
   {#if disabled}
     <div class="disabled-overlay">
       Not available on Mini6
@@ -224,19 +284,19 @@
     position: relative;
     flex-wrap: wrap;
   }
-  
+
   .button-row.disabled {
     opacity: 0.6;
     background: #f9f9f9;
   }
-  
+
   .button-num {
     font-weight: 500;
     color: #666;
     min-width: 80px;
     padding-top: 0.4rem;
   }
-  
+
   .field {
     display: flex;
     align-items: center;
@@ -244,13 +304,13 @@
     flex-direction: column;
     position: relative;
   }
-  
+
   .field-label {
     font-size: 0.75rem;
     color: #666;
     align-self: flex-start;
   }
-  
+
   .input-label {
     width: 80px;
     padding: 0.375rem 0.5rem;
@@ -258,7 +318,7 @@
     border-radius: 4px;
     font-size: 0.875rem;
   }
-  
+
   .input-cc {
     width: 60px;
     padding: 0.375rem 0.5rem;
@@ -266,7 +326,7 @@
     border-radius: 4px;
     font-size: 0.875rem;
   }
-  
+
   .input-channel {
     width: 60px;
     padding: 0.375rem 0.5rem;
@@ -274,7 +334,7 @@
     border-radius: 4px;
     font-size: 0.875rem;
   }
-  
+
   .input-cc-value {
     width: 60px;
     padding: 0.375rem 0.5rem;
@@ -282,7 +342,7 @@
     border-radius: 4px;
     font-size: 0.875rem;
   }
-  
+
   .select {
     padding: 0.375rem 0.5rem;
     border: 1px solid #ccc;
@@ -290,11 +350,11 @@
     font-size: 0.875rem;
     background: white;
   }
-  
+
   input.error {
     border-color: #dc3545;
   }
-  
+
   .error-text {
     position: absolute;
     top: 100%;
@@ -304,7 +364,7 @@
     white-space: nowrap;
     margin-top: 2px;
   }
-  
+
   .disabled-overlay {
     position: absolute;
     top: 0;

--- a/config-editor/src/lib/formStore.ts
+++ b/config-editor/src/lib/formStore.ts
@@ -186,6 +186,33 @@ export function updateField(path: string, value: any) {
   }, DEBOUNCE_MS);
 }
 
+export function syncButtonStates(buttonIndex: number, keytimes: number) {
+  formState.update(state => {
+    const newConfig = structuredClone(state.config);
+    const btn = newConfig.buttons[buttonIndex];
+    if (!btn) return state;
+
+    if (keytimes <= 1) {
+      delete btn.keytimes;
+      delete btn.states;
+    } else {
+      btn.keytimes = keytimes;
+      const current = btn.states ?? [];
+      if (current.length < keytimes) {
+        while (current.length < keytimes) current.push({});
+      } else if (current.length > keytimes) {
+        current.length = keytimes;
+      }
+      btn.states = current;
+    }
+
+    return { ...state, config: newConfig, isDirty: true };
+  });
+
+  validate();
+  formState.update(state => pushHistory(state));
+}
+
 function createDefaultButton(index: number): ButtonConfig {
   return {
     label: `BTN${index}`,

--- a/config-editor/src/lib/formStore.ts
+++ b/config-editor/src/lib/formStore.ts
@@ -187,6 +187,11 @@ export function updateField(path: string, value: any) {
 }
 
 export function syncButtonStates(buttonIndex: number, keytimes: number) {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+
   formState.update(state => {
     const newConfig = structuredClone(state.config);
     const btn = newConfig.buttons[buttonIndex];

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -6,18 +6,29 @@ export type ButtonColor =
 
 export type ButtonMode = 'toggle' | 'momentary';
 export type OffMode = 'dim' | 'off';
+export type MessageType = 'cc' | 'note' | 'pc' | 'pc_inc' | 'pc_dec';
 export type Polarity = 'normal' | 'inverted';
 export type DeviceType = 'std10' | 'mini6';
 
 export interface ButtonConfig {
   label: string;
-  cc: number;
   color: ButtonColor;
+  type?: MessageType;      // defaults to 'cc'
   mode?: ButtonMode;
   off_mode?: OffMode;
-  channel?: number;  // Stored as 0-15, displayed as 1-16
-  cc_on?: number;    // CC value when button is ON (default: 127)
-  cc_off?: number;   // CC value when button is OFF (default: 0)
+  channel?: number;        // Stored as 0-15, displayed as 1-16
+  // CC fields (type='cc')
+  cc?: number;
+  cc_on?: number;          // CC value when ON (default: 127)
+  cc_off?: number;         // CC value when OFF (default: 0)
+  // Note fields (type='note')
+  note?: number;           // MIDI note number 0-127
+  velocity_on?: number;    // Note velocity when ON (default: 127)
+  velocity_off?: number;   // Note velocity when OFF (default: 0)
+  // PC fields (type='pc')
+  program?: number;        // Program number 0-127
+  // PC inc/dec fields (type='pc_inc' | 'pc_dec')
+  pc_step?: number;        // Step size (default: 1)
 }
 
 export interface EncoderPush {

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -10,6 +10,17 @@ export type MessageType = 'cc' | 'note' | 'pc' | 'pc_inc' | 'pc_dec';
 export type Polarity = 'normal' | 'inverted';
 export type DeviceType = 'std10' | 'mini6';
 
+export interface StateOverride {
+  cc?: number;
+  cc_on?: number;
+  cc_off?: number;
+  note?: number;
+  velocity_on?: number;
+  velocity_off?: number;
+  color?: ButtonColor;
+  label?: string;
+}
+
 export interface ButtonConfig {
   label: string;
   color: ButtonColor;
@@ -29,6 +40,9 @@ export interface ButtonConfig {
   program?: number;        // Program number 0-127
   // PC inc/dec fields (type='pc_inc' | 'pc_dec')
   pc_step?: number;        // Step size (default: 1)
+  // Keytimes cycling
+  keytimes?: number;         // States to cycle through on press (1-99); 1 = no cycling
+  states?: StateOverride[];  // Per-state overrides; length should match keytimes
 }
 
 export interface EncoderPush {

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -17,6 +17,8 @@ export interface StateOverride {
   note?: number;
   velocity_on?: number;
   velocity_off?: number;
+  program?: number;
+  pc_step?: number;
   color?: ButtonColor;
   label?: string;
 }

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -66,14 +66,14 @@ export const validators = {
   },
 
   pcStep: (value: number): string | null => {
-    if (value < 1 || value > 127) return 'Step must be between 1 and 127';
     if (!Number.isInteger(value)) return 'Step must be an integer';
+    if (value < 1 || value > 127) return 'Step must be between 1 and 127';
     return null;
   },
 
   keytimes: (value: number): string | null => {
-    if (value < 1 || value > 99) return 'Keytimes must be between 1 and 99';
     if (!Number.isInteger(value)) return 'Keytimes must be an integer';
+    if (value < 1 || value > 99) return 'Keytimes must be between 1 and 99';
     return null;
   },
 };
@@ -130,6 +130,10 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
         const stepError = validators.pcStep(btn.pc_step);
         if (stepError) errors.set(`buttons[${idx}].pc_step`, stepError);
       }
+    }
+
+    if (btn.states && (btn.keytimes === undefined || btn.keytimes <= 1)) {
+      errors.set(`buttons[${idx}].states`, 'states requires keytimes > 1');
     }
 
     if (btn.keytimes !== undefined) {

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -48,7 +48,6 @@ export const validators = {
   },
 
   note: (value: number): string | null => {
-    if (value === undefined || value === null) return 'Note is required';
     if (value < 0 || value > 127) return 'Note must be between 0 and 127';
     if (!Number.isInteger(value)) return 'Note must be an integer';
     return null;
@@ -61,7 +60,6 @@ export const validators = {
   },
 
   program: (value: number): string | null => {
-    if (value === undefined || value === null) return 'Program is required';
     if (value < 0 || value > 127) return 'Program must be between 0 and 127';
     if (!Number.isInteger(value)) return 'Program must be an integer';
     return null;

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -70,6 +70,12 @@ export const validators = {
     if (!Number.isInteger(value)) return 'Step must be an integer';
     return null;
   },
+
+  keytimes: (value: number): string | null => {
+    if (value < 1 || value > 99) return 'Keytimes must be between 1 and 99';
+    if (!Number.isInteger(value)) return 'Keytimes must be an integer';
+    return null;
+  },
 };
 
 export function validateConfig(config: MidiCaptainConfig): ValidationResult {
@@ -123,6 +129,41 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
       if (btn.pc_step !== undefined) {
         const stepError = validators.pcStep(btn.pc_step);
         if (stepError) errors.set(`buttons[${idx}].pc_step`, stepError);
+      }
+    }
+
+    if (btn.keytimes !== undefined) {
+      const ktError = validators.keytimes(btn.keytimes);
+      if (ktError) errors.set(`buttons[${idx}].keytimes`, ktError);
+
+      if (btn.states) {
+        btn.states.forEach((state, si) => {
+          const sp = `buttons[${idx}].states[${si}]`;
+          if (state.cc !== undefined) {
+            const e = validators.cc(state.cc);
+            if (e) errors.set(`${sp}.cc`, e);
+          }
+          if (state.cc_on !== undefined) {
+            const e = validators.withinRange(state.cc_on, 0, 127);
+            if (e) errors.set(`${sp}.cc_on`, e);
+          }
+          if (state.cc_off !== undefined) {
+            const e = validators.withinRange(state.cc_off, 0, 127);
+            if (e) errors.set(`${sp}.cc_off`, e);
+          }
+          if (state.note !== undefined) {
+            const e = validators.note(state.note);
+            if (e) errors.set(`${sp}.note`, e);
+          }
+          if (state.velocity_on !== undefined) {
+            const e = validators.velocity(state.velocity_on);
+            if (e) errors.set(`${sp}.velocity_on`, e);
+          }
+          if (state.velocity_off !== undefined) {
+            const e = validators.velocity(state.velocity_off);
+            if (e) errors.set(`${sp}.velocity_off`, e);
+          }
+        });
       }
     }
   });

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -171,6 +171,10 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
             const e = validators.pcStep(state.pc_step);
             if (e) errors.set(`${sp}.pc_step`, e);
           }
+          if (state.label !== undefined) {
+            const e = validators.label(state.label);
+            if (e) errors.set(`${sp}.label`, e);
+          }
         });
       }
     }

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -163,6 +163,14 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
             const e = validators.velocity(state.velocity_off);
             if (e) errors.set(`${sp}.velocity_off`, e);
           }
+          if (state.program !== undefined) {
+            const e = validators.program(state.program);
+            if (e) errors.set(`${sp}.program`, e);
+          }
+          if (state.pc_step !== undefined) {
+            const e = validators.pcStep(state.pc_step);
+            if (e) errors.set(`${sp}.pc_step`, e);
+          }
         });
       }
     }

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -46,6 +46,32 @@ export const validators = {
     }
     return null;
   },
+
+  note: (value: number): string | null => {
+    if (value === undefined || value === null) return 'Note is required';
+    if (value < 0 || value > 127) return 'Note must be between 0 and 127';
+    if (!Number.isInteger(value)) return 'Note must be an integer';
+    return null;
+  },
+
+  velocity: (value: number): string | null => {
+    if (value < 0 || value > 127) return 'Velocity must be between 0 and 127';
+    if (!Number.isInteger(value)) return 'Velocity must be an integer';
+    return null;
+  },
+
+  program: (value: number): string | null => {
+    if (value === undefined || value === null) return 'Program is required';
+    if (value < 0 || value > 127) return 'Program must be between 0 and 127';
+    if (!Number.isInteger(value)) return 'Program must be an integer';
+    return null;
+  },
+
+  pcStep: (value: number): string | null => {
+    if (value < 1 || value > 127) return 'Step must be between 1 and 127';
+    if (!Number.isInteger(value)) return 'Step must be an integer';
+    return null;
+  },
 };
 
 export function validateConfig(config: MidiCaptainConfig): ValidationResult {
@@ -68,13 +94,38 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
   // Validate all buttons
   config.buttons.forEach((btn, idx) => {
     const labelError = validators.label(btn.label);
-    if (labelError) {
-      errors.set(`buttons[${idx}].label`, labelError);
-    }
-    
-    const ccError = validators.cc(btn.cc);
-    if (ccError) {
-      errors.set(`buttons[${idx}].cc`, ccError);
+    if (labelError) errors.set(`buttons[${idx}].label`, labelError);
+
+    const msgType = btn.type ?? 'cc';
+
+    if (msgType === 'cc') {
+      if (btn.cc !== undefined) {
+        const ccError = validators.cc(btn.cc);
+        if (ccError) errors.set(`buttons[${idx}].cc`, ccError);
+      }
+    } else if (msgType === 'note') {
+      if (btn.note !== undefined) {
+        const noteError = validators.note(btn.note);
+        if (noteError) errors.set(`buttons[${idx}].note`, noteError);
+      }
+      if (btn.velocity_on !== undefined) {
+        const velError = validators.velocity(btn.velocity_on);
+        if (velError) errors.set(`buttons[${idx}].velocity_on`, velError);
+      }
+      if (btn.velocity_off !== undefined) {
+        const velError = validators.velocity(btn.velocity_off);
+        if (velError) errors.set(`buttons[${idx}].velocity_off`, velError);
+      }
+    } else if (msgType === 'pc') {
+      if (btn.program !== undefined) {
+        const progError = validators.program(btn.program);
+        if (progError) errors.set(`buttons[${idx}].program`, progError);
+      }
+    } else if (msgType === 'pc_inc' || msgType === 'pc_dec') {
+      if (btn.pc_step !== undefined) {
+        const stepError = validators.pcStep(btn.pc_step);
+        if (stepError) errors.set(`buttons[${idx}].pc_step`, stepError);
+      }
     }
   });
   

--- a/docs/plans/2026-03-01-unified-message-types.md
+++ b/docs/plans/2026-03-01-unified-message-types.md
@@ -1,0 +1,923 @@
+# Unified MIDI Message Types Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Note and PC (Program Change) message type support to both firmware and GUI config editor, unified with the existing CC type and keytimes system from PR #50.
+
+**Architecture:** Add a `type` field (`cc` | `note` | `pc` | `pc_inc` | `pc_dec`) to button configs. Each type gets its own set of validated fields in `config.py`. `code.py` dispatches on `type` when sending/receiving MIDI. The GUI config editor shows only the relevant input fields for the selected type.
+
+**Tech Stack:** CircuitPython firmware (Python), pytest for firmware tests, SvelteKit + TypeScript for config editor (no editor test runner — manual review only).
+
+**Backward compatibility:** Any button without a `type` field defaults to `cc`. Invalid types fall back to `cc`.
+
+---
+
+## Current State (after PR #50 merge)
+
+- `firmware/dev/core/config.py`: Has keytimes support; CC-only type system (no `type` field)
+- `firmware/dev/code.py`: Has keytimes/ButtonState; CC-only MIDI dispatch
+- `config-editor/src/lib/types.ts`: `ButtonConfig` is CC-only
+- `config-editor/src/lib/validation.ts`: Validates CC fields only
+- `config-editor/src/lib/components/ButtonRow.svelte`: Shows CC fields only
+- Tests: 81 passing
+
+---
+
+## Task 1: Add `type` field to firmware `config.py`
+
+**Files:**
+- Modify: `firmware/dev/core/config.py`
+- Test: `tests/test_config.py`
+
+### Step 1: Write failing tests
+
+Add to `tests/test_config.py` after the existing `TestValidateButton` class:
+
+```python
+class TestButtonMessageTypes:
+    """Tests for multi-type button message support."""
+
+    def test_default_type_is_cc(self):
+        btn = validate_button({}, index=0)
+        assert btn["type"] == "cc"
+
+    def test_cc_type_explicit(self):
+        btn = validate_button({"type": "cc", "cc": 50}, index=0)
+        assert btn["type"] == "cc"
+        assert btn["cc"] == 50
+        assert btn["cc_on"] == 127
+        assert btn["cc_off"] == 0
+
+    def test_cc_type_no_note_fields(self):
+        btn = validate_button({"type": "cc"}, index=0)
+        assert "note" not in btn
+        assert "velocity_on" not in btn
+        assert "velocity_off" not in btn
+
+    def test_cc_type_no_pc_fields(self):
+        btn = validate_button({"type": "cc"}, index=0)
+        assert "program" not in btn
+        assert "pc_step" not in btn
+
+    def test_note_type(self):
+        btn = validate_button({"type": "note", "note": 60}, index=0)
+        assert btn["type"] == "note"
+        assert btn["note"] == 60
+        assert btn["velocity_on"] == 127
+        assert btn["velocity_off"] == 0
+
+    def test_note_type_defaults(self):
+        btn = validate_button({"type": "note"}, index=0)
+        assert btn["note"] == 60
+        assert btn["velocity_on"] == 127
+        assert btn["velocity_off"] == 0
+
+    def test_note_type_custom_velocity(self):
+        btn = validate_button({"type": "note", "note": 36, "velocity_on": 100, "velocity_off": 0}, index=0)
+        assert btn["velocity_on"] == 100
+        assert btn["velocity_off"] == 0
+
+    def test_note_type_no_cc_fields(self):
+        btn = validate_button({"type": "note"}, index=0)
+        assert "cc" not in btn
+        assert "cc_on" not in btn
+        assert "cc_off" not in btn
+
+    def test_pc_type(self):
+        btn = validate_button({"type": "pc", "program": 5}, index=0)
+        assert btn["type"] == "pc"
+        assert btn["program"] == 5
+
+    def test_pc_type_default_program(self):
+        btn = validate_button({"type": "pc"}, index=0)
+        assert btn["program"] == 0
+
+    def test_pc_type_no_cc_fields(self):
+        btn = validate_button({"type": "pc"}, index=0)
+        assert "cc" not in btn
+        assert "cc_on" not in btn
+        assert "cc_off" not in btn
+
+    def test_pc_inc_type(self):
+        btn = validate_button({"type": "pc_inc", "pc_step": 5}, index=0)
+        assert btn["type"] == "pc_inc"
+        assert btn["pc_step"] == 5
+
+    def test_pc_dec_type(self):
+        btn = validate_button({"type": "pc_dec", "pc_step": 2}, index=0)
+        assert btn["type"] == "pc_dec"
+        assert btn["pc_step"] == 2
+
+    def test_pc_inc_dec_default_step(self):
+        btn_inc = validate_button({"type": "pc_inc"}, index=0)
+        btn_dec = validate_button({"type": "pc_dec"}, index=0)
+        assert btn_inc["pc_step"] == 1
+        assert btn_dec["pc_step"] == 1
+
+    def test_invalid_type_falls_back_to_cc(self):
+        btn = validate_button({"type": "invalid_type"}, index=0)
+        assert btn["type"] == "cc"
+        assert "cc" in btn
+
+    def test_type_inherits_global_channel(self):
+        btn = validate_button({"type": "note", "note": 48}, index=0, global_channel=3)
+        assert btn["channel"] == 3
+
+    def test_keytimes_works_with_note_type(self):
+        btn = validate_button({"type": "note", "note": 60, "keytimes": 2}, index=0)
+        assert btn["keytimes"] == 2
+
+    def test_keytimes_works_with_cc_type(self):
+        btn = validate_button({"type": "cc", "cc": 20, "keytimes": 3}, index=0)
+        assert btn["keytimes"] == 3
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+python3 -m pytest tests/test_config.py::TestButtonMessageTypes -v
+```
+
+Expected: All new tests FAIL (no `type` field exists yet)
+
+### Step 3: Implement type support in `config.py`
+
+Replace the `validate_button` function body. The new implementation:
+
+```python
+VALID_TYPES = ("cc", "note", "pc", "pc_inc", "pc_dec")
+
+def validate_button(btn, index=0, global_channel=None):
+    """Validate a button config dict, filling in defaults.
+
+    Args:
+        btn: Button config dict
+        index: Button index (for default CC calculation)
+        global_channel: Global MIDI channel (0-15), used if button doesn't specify channel
+
+    Returns:
+        Validated button config with all required fields
+
+    Button Types:
+        - "cc": Control Change (default)
+        - "note": MIDI Note On/Off
+        - "pc": Program Change fixed
+        - "pc_inc": Program Change increment
+        - "pc_dec": Program Change decrement
+    """
+    if global_channel is not None:
+        default_channel = global_channel
+    else:
+        default_channel = 0
+
+    # Keytimes: default to 1 (no cycling), clamp to 1-99
+    keytimes = btn.get("keytimes", 1)
+    if not isinstance(keytimes, int):
+        keytimes = 1
+    keytimes = max(1, min(99, keytimes))
+
+    # Determine message type, fall back to cc if invalid
+    msg_type = btn.get("type", "cc")
+    if msg_type not in VALID_TYPES:
+        msg_type = "cc"
+
+    validated = {
+        "label": btn.get("label", str(index + 1)),
+        "color": btn.get("color", "white"),
+        "mode": btn.get("mode", "toggle"),
+        "off_mode": btn.get("off_mode", "dim"),
+        "channel": btn.get("channel", default_channel),
+        "type": msg_type,
+        "keytimes": keytimes,
+    }
+
+    # Type-specific fields
+    if msg_type == "cc":
+        validated["cc"] = btn.get("cc", 20 + index)
+        validated["cc_on"] = btn.get("cc_on", 127)
+        validated["cc_off"] = btn.get("cc_off", 0)
+    elif msg_type == "note":
+        validated["note"] = btn.get("note", 60)
+        validated["velocity_on"] = btn.get("velocity_on", 127)
+        validated["velocity_off"] = btn.get("velocity_off", 0)
+    elif msg_type == "pc":
+        validated["program"] = btn.get("program", 0)
+    elif msg_type in ("pc_inc", "pc_dec"):
+        validated["pc_step"] = btn.get("pc_step", 1)
+
+    # For keytimes > 1, validate and pass through states array
+    if keytimes > 1:
+        states = btn.get("states", [])
+        if isinstance(states, list):
+            validated_states = []
+            for state in states:
+                if isinstance(state, dict):
+                    validated_state = {}
+                    for field in ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "color", "label"):
+                        if field in state:
+                            validated_state[field] = state[field]
+                    validated_states.append(validated_state)
+            if validated_states:
+                validated["states"] = validated_states
+
+    return validated
+```
+
+Note: Add `VALID_TYPES` constant at module level (top of file, after imports).
+
+### Step 4: Run tests to verify they pass
+
+```bash
+python3 -m pytest tests/test_config.py -v
+```
+
+Expected: All 81 + new tests PASS
+
+### Step 5: Commit
+
+```bash
+git add firmware/dev/core/config.py tests/test_config.py
+git commit -m "Add multi-type button support to config.py: cc, note, pc, pc_inc, pc_dec"
+```
+
+---
+
+## Task 2: Add MIDI stubs to conftest and note/PC tests for code.py
+
+**Files:**
+- Modify: `tests/conftest.py`
+- Modify: `tests/test_config.py` (verify existing cc defaults still pass)
+
+### Step 1: Add MIDI stubs to `conftest.py`
+
+In `install_mocks()`, after `sys.modules["adafruit_midi.control_change"] = StubModule()`, add:
+
+```python
+sys.modules["adafruit_midi.program_change"] = StubModule()
+sys.modules["adafruit_midi.note_on"] = StubModule()
+sys.modules["adafruit_midi.note_off"] = StubModule()
+```
+
+### Step 2: Run full test suite to confirm still passing
+
+```bash
+python3 -m pytest tests/ -q
+```
+
+Expected: All tests PASS (no regressions)
+
+### Step 3: Commit
+
+```bash
+git add tests/conftest.py
+git commit -m "Add MIDI stub modules for program_change, note_on, note_off"
+```
+
+---
+
+## Task 3: Extend `code.py` with Note and PC message dispatch
+
+**Files:**
+- Modify: `firmware/dev/code.py`
+
+This file runs on CircuitPython hardware and can't be fully unit-tested, but the changes follow the exact same patterns already used for CC.
+
+### Step 1: Add imports (near line 37, after existing ControlChange import)
+
+```python
+from adafruit_midi.program_change import ProgramChange
+from adafruit_midi.note_on import NoteOn
+from adafruit_midi.note_off import NoteOff
+```
+
+### Step 2: Add PC state arrays (near line 378, after existing `button_states`)
+
+```python
+pc_values = [0] * BUTTON_COUNT       # Current PC value for each button (0-127)
+pc_flash_timers = [0] * BUTTON_COUNT # Countdown for PC button LED flash
+PC_FLASH_DURATION = 10               # ~100ms at typical loop speed (~10ms/iter)
+```
+
+### Step 3: Add PC helper functions (after `init_leds`, before "Polling Functions" section)
+
+```python
+def clamp_pc_value(value):
+    """Clamp PC value to valid MIDI range (0-127)."""
+    return max(0, min(127, value))
+
+
+def flash_pc_button(button_idx):
+    """Light LED briefly for PC button press feedback.
+
+    Args:
+        button_idx: 1-indexed button number (matches set_button_state convention)
+    """
+    set_button_state(button_idx, True)
+    pc_flash_timers[button_idx - 1] = PC_FLASH_DURATION
+
+
+def update_pc_flash_timers():
+    """Decrement flash timers and turn off LEDs when expired. Call each main loop."""
+    for i in range(BUTTON_COUNT):
+        if pc_flash_timers[i] > 0:
+            pc_flash_timers[i] -= 1
+            if pc_flash_timers[i] == 0:
+                set_button_state(i + 1, False)
+```
+
+### Step 4: Extend `handle_midi()` to handle NoteOn, NoteOff, ProgramChange
+
+Replace the existing `handle_midi` function body. The new version handles all incoming message types:
+
+```python
+def handle_midi():
+    """Handle incoming MIDI messages."""
+    msg = midi.receive()
+    if not msg:
+        return
+
+    msg_channel = getattr(msg, 'channel', 0) or 0
+
+    if isinstance(msg, ControlChange):
+        cc = msg.control
+        val = msg.value
+        print(f"[MIDI RX] Ch{msg_channel+1} CC{cc}={val}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type", "cc") == "cc" and btn_config.get("cc") == cc and btn_config.get("channel", 0) == msg_channel:
+                set_button_state(i + 1, val > 63)
+                status_label.text = f"RX CC{cc}={val}"
+                break
+
+    elif isinstance(msg, NoteOn):
+        note = msg.note
+        vel = msg.velocity
+        print(f"[MIDI RX] Ch{msg_channel+1} NoteOn{note} vel{vel}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type") == "note" and btn_config.get("note") == note and btn_config.get("channel", 0) == msg_channel:
+                set_button_state(i + 1, vel > 0)
+                status_label.text = f"RX Note{note}"
+                break
+
+    elif isinstance(msg, NoteOff):
+        note = msg.note
+        print(f"[MIDI RX] Ch{msg_channel+1} NoteOff{note}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type") == "note" and btn_config.get("note") == note and btn_config.get("channel", 0) == msg_channel:
+                set_button_state(i + 1, False)
+                status_label.text = f"RX NoteOff{note}"
+                break
+
+    elif isinstance(msg, ProgramChange):
+        program = msg.patch
+        print(f"[MIDI RX] Ch{msg_channel+1} PC{program}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type") in ("pc_inc", "pc_dec") and btn_config.get("channel", 0) == msg_channel:
+                pc_values[i] = program
+        status_label.text = f"RX PC{program}"
+```
+
+### Step 5: Extend `handle_switches()` to dispatch all 5 message types
+
+Replace the inner `if/elif pressed` block with a full type-dispatch. Find the block starting around line 631:
+
+```python
+            message_type = btn_config.get("type", "cc")
+            mode = btn_config.get("mode", "toggle")
+            channel = btn_config.get("channel", 0)
+
+            if message_type == "cc":
+                cc = btn_config.get("cc", 20 + idx)
+                cc_on = btn_config.get("cc_on", 127)
+                cc_off = btn_config.get("cc_off", 0)
+                if mode == "momentary":
+                    val = cc_on if pressed else cc_off
+                    set_button_state(btn_num, pressed)
+                    midi.send(ControlChange(cc, val, channel=channel))
+                    print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, momentary)")
+                    status_label.text = f"TX CC{cc}={val}"
+                elif pressed:
+                    new_state = not button_states[idx]
+                    set_button_state(btn_num, new_state)
+                    val = cc_on if new_state else cc_off
+                    midi.send(ControlChange(cc, val, channel=channel))
+                    print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, toggle)")
+                    status_label.text = f"TX CC{cc}={'ON' if new_state else 'OFF'}"
+
+            elif message_type == "note":
+                note = btn_config.get("note", 60)
+                vel_on = btn_config.get("velocity_on", 127)
+                vel_off = btn_config.get("velocity_off", 0)
+                if mode == "momentary":
+                    if pressed:
+                        midi.send(NoteOn(note, vel_on, channel=channel))
+                        set_button_state(btn_num, True)
+                        print(f"[MIDI TX] Ch{channel+1} NoteOn{note} vel{vel_on} (switch {btn_num})")
+                        status_label.text = f"TX Note{note}"
+                    else:
+                        midi.send(NoteOff(note, vel_off, channel=channel))
+                        set_button_state(btn_num, False)
+                        print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num})")
+                elif pressed:
+                    new_state = not button_states[idx]
+                    set_button_state(btn_num, new_state)
+                    if new_state:
+                        midi.send(NoteOn(note, vel_on, channel=channel))
+                        print(f"[MIDI TX] Ch{channel+1} NoteOn{note} vel{vel_on} (switch {btn_num}, toggle on)")
+                        status_label.text = f"TX Note{note} ON"
+                    else:
+                        midi.send(NoteOff(note, vel_off, channel=channel))
+                        print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num}, toggle off)")
+                        status_label.text = f"TX Note{note} OFF"
+
+            elif message_type == "pc" and pressed:
+                program = btn_config.get("program", 0)
+                midi.send(ProgramChange(program, channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{program} (switch {btn_num})")
+                status_label.text = f"TX PC{program}"
+                flash_pc_button(btn_num)
+
+            elif message_type == "pc_inc" and pressed:
+                step = btn_config.get("pc_step", 1)
+                pc_values[idx] = clamp_pc_value(pc_values[idx] + step)
+                midi.send(ProgramChange(pc_values[idx], channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, inc)")
+                status_label.text = f"TX PC{pc_values[idx]}"
+                flash_pc_button(btn_num)
+
+            elif message_type == "pc_dec" and pressed:
+                step = btn_config.get("pc_step", 1)
+                pc_values[idx] = clamp_pc_value(pc_values[idx] - step)
+                midi.send(ProgramChange(pc_values[idx], channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, dec)")
+                status_label.text = f"TX PC{pc_values[idx]}"
+                flash_pc_button(btn_num)
+```
+
+### Step 6: Add `update_pc_flash_timers()` to main loop
+
+In the `while True:` loop (near bottom of file), after `handle_switches()`:
+
+```python
+    update_pc_flash_timers()
+```
+
+### Step 7: Run full test suite to confirm no regressions
+
+```bash
+python3 -m pytest tests/ -q
+```
+
+Expected: All tests PASS (code.py changes can't be directly tested here but must not break imports)
+
+### Step 8: Commit
+
+```bash
+git add firmware/dev/code.py
+git commit -m "Add Note and PC message dispatch in code.py: 5 message types fully supported"
+```
+
+---
+
+## Task 4: Add example config showing all 5 types
+
+**Files:**
+- Create: `firmware/dev/config-example-all-types.json`
+
+### Step 1: Create the example config
+
+```json
+{
+  "device": "std10",
+  "display": {
+    "button_text_size": "medium",
+    "status_text_size": "medium",
+    "expression_text_size": "medium"
+  },
+  "buttons": [
+    {"label": "CC20",   "type": "cc",     "cc": 20,      "color": "red"},
+    {"label": "TREM",   "type": "note",   "note": 60,    "velocity_on": 127, "velocity_off": 0, "color": "blue", "mode": "momentary"},
+    {"label": "CHORD",  "type": "note",   "note": 48,    "color": "cyan", "mode": "toggle"},
+    {"label": "PATCH1", "type": "pc",     "program": 0,  "color": "green"},
+    {"label": "PATCH2", "type": "pc",     "program": 1,  "color": "yellow"},
+    {"label": "PATCH3", "type": "pc",     "program": 2,  "color": "magenta"},
+    {"label": "PATCH4", "type": "pc",     "program": 3,  "color": "white"},
+    {"label": "PATCH5", "type": "pc",     "program": 4,  "color": "orange"},
+    {"label": "PC+",    "type": "pc_inc", "pc_step": 1,  "color": "orange"},
+    {"label": "PC-",    "type": "pc_dec", "pc_step": 1,  "color": "purple"}
+  ],
+  "encoder": {
+    "enabled": true,
+    "cc": 11,
+    "label": "ENC",
+    "min": 0,
+    "max": 127,
+    "initial": 64,
+    "steps": null,
+    "push": {
+      "enabled": true,
+      "cc": 14,
+      "label": "PUSH",
+      "mode": "momentary"
+    }
+  }
+}
+```
+
+### Step 2: Commit
+
+```bash
+git add firmware/dev/config-example-all-types.json
+git commit -m "Add example config showing all 5 message types"
+```
+
+---
+
+## Task 5: Update TypeScript types in config editor
+
+**Files:**
+- Modify: `config-editor/src/lib/types.ts`
+
+### Step 1: Update `types.ts`
+
+Add `MessageType` and update `ButtonConfig`:
+
+```typescript
+export type MessageType = 'cc' | 'note' | 'pc' | 'pc_inc' | 'pc_dec';
+```
+
+Update `ButtonConfig` interface — replace the current CC-only interface with:
+
+```typescript
+export interface ButtonConfig {
+  label: string;
+  color: ButtonColor;
+  type?: MessageType;      // defaults to 'cc'
+  mode?: ButtonMode;
+  off_mode?: OffMode;
+  channel?: number;        // Stored as 0-15, displayed as 1-16
+  // CC fields (type='cc')
+  cc?: number;
+  cc_on?: number;          // CC value when ON (default: 127)
+  cc_off?: number;         // CC value when OFF (default: 0)
+  // Note fields (type='note')
+  note?: number;           // MIDI note number 0-127
+  velocity_on?: number;    // Note velocity when ON (default: 127)
+  velocity_off?: number;   // Note velocity when OFF (default: 0)
+  // PC fields (type='pc')
+  program?: number;        // Program number 0-127
+  // PC inc/dec fields (type='pc_inc' | 'pc_dec')
+  pc_step?: number;        // Step size (default: 1)
+}
+```
+
+Note: `cc` becomes optional since Note/PC buttons don't have a CC number. Existing configs that don't include `type` still work — the GUI and firmware both default to `cc`.
+
+### Step 2: Commit
+
+```bash
+git add config-editor/src/lib/types.ts
+git commit -m "Add MessageType and type-specific fields to ButtonConfig TypeScript types"
+```
+
+---
+
+## Task 6: Update validation in config editor
+
+**Files:**
+- Modify: `config-editor/src/lib/validation.ts`
+
+### Step 1: Add new validators and update `validateConfig`
+
+Add `note` and `velocity` validators after the existing `cc` validator:
+
+```typescript
+  note: (value: number): string | null => {
+    if (value === undefined || value === null) return 'Note is required';
+    if (value < 0 || value > 127) return 'Note must be between 0 and 127';
+    if (!Number.isInteger(value)) return 'Note must be an integer';
+    return null;
+  },
+
+  velocity: (value: number): string | null => {
+    if (value < 0 || value > 127) return 'Velocity must be between 0 and 127';
+    if (!Number.isInteger(value)) return 'Velocity must be an integer';
+    return null;
+  },
+
+  program: (value: number): string | null => {
+    if (value === undefined || value === null) return 'Program is required';
+    if (value < 0 || value > 127) return 'Program must be between 0 and 127';
+    if (!Number.isInteger(value)) return 'Program must be an integer';
+    return null;
+  },
+
+  pcStep: (value: number): string | null => {
+    if (value < 1 || value > 127) return 'Step must be between 1 and 127';
+    if (!Number.isInteger(value)) return 'Step must be an integer';
+    return null;
+  },
+```
+
+Replace the button validation loop in `validateConfig` with type-aware validation:
+
+```typescript
+  config.buttons.forEach((btn, idx) => {
+    const labelError = validators.label(btn.label);
+    if (labelError) errors.set(`buttons[${idx}].label`, labelError);
+
+    const msgType = btn.type ?? 'cc';
+
+    if (msgType === 'cc') {
+      if (btn.cc !== undefined) {
+        const ccError = validators.cc(btn.cc);
+        if (ccError) errors.set(`buttons[${idx}].cc`, ccError);
+      }
+    } else if (msgType === 'note') {
+      if (btn.note !== undefined) {
+        const noteError = validators.note(btn.note);
+        if (noteError) errors.set(`buttons[${idx}].note`, noteError);
+      }
+      if (btn.velocity_on !== undefined) {
+        const velError = validators.velocity(btn.velocity_on);
+        if (velError) errors.set(`buttons[${idx}].velocity_on`, velError);
+      }
+      if (btn.velocity_off !== undefined) {
+        const velError = validators.velocity(btn.velocity_off);
+        if (velError) errors.set(`buttons[${idx}].velocity_off`, velError);
+      }
+    } else if (msgType === 'pc') {
+      if (btn.program !== undefined) {
+        const progError = validators.program(btn.program);
+        if (progError) errors.set(`buttons[${idx}].program`, progError);
+      }
+    } else if (msgType === 'pc_inc' || msgType === 'pc_dec') {
+      if (btn.pc_step !== undefined) {
+        const stepError = validators.pcStep(btn.pc_step);
+        if (stepError) errors.set(`buttons[${idx}].pc_step`, stepError);
+      }
+    }
+  });
+```
+
+### Step 2: Commit
+
+```bash
+git add config-editor/src/lib/validation.ts
+git commit -m "Add type-aware validation for note, pc, pc_inc, pc_dec message types"
+```
+
+---
+
+## Task 7: Update GUI `ButtonRow.svelte` with type selector and conditional fields
+
+**Files:**
+- Modify: `config-editor/src/lib/components/ButtonRow.svelte`
+
+### Step 1: Update the `<script>` block
+
+Replace the import line and add new handlers and derived values:
+
+```typescript
+import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType } from '$lib/types';
+```
+
+Add derived type check after `const basePath`:
+```typescript
+let msgType = $derived((button.type ?? 'cc') as MessageType);
+let isCC = $derived(msgType === 'cc');
+let isNote = $derived(msgType === 'note');
+let isPC = $derived(msgType === 'pc');
+let isPCIncDec = $derived(msgType === 'pc_inc' || msgType === 'pc_dec');
+let showMode = $derived(isCC || isNote);  // PC types are always press-only
+```
+
+Add new handler functions after existing ones:
+
+```typescript
+function handleTypeChange(e: Event) {
+  const target = e.target as HTMLSelectElement;
+  onUpdate('type', target.value as MessageType);
+}
+
+function handleNoteChange(e: Event) {
+  const target = e.target as HTMLInputElement;
+  onUpdate('note', parseInt(target.value));
+}
+
+function handleVelocityOnChange(e: Event) {
+  const target = e.target as HTMLInputElement;
+  const value = target.value === '' ? undefined : parseInt(target.value);
+  onUpdate('velocity_on', value);
+}
+
+function handleVelocityOffChange(e: Event) {
+  const target = e.target as HTMLInputElement;
+  const value = target.value === '' ? undefined : parseInt(target.value);
+  onUpdate('velocity_off', value);
+}
+
+function handleProgramChange(e: Event) {
+  const target = e.target as HTMLInputElement;
+  onUpdate('program', parseInt(target.value));
+}
+
+function handlePCStepChange(e: Event) {
+  const target = e.target as HTMLInputElement;
+  onUpdate('pc_step', parseInt(target.value));
+}
+```
+
+Add new error bindings after existing ones:
+```typescript
+let noteError = $derived($validationErrors.get(`${basePath}.note`));
+let velocityOnError = $derived($validationErrors.get(`${basePath}.velocity_on`));
+let velocityOffError = $derived($validationErrors.get(`${basePath}.velocity_off`));
+let programError = $derived($validationErrors.get(`${basePath}.program`));
+let pcStepError = $derived($validationErrors.get(`${basePath}.pc_step`));
+```
+
+### Step 2: Update the template HTML
+
+After the Label field and before the Channel field, add the Type selector:
+
+```html
+<div class="field">
+  <label class="field-label">Type:</label>
+  <select
+    class="select"
+    value={button.type ?? 'cc'}
+    onchange={handleTypeChange}
+    disabled={disabled}
+  >
+    <option value="cc">CC</option>
+    <option value="note">Note</option>
+    <option value="pc">PC Fixed</option>
+    <option value="pc_inc">PC+</option>
+    <option value="pc_dec">PC-</option>
+  </select>
+</div>
+```
+
+Replace the CC field block with a conditional section:
+
+```html
+{#if isCC}
+  <div class="field">
+    <label class="field-label">CC:</label>
+    <input type="number" class="input-cc" class:error={!!ccError}
+      value={button.cc ?? ''} onblur={handleCCChange} disabled={disabled}
+      min="0" max="127" />
+    {#if ccError}<span class="error-text">{ccError}</span>{/if}
+  </div>
+  <div class="field">
+    <label class="field-label">ON Value:</label>
+    <input type="number" class="input-cc-value" class:error={!!ccOnError}
+      value={button.cc_on !== undefined ? button.cc_on : ''} onblur={handleCCOnChange}
+      disabled={disabled} min="0" max="127" placeholder="127" />
+    {#if ccOnError}<span class="error-text">{ccOnError}</span>{/if}
+  </div>
+  <div class="field">
+    <label class="field-label">OFF Value:</label>
+    <input type="number" class="input-cc-value" class:error={!!ccOffError}
+      value={button.cc_off !== undefined ? button.cc_off : ''} onblur={handleCCOffChange}
+      disabled={disabled} min="0" max="127" placeholder="0" />
+    {#if ccOffError}<span class="error-text">{ccOffError}</span>{/if}
+  </div>
+{:else if isNote}
+  <div class="field">
+    <label class="field-label">Note:</label>
+    <input type="number" class="input-cc" class:error={!!noteError}
+      value={button.note ?? 60} onblur={handleNoteChange} disabled={disabled}
+      min="0" max="127" />
+    {#if noteError}<span class="error-text">{noteError}</span>{/if}
+  </div>
+  <div class="field">
+    <label class="field-label">Vel ON:</label>
+    <input type="number" class="input-cc-value" class:error={!!velocityOnError}
+      value={button.velocity_on !== undefined ? button.velocity_on : ''} onblur={handleVelocityOnChange}
+      disabled={disabled} min="0" max="127" placeholder="127" />
+    {#if velocityOnError}<span class="error-text">{velocityOnError}</span>{/if}
+  </div>
+  <div class="field">
+    <label class="field-label">Vel OFF:</label>
+    <input type="number" class="input-cc-value" class:error={!!velocityOffError}
+      value={button.velocity_off !== undefined ? button.velocity_off : ''} onblur={handleVelocityOffChange}
+      disabled={disabled} min="0" max="127" placeholder="0" />
+    {#if velocityOffError}<span class="error-text">{velocityOffError}</span>{/if}
+  </div>
+{:else if isPC}
+  <div class="field">
+    <label class="field-label">Program:</label>
+    <input type="number" class="input-cc" class:error={!!programError}
+      value={button.program ?? 0} onblur={handleProgramChange} disabled={disabled}
+      min="0" max="127" />
+    {#if programError}<span class="error-text">{programError}</span>{/if}
+  </div>
+{:else if isPCIncDec}
+  <div class="field">
+    <label class="field-label">Step:</label>
+    <input type="number" class="input-cc" class:error={!!pcStepError}
+      value={button.pc_step ?? 1} onblur={handlePCStepChange} disabled={disabled}
+      min="1" max="127" />
+    {#if pcStepError}<span class="error-text">{pcStepError}</span>{/if}
+  </div>
+{/if}
+```
+
+Replace the Switch Mode and LED Off Mode fields to be conditional on type (PC types don't use them):
+
+```html
+{#if showMode}
+  <div class="field">
+    <label class="field-label">Switch Mode:</label>
+    <select class="select" value={button.mode || 'toggle'} onchange={handleModeChange} disabled={disabled}>
+      <option value="toggle">Toggle</option>
+      <option value="momentary">Momentary</option>
+    </select>
+  </div>
+  <div class="field">
+    <label class="field-label">LED Off Mode:</label>
+    <select class="select" value={button.off_mode || 'dim'} onchange={handleOffModeChange} disabled={disabled}>
+      <option value="dim">Dim</option>
+      <option value="off">Off</option>
+    </select>
+  </div>
+{/if}
+```
+
+### Step 3: Verify in browser (manual)
+
+Run the config editor dev server and verify:
+- Type dropdown shows all 5 options
+- Selecting CC shows CC/ON/OFF fields and Switch Mode/LED Off Mode
+- Selecting Note shows Note/Vel ON/Vel OFF and Switch Mode/LED Off Mode
+- Selecting PC Fixed shows Program field only (no mode)
+- Selecting PC+/PC- shows Step field only (no mode)
+- Existing configs without `type` field load correctly as CC
+
+```bash
+cd config-editor && npm run dev
+```
+
+### Step 4: Commit
+
+```bash
+git add config-editor/src/lib/components/ButtonRow.svelte
+git commit -m "Update ButtonRow GUI: type selector with conditional fields for all 5 message types"
+```
+
+---
+
+## Task 8: Update `formStore.ts` to handle type changes cleanly
+
+**Files:**
+- Modify: `config-editor/src/lib/formStore.ts`
+
+When a user changes a button's `type`, the old type's fields remain in the config object. This is mostly harmless (firmware ignores extra fields), but check if `formStore.ts` needs any handling.
+
+### Step 1: Read the current formStore
+
+```bash
+# Read the file first
+cat config-editor/src/lib/formStore.ts
+```
+
+### Step 2: Check if `updateButtonField` needs any changes
+
+If `updateButtonField` simply does `button[field] = value`, no changes are needed — the firmware's `validate_button` already strips out irrelevant fields server-side when loading. The GUI just passes through what it has.
+
+If there's any logic that assumes `cc` is always present, update it to handle optional `cc`.
+
+### Step 3: Commit if changes were needed
+
+```bash
+git add config-editor/src/lib/formStore.ts
+git commit -m "Handle optional cc field in formStore for multi-type buttons"
+```
+
+---
+
+## Task 9: Final integration check
+
+### Step 1: Run all firmware tests
+
+```bash
+python3 -m pytest tests/ -v
+```
+
+Expected: All tests PASS
+
+### Step 2: Manual check — load example config in GUI
+
+1. Start dev server: `cd config-editor && npm run dev`
+2. Load `firmware/dev/config-example-all-types.json`
+3. Verify all 10 buttons display correctly with correct field types
+4. Change a button type and verify fields update
+
+### Step 3: Final commit if any cleanup needed, then summary
+
+```bash
+git log --oneline -10
+```
+
+Verify clean commit history with each feature isolated.

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -521,7 +521,7 @@ def get_button_color(btn_config, keytime_index):
     Returns:
         RGB tuple for the color
     """
-    return get_color(get_button_state_config(btn_config, keytime_index)["color"])
+    return get_color(get_button_state_config(btn_config, keytime_index).get("color", "white"))
 
 
 def set_button_state(switch_idx, on):
@@ -675,7 +675,8 @@ def handle_switches():
                     print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, momentary)")
                     status_label.text = f"TX CC{cc}={val}"
                 elif pressed:
-                    new_state = not button_states[idx].state
+                    # Keytimes cycling always stays on; standard toggle flips on/off
+                    new_state = True if btn_state.keytimes > 1 else not button_states[idx].state
                     set_button_state(btn_num, new_state)
                     val = cc_on if new_state else cc_off
                     midi.send(ControlChange(cc, val, channel=channel))
@@ -700,7 +701,8 @@ def handle_switches():
                         set_button_state(btn_num, False)
                         print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num})")
                 elif pressed:
-                    new_state = not button_states[idx].state
+                    # Keytimes cycling always stays on; standard toggle flips on/off
+                    new_state = True if btn_state.keytimes > 1 else not button_states[idx].state
                     set_button_state(btn_num, new_state)
                     if new_state:
                         midi.send(NoteOn(note, vel_on, channel=channel))

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -688,7 +688,6 @@ def handle_switches():
             # Convert to 1-indexed button number
             btn_num = i if HAS_ENCODER else i + 1
             idx = btn_num - 1
-            btn_state = button_states[idx]
             btn_config = buttons[idx] if idx < len(buttons) else {"cc": 20 + idx}
             
             message_type = btn_config.get("type", "cc")

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -635,10 +635,8 @@ def handle_midi():
     elif isinstance(msg, ProgramChange):
         program = msg.patch
         print(f"[MIDI RX] Ch{msg_channel+1} PC{program}")
-        # Update all pc_inc/pc_dec buttons on this channel (no break - sync all trackers)
-        for i, btn_config in enumerate(buttons):
-            if btn_config.get("type") in ("pc_inc", "pc_dec") and btn_config.get("channel", 0) == msg_channel:
-                pc_values[msg_channel] = program
+        # pc_values is per-channel, so one assignment covers all pc_inc/pc_dec buttons on this channel
+        pc_values[msg_channel] = program
         status_label.text = f"RX PC{program}"
 
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -634,7 +634,7 @@ def handle_midi():
     if not msg:
         return
 
-    msg_channel = getattr(msg, 'channel', 0) or 0
+    msg_channel = getattr(msg, 'channel', 0) or 0  # channel is None when received on default channel
 
     if isinstance(msg, ControlChange):
         cc = msg.control
@@ -668,6 +668,7 @@ def handle_midi():
     elif isinstance(msg, ProgramChange):
         program = msg.patch
         print(f"[MIDI RX] Ch{msg_channel+1} PC{program}")
+        # Update all pc_inc/pc_dec buttons on this channel (no break - sync all trackers)
         for i, btn_config in enumerate(buttons):
             if btn_config.get("type") in ("pc_inc", "pc_dec") and btn_config.get("channel", 0) == msg_channel:
                 pc_values[i] = program

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -35,6 +35,9 @@ import terminalio
 from adafruit_st7789 import ST7789
 import adafruit_midi
 from adafruit_midi.control_change import ControlChange
+from adafruit_midi.program_change import ProgramChange
+from adafruit_midi.note_on import NoteOn
+from adafruit_midi.note_off import NoteOff
 
 # Import core modules (testable logic)
 from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display
@@ -383,6 +386,10 @@ for i in range(BUTTON_COUNT):
     keytimes = btn_config.get("keytimes", 1)
     button_states.append(ButtonState(cc=cc, mode=mode, keytimes=keytimes))
 
+pc_values = [0] * BUTTON_COUNT       # Current PC value for each button (0-127)
+pc_flash_timers = [0] * BUTTON_COUNT # Countdown for PC button LED flash
+PC_FLASH_DURATION = 10               # ~100ms at typical loop speed (~10ms/iter)
+
 encoder_value = ENC_INITIAL  # Internal value 0-127
 encoder_slot = -1  # Current slot (set on first change)
 
@@ -592,6 +599,30 @@ def init_leds():
         set_button_state(i, False)
 
 
+def clamp_pc_value(value):
+    """Clamp PC value to valid MIDI range (0-127)."""
+    return max(0, min(127, value))
+
+
+def flash_pc_button(button_idx):
+    """Light LED briefly for PC button press feedback.
+
+    Args:
+        button_idx: 1-indexed button number (matches set_button_state convention)
+    """
+    set_button_state(button_idx, True)
+    pc_flash_timers[button_idx - 1] = PC_FLASH_DURATION
+
+
+def update_pc_flash_timers():
+    """Decrement flash timers and turn off LEDs when expired. Call each main loop."""
+    for i in range(BUTTON_COUNT):
+        if pc_flash_timers[i] > 0:
+            pc_flash_timers[i] -= 1
+            if pc_flash_timers[i] == 0:
+                set_button_state(i + 1, False)
+
+
 # =============================================================================
 # Polling Functions
 # =============================================================================
@@ -600,27 +631,47 @@ def init_leds():
 def handle_midi():
     """Handle incoming MIDI messages."""
     msg = midi.receive()
-    if msg and isinstance(msg, ControlChange):
+    if not msg:
+        return
+
+    msg_channel = getattr(msg, 'channel', 0) or 0
+
+    if isinstance(msg, ControlChange):
         cc = msg.control
         val = msg.value
-        # ControlChange objects have a .channel attribute (0-15 = MIDI Ch 1-16)
-        # If channel is None, it means it was sent on the default channel
-        msg_channel = getattr(msg, 'channel', 0)
-        if msg_channel is None:
-            msg_channel = 0
         print(f"[MIDI RX] Ch{msg_channel+1} CC{cc}={val}")
-
-        # Check if this CC matches any button (must match both CC number and channel)
         for i, btn_config in enumerate(buttons):
-            btn_cc = btn_config.get("cc")
-            btn_channel = btn_config.get("channel", 0)
-            if btn_cc == cc and btn_channel == msg_channel:
-                # Use ButtonState's on_midi_receive to handle host override
-                btn_state = button_states[i]
-                new_state = btn_state.on_midi_receive(val)
-                set_button_state(i + 1, new_state)
+            if btn_config.get("type", "cc") == "cc" and btn_config.get("cc") == cc and btn_config.get("channel", 0) == msg_channel:
+                set_button_state(i + 1, val > 63)
                 status_label.text = f"RX CC{cc}={val}"
                 break
+
+    elif isinstance(msg, NoteOn):
+        note = msg.note
+        vel = msg.velocity
+        print(f"[MIDI RX] Ch{msg_channel+1} NoteOn{note} vel{vel}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type") == "note" and btn_config.get("note") == note and btn_config.get("channel", 0) == msg_channel:
+                set_button_state(i + 1, vel > 0)
+                status_label.text = f"RX Note{note}"
+                break
+
+    elif isinstance(msg, NoteOff):
+        note = msg.note
+        print(f"[MIDI RX] Ch{msg_channel+1} NoteOff{note}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type") == "note" and btn_config.get("note") == note and btn_config.get("channel", 0) == msg_channel:
+                set_button_state(i + 1, False)
+                status_label.text = f"RX NoteOff{note}"
+                break
+
+    elif isinstance(msg, ProgramChange):
+        program = msg.patch
+        print(f"[MIDI RX] Ch{msg_channel+1} PC{program}")
+        for i, btn_config in enumerate(buttons):
+            if btn_config.get("type") in ("pc_inc", "pc_dec") and btn_config.get("channel", 0) == msg_channel:
+                pc_values[i] = program
+        status_label.text = f"RX PC{program}"
 
 
 def handle_switches():
@@ -639,43 +690,76 @@ def handle_switches():
             btn_state = button_states[idx]
             btn_config = buttons[idx] if idx < len(buttons) else {"cc": 20 + idx}
             
-            # Get per-keytime config (CC, values, color)
-            state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
-            cc = state_cfg["cc"]
-            cc_on = state_cfg["cc_on"]
-            cc_off = state_cfg["cc_off"]
-            channel = btn_config.get("channel", 0)  # 0 = MIDI Channel 1
+            message_type = btn_config.get("type", "cc")
+            mode = btn_config.get("mode", "toggle")
+            channel = btn_config.get("channel", 0)
 
-            if pressed:
-                # On press: use ButtonState to handle state transition
-                state_changed, new_state, midi_val = btn_state.on_press()
-                
-                if state_changed:
-                    # Determine value to send
-                    if btn_state.keytimes > 1:
-                        # Keytimes: always send cc_on when cycling
-                        val = cc_on
-                        set_button_state(btn_num, True)
-                        status_msg = f"TX CC{cc}={val} ({btn_state.get_keytime()})"
-                    else:
-                        # Standard toggle/momentary
-                        val = cc_on if new_state else cc_off
-                        set_button_state(btn_num, new_state)
-                        status_msg = f"TX CC{cc}={val}"
-                    
-                    # Send MIDI and update display
+            if message_type == "cc":
+                cc = btn_config.get("cc", 20 + idx)
+                cc_on = btn_config.get("cc_on", 127)
+                cc_off = btn_config.get("cc_off", 0)
+                if mode == "momentary":
+                    val = cc_on if pressed else cc_off
+                    set_button_state(btn_num, pressed)
                     midi.send(ControlChange(cc, val, channel=channel))
-                    mode = btn_config.get("mode", "toggle")
-                    print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, {mode})")
-                    status_label.text = status_msg
-            else:
-                # On release: check if we need to send release message (momentary mode)
-                state_changed, new_state, midi_val = btn_state.on_release()
-                if state_changed and midi_val is not None:
+                    print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, momentary)")
+                    status_label.text = f"TX CC{cc}={val}"
+                elif pressed:
+                    new_state = not button_states[idx].state
                     set_button_state(btn_num, new_state)
-                    midi.send(ControlChange(cc, midi_val, channel=channel))
-                    print(f"[MIDI TX] Ch{channel+1} CC{cc}={midi_val} (switch {btn_num}, release)")
-                    status_label.text = f"TX CC{cc}={midi_val}"
+                    val = cc_on if new_state else cc_off
+                    midi.send(ControlChange(cc, val, channel=channel))
+                    print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, toggle)")
+                    status_label.text = f"TX CC{cc}={'ON' if new_state else 'OFF'}"
+
+            elif message_type == "note":
+                note = btn_config.get("note", 60)
+                vel_on = btn_config.get("velocity_on", 127)
+                vel_off = btn_config.get("velocity_off", 0)
+                if mode == "momentary":
+                    if pressed:
+                        midi.send(NoteOn(note, vel_on, channel=channel))
+                        set_button_state(btn_num, True)
+                        print(f"[MIDI TX] Ch{channel+1} NoteOn{note} vel{vel_on} (switch {btn_num})")
+                        status_label.text = f"TX Note{note}"
+                    else:
+                        midi.send(NoteOff(note, vel_off, channel=channel))
+                        set_button_state(btn_num, False)
+                        print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num})")
+                elif pressed:
+                    new_state = not button_states[idx].state
+                    set_button_state(btn_num, new_state)
+                    if new_state:
+                        midi.send(NoteOn(note, vel_on, channel=channel))
+                        print(f"[MIDI TX] Ch{channel+1} NoteOn{note} vel{vel_on} (switch {btn_num}, toggle on)")
+                        status_label.text = f"TX Note{note} ON"
+                    else:
+                        midi.send(NoteOff(note, vel_off, channel=channel))
+                        print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num}, toggle off)")
+                        status_label.text = f"TX Note{note} OFF"
+
+            elif message_type == "pc" and pressed:
+                program = btn_config.get("program", 0)
+                midi.send(ProgramChange(program, channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{program} (switch {btn_num})")
+                status_label.text = f"TX PC{program}"
+                flash_pc_button(btn_num)
+
+            elif message_type == "pc_inc" and pressed:
+                step = btn_config.get("pc_step", 1)
+                pc_values[idx] = clamp_pc_value(pc_values[idx] + step)
+                midi.send(ProgramChange(pc_values[idx], channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, inc)")
+                status_label.text = f"TX PC{pc_values[idx]}"
+                flash_pc_button(btn_num)
+
+            elif message_type == "pc_dec" and pressed:
+                step = btn_config.get("pc_step", 1)
+                pc_values[idx] = clamp_pc_value(pc_values[idx] - step)
+                midi.send(ProgramChange(pc_values[idx], channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, dec)")
+                status_label.text = f"TX PC{pc_values[idx]}"
+                flash_pc_button(btn_num)
 
 
 def handle_encoder_button():
@@ -837,6 +921,7 @@ print("\nRunning...")
 while True:
     handle_midi()
     handle_switches()
+    update_pc_flash_timers()
     if HAS_ENCODER:
         handle_encoder_button()
         handle_encoder()

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -386,7 +386,7 @@ for i in range(BUTTON_COUNT):
     keytimes = btn_config.get("keytimes", 1)
     button_states.append(ButtonState(cc=cc, mode=mode, keytimes=keytimes))
 
-pc_values = [0] * BUTTON_COUNT       # Current PC value for each button (0-127)
+pc_values = [0] * 16                 # Current PC value per MIDI channel (0-15), shared across all pc_inc/pc_dec buttons
 pc_flash_timers = [0] * BUTTON_COUNT # Countdown for PC button LED flash
 PC_FLASH_DURATION = 10               # ~100ms at typical loop speed (~10ms/iter)
 
@@ -637,7 +637,7 @@ def handle_midi():
         # Update all pc_inc/pc_dec buttons on this channel (no break - sync all trackers)
         for i, btn_config in enumerate(buttons):
             if btn_config.get("type") in ("pc_inc", "pc_dec") and btn_config.get("channel", 0) == msg_channel:
-                pc_values[i] = program
+                pc_values[msg_channel] = program
         status_label.text = f"RX PC{program}"
 
 
@@ -676,7 +676,8 @@ def handle_switches():
                     status_label.text = f"TX CC{cc}={val}"
                 elif pressed:
                     # Keytimes cycling always stays on; standard toggle flips on/off
-                    new_state = True if btn_state.keytimes > 1 else not button_states[idx].state
+                    new_state = True if btn_state.keytimes > 1 else not btn_state.state
+                    btn_state.state = new_state
                     set_button_state(btn_num, new_state)
                     val = cc_on if new_state else cc_off
                     midi.send(ControlChange(cc, val, channel=channel))
@@ -702,7 +703,8 @@ def handle_switches():
                         print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num})")
                 elif pressed:
                     # Keytimes cycling always stays on; standard toggle flips on/off
-                    new_state = True if btn_state.keytimes > 1 else not button_states[idx].state
+                    new_state = True if btn_state.keytimes > 1 else not btn_state.state
+                    btn_state.state = new_state
                     set_button_state(btn_num, new_state)
                     if new_state:
                         midi.send(NoteOn(note, vel_on, channel=channel))
@@ -726,20 +728,20 @@ def handle_switches():
                 btn_state.advance_keytime()
                 state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
                 step = state_cfg.get("pc_step", 1)
-                pc_values[idx] = clamp_pc_value(pc_values[idx] + step)
-                midi.send(ProgramChange(pc_values[idx], channel=channel))
-                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, inc)")
-                status_label.text = f"TX PC{pc_values[idx]}"
+                pc_values[channel] = clamp_pc_value(pc_values[channel] + step)
+                midi.send(ProgramChange(pc_values[channel], channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[channel]} (switch {btn_num}, inc)")
+                status_label.text = f"TX PC{pc_values[channel]}"
                 flash_pc_button(btn_num)
 
             elif message_type == "pc_dec" and pressed:
                 btn_state.advance_keytime()
                 state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
                 step = state_cfg.get("pc_step", 1)
-                pc_values[idx] = clamp_pc_value(pc_values[idx] - step)
-                midi.send(ProgramChange(pc_values[idx], channel=channel))
-                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, dec)")
-                status_label.text = f"TX PC{pc_values[idx]}"
+                pc_values[channel] = clamp_pc_value(pc_values[channel] - step)
+                midi.send(ProgramChange(pc_values[channel], channel=channel))
+                print(f"[MIDI TX] Ch{channel+1} PC{pc_values[channel]} (switch {btn_num}, dec)")
+                status_label.text = f"TX PC{pc_values[channel]}"
                 flash_pc_button(btn_num)
 
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -521,7 +521,7 @@ def get_button_color(btn_config, keytime_index):
     Returns:
         RGB tuple for the color
     """
-    return get_button_state_config(btn_config, keytime_index)["color"]
+    return get_color(get_button_state_config(btn_config, keytime_index)["color"])
 
 
 def set_button_state(switch_idx, on):
@@ -662,8 +662,8 @@ def handle_switches():
             channel = btn_config.get("channel", 0)
 
             if message_type == "cc":
-                if pressed and btn_state.keytimes > 1:
-                    btn_state.current_keytime = (btn_state.current_keytime % btn_state.keytimes) + 1
+                if pressed:
+                    btn_state.advance_keytime()
                 state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
                 cc = state_cfg.get("cc", 20 + idx)
                 cc_on = state_cfg.get("cc_on", 127)
@@ -683,8 +683,8 @@ def handle_switches():
                     status_label.text = f"TX CC{cc}={'ON' if new_state else 'OFF'}"
 
             elif message_type == "note":
-                if pressed and btn_state.keytimes > 1:
-                    btn_state.current_keytime = (btn_state.current_keytime % btn_state.keytimes) + 1
+                if pressed:
+                    btn_state.advance_keytime()
                 state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
                 note = state_cfg.get("note", 60)
                 vel_on = state_cfg.get("velocity_on", 127)
@@ -712,14 +712,18 @@ def handle_switches():
                         status_label.text = f"TX Note{note} OFF"
 
             elif message_type == "pc" and pressed:
-                program = btn_config.get("program", 0)
+                btn_state.advance_keytime()
+                state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
+                program = state_cfg.get("program", 0)
                 midi.send(ProgramChange(program, channel=channel))
                 print(f"[MIDI TX] Ch{channel+1} PC{program} (switch {btn_num})")
                 status_label.text = f"TX PC{program}"
                 flash_pc_button(btn_num)
 
             elif message_type == "pc_inc" and pressed:
-                step = btn_config.get("pc_step", 1)
+                btn_state.advance_keytime()
+                state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
+                step = state_cfg.get("pc_step", 1)
                 pc_values[idx] = clamp_pc_value(pc_values[idx] + step)
                 midi.send(ProgramChange(pc_values[idx], channel=channel))
                 print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, inc)")
@@ -727,7 +731,9 @@ def handle_switches():
                 flash_pc_button(btn_num)
 
             elif message_type == "pc_dec" and pressed:
-                step = btn_config.get("pc_step", 1)
+                btn_state.advance_keytime()
+                state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
+                step = state_cfg.get("pc_step", 1)
                 pc_values[idx] = clamp_pc_value(pc_values[idx] - step)
                 midi.send(ProgramChange(pc_values[idx], channel=channel))
                 print(f"[MIDI TX] Ch{channel+1} PC{pc_values[idx]} (switch {btn_num}, dec)")

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -41,7 +41,7 @@ from adafruit_midi.note_off import NoteOff
 
 # Import core modules (testable logic)
 from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display
-from core.config import load_config as _load_config_from_file, get_display_config
+from core.config import load_config as _load_config_from_file, get_display_config, get_button_state_config
 from core.button import Switch, ButtonState
 
 # =============================================================================
@@ -511,40 +511,6 @@ display.show(main_group)
 # =============================================================================
 
 
-def get_button_state_config(btn_config, keytime_index):
-    """Get configuration for button at specific keytime state.
-    
-    Args:
-        btn_config: Button configuration dict
-        keytime_index: Current keytime position (1-indexed)
-        
-    Returns:
-        Dict with cc, cc_on, cc_off, and color for this state
-    """
-    states = btn_config.get("states", [])
-    
-    # Get per-state overrides if available
-    if states and 0 < keytime_index <= len(states):
-        state_config = states[keytime_index - 1]
-        cc = state_config.get("cc", btn_config.get("cc", 20))
-        cc_on = state_config.get("cc_on", btn_config.get("cc_on", 127))
-        cc_off = state_config.get("cc_off", btn_config.get("cc_off", 0))
-        color = get_color(state_config.get("color", btn_config.get("color", "white")))
-    else:
-        # Fallback to base button config
-        cc = btn_config.get("cc", 20)
-        cc_on = btn_config.get("cc_on", 127)
-        cc_off = btn_config.get("cc_off", 0)
-        color = get_color(btn_config.get("color", "white"))
-    
-    return {
-        "cc": cc,
-        "cc_on": cc_on,
-        "cc_off": cc_off,
-        "color": color
-    }
-
-
 def get_button_color(btn_config, keytime_index):
     """Get color for button at specific keytime state.
     
@@ -688,16 +654,20 @@ def handle_switches():
             # Convert to 1-indexed button number
             btn_num = i if HAS_ENCODER else i + 1
             idx = btn_num - 1
+            btn_state = button_states[idx]
             btn_config = buttons[idx] if idx < len(buttons) else {"cc": 20 + idx}
-            
+
             message_type = btn_config.get("type", "cc")
             mode = btn_config.get("mode", "toggle")
             channel = btn_config.get("channel", 0)
 
             if message_type == "cc":
-                cc = btn_config.get("cc", 20 + idx)
-                cc_on = btn_config.get("cc_on", 127)
-                cc_off = btn_config.get("cc_off", 0)
+                if pressed and btn_state.keytimes > 1:
+                    btn_state.current_keytime = (btn_state.current_keytime % btn_state.keytimes) + 1
+                state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
+                cc = state_cfg.get("cc", 20 + idx)
+                cc_on = state_cfg.get("cc_on", 127)
+                cc_off = state_cfg.get("cc_off", 0)
                 if mode == "momentary":
                     val = cc_on if pressed else cc_off
                     set_button_state(btn_num, pressed)
@@ -713,9 +683,12 @@ def handle_switches():
                     status_label.text = f"TX CC{cc}={'ON' if new_state else 'OFF'}"
 
             elif message_type == "note":
-                note = btn_config.get("note", 60)
-                vel_on = btn_config.get("velocity_on", 127)
-                vel_off = btn_config.get("velocity_off", 0)
+                if pressed and btn_state.keytimes > 1:
+                    btn_state.current_keytime = (btn_state.current_keytime % btn_state.keytimes) + 1
+                state_cfg = get_button_state_config(btn_config, btn_state.get_keytime())
+                note = state_cfg.get("note", 60)
+                vel_on = state_cfg.get("velocity_on", 127)
+                vel_off = state_cfg.get("velocity_off", 0)
                 if mode == "momentary":
                     if pressed:
                         midi.send(NoteOn(note, vel_on, channel=channel))

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -381,7 +381,7 @@ EXP2_CHANNEL = exp2_config.get("channel", 0)
 button_states = []
 for i in range(BUTTON_COUNT):
     btn_config = buttons[i] if i < len(buttons) else {}
-    cc = btn_config.get("cc", 20 + i)
+    cc = btn_config.get("cc", 0)  # 0 for non-CC types; ButtonState.cc unused by note/pc dispatch
     mode = btn_config.get("mode", "toggle")
     keytimes = btn_config.get("keytimes", 1)
     button_states.append(ButtonState(cc=cc, mode=mode, keytimes=keytimes))
@@ -608,7 +608,8 @@ def handle_midi():
         print(f"[MIDI RX] Ch{msg_channel+1} CC{cc}={val}")
         for i, btn_config in enumerate(buttons):
             if btn_config.get("type", "cc") == "cc" and btn_config.get("cc") == cc and btn_config.get("channel", 0) == msg_channel:
-                set_button_state(i + 1, val > 63)
+                new_state = button_states[i].on_midi_receive(val)
+                set_button_state(i + 1, new_state)
                 status_label.text = f"RX CC{cc}={val}"
                 break
 

--- a/firmware/dev/config-example-all-types.json
+++ b/firmware/dev/config-example-all-types.json
@@ -1,0 +1,35 @@
+{
+  "device": "std10",
+  "display": {
+    "button_text_size": "medium",
+    "status_text_size": "medium",
+    "expression_text_size": "medium"
+  },
+  "buttons": [
+    {"label": "CC20",   "type": "cc",     "cc": 20,      "color": "red"},
+    {"label": "TREM",   "type": "note",   "note": 60,    "velocity_on": 127, "velocity_off": 0, "color": "blue", "mode": "momentary"},
+    {"label": "CHORD",  "type": "note",   "note": 48,    "color": "cyan", "mode": "toggle"},
+    {"label": "PATCH1", "type": "pc",     "program": 0,  "color": "green"},
+    {"label": "PATCH2", "type": "pc",     "program": 1,  "color": "yellow"},
+    {"label": "PATCH3", "type": "pc",     "program": 2,  "color": "magenta"},
+    {"label": "PATCH4", "type": "pc",     "program": 3,  "color": "white"},
+    {"label": "PATCH5", "type": "pc",     "program": 4,  "color": "orange"},
+    {"label": "PC+",    "type": "pc_inc", "pc_step": 1,  "color": "orange"},
+    {"label": "PC-",    "type": "pc_dec", "pc_step": 1,  "color": "purple"}
+  ],
+  "encoder": {
+    "enabled": true,
+    "cc": 11,
+    "label": "ENC",
+    "min": 0,
+    "max": 127,
+    "initial": 64,
+    "steps": null,
+    "push": {
+      "enabled": true,
+      "cc": 14,
+      "label": "PUSH",
+      "mode": "momentary"
+    }
+  }
+}

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -113,7 +113,11 @@ class ButtonState:
     
     def on_release(self):
         """Handle button release.
-        
+
+        NOTE: handle_switches() in code.py does NOT call this method — release
+        handling is inlined there alongside MIDI dispatch. This method is used
+        by tests and any external consumers that need the full ButtonState API.
+
         Returns:
             Tuple of (state_changed: bool, new_state: bool, midi_value: int)
             For toggle mode, returns (False, state, None) - no action on release

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -87,7 +87,12 @@ class ButtonState:
     def on_press(self):
         """Handle button press.
 
-        For keytimes > 1: advances to next keytime state (cycling back to 1 after max).
+        For keytimes > 1: advances to next keytime state via advance_keytime().
+
+        NOTE: handle_switches() in code.py does NOT call this method — it calls
+        advance_keytime() directly to keep keytime management and MIDI dispatch
+        in one place. This method is used by tests and any external consumers
+        that need the full ButtonState API without MIDI dispatch.
 
         Returns:
             Tuple of (state_changed: bool, new_state: bool, midi_value: int)

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -76,24 +76,29 @@ class ButtonState:
         """Set state (used by host override)."""
         self._state = bool(value)
     
+    def advance_keytime(self):
+        """Advance to next keytime state, cycling back to 1 after max.
+
+        No-op when keytimes == 1.
+        """
+        if self.keytimes > 1:
+            self.current_keytime = (self.current_keytime % self.keytimes) + 1
+
     def on_press(self):
         """Handle button press.
-        
+
         For keytimes > 1: advances to next keytime state (cycling back to 1 after max).
-        
+
         Returns:
             Tuple of (state_changed: bool, new_state: bool, midi_value: int)
         """
         if self.mode == "momentary":
             self._state = True
-            # For keytimes with momentary, advance state on press
-            if self.keytimes > 1:
-                self.current_keytime = (self.current_keytime % self.keytimes) + 1
+            self.advance_keytime()
             return True, True, 127
         else:  # toggle
-            # For keytimes, advance to next state
             if self.keytimes > 1:
-                self.current_keytime = (self.current_keytime % self.keytimes) + 1
+                self.advance_keytime()
                 self._state = True  # Always "on" when cycling keytimes
                 return True, True, 127
             else:

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -47,6 +47,21 @@ def _default_config(button_count):
     }
 
 
+_MIDI_BYTE_FIELDS = ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "program")
+
+def _clamp_state_field(field, value):
+    """Clamp numeric state override fields to valid MIDI ranges. Non-numeric fields pass through."""
+    if field in _MIDI_BYTE_FIELDS:
+        if not isinstance(value, int):
+            return 0
+        return max(0, min(127, value))
+    if field == "pc_step":
+        if not isinstance(value, int):
+            return 1
+        return max(1, min(127, value))
+    return value  # color, label — pass through as-is
+
+
 def validate_button(btn, index=0, global_channel=None):
     """Validate a button config dict, filling in defaults.
 
@@ -115,7 +130,7 @@ def validate_button(btn, index=0, global_channel=None):
                     validated_state = {}
                     for field in STATE_OVERRIDE_FIELDS:
                         if field in state:
-                            validated_state[field] = state[field]
+                            validated_state[field] = _clamp_state_field(field, state[field])
                     validated_states.append(validated_state)
             if validated_states:
                 validated["states"] = validated_states

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -10,6 +10,8 @@ except ImportError:
     # CircuitPython has json built-in, but just in case
     json = None
 
+VALID_TYPES = ("cc", "note", "pc", "pc_inc", "pc_dec")
+
 
 def load_config(config_path="/config.json", button_count=10):
     """Load button configuration from JSON file.
@@ -46,64 +48,77 @@ def _default_config(button_count):
 
 def validate_button(btn, index=0, global_channel=None):
     """Validate a button config dict, filling in defaults.
-    
+
     Args:
         btn: Button config dict
         index: Button index (for default CC calculation)
         global_channel: Global MIDI channel (0-15), used if button doesn't specify channel
-        
+
     Returns:
         Validated button config with all required fields
+
+    Button Types:
+        - "cc": Control Change (default)
+        - "note": MIDI Note On/Off
+        - "pc": Program Change fixed
+        - "pc_inc": Program Change increment
+        - "pc_dec": Program Change decrement
     """
-    # Channel: per-button override or global channel or default to 0 (MIDI Ch 1)
     if global_channel is not None:
         default_channel = global_channel
     else:
         default_channel = 0
-    
+
     # Keytimes: default to 1 (no cycling), clamp to 1-99
     keytimes = btn.get("keytimes", 1)
     if not isinstance(keytimes, int):
         keytimes = 1
     keytimes = max(1, min(99, keytimes))
-    
+
+    # Determine message type, fall back to cc if invalid
+    msg_type = btn.get("type", "cc")
+    if msg_type not in VALID_TYPES:
+        msg_type = "cc"
+
     validated = {
         "label": btn.get("label", str(index + 1)),
-        "cc": btn.get("cc", 20 + index),
         "color": btn.get("color", "white"),
         "mode": btn.get("mode", "toggle"),
         "off_mode": btn.get("off_mode", "dim"),
         "channel": btn.get("channel", default_channel),
-        "cc_on": btn.get("cc_on", 127),
-        "cc_off": btn.get("cc_off", 0),
+        "type": msg_type,
         "keytimes": keytimes,
     }
-    
+
+    # Type-specific fields
+    if msg_type == "cc":
+        validated["cc"] = btn.get("cc", 20 + index)
+        validated["cc_on"] = btn.get("cc_on", 127)
+        validated["cc_off"] = btn.get("cc_off", 0)
+    elif msg_type == "note":
+        validated["note"] = btn.get("note", 60)
+        validated["velocity_on"] = btn.get("velocity_on", 127)
+        validated["velocity_off"] = btn.get("velocity_off", 0)
+    elif msg_type == "pc":
+        validated["program"] = btn.get("program", 0)
+    elif msg_type in ("pc_inc", "pc_dec"):
+        validated["pc_step"] = btn.get("pc_step", 1)
+
     # For keytimes > 1, validate and pass through states array
     if keytimes > 1:
         states = btn.get("states", [])
         if isinstance(states, list):
-            # Validate each state entry
             validated_states = []
             for state in states:
                 if isinstance(state, dict):
                     validated_state = {}
-                    # Copy through recognized fields with validation
-                    if "cc" in state:
-                        validated_state["cc"] = state["cc"]
-                    if "cc_on" in state:
-                        validated_state["cc_on"] = state["cc_on"]
-                    if "cc_off" in state:
-                        validated_state["cc_off"] = state["cc_off"]
-                    if "color" in state:
-                        validated_state["color"] = state["color"]
-                    if "label" in state:
-                        validated_state["label"] = state["label"]
+                    for field in ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "color", "label"):
+                        if field in state:
+                            validated_state[field] = state[field]
                     validated_states.append(validated_state)
-            
             if validated_states:
                 validated["states"] = validated_states
-    
+
     return validated
 
 

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -157,6 +157,36 @@ def validate_config(cfg, button_count=10):
     return result
 
 
+def get_button_state_config(btn_config, keytime_index):
+    """Get button config merged with per-state overrides for a given keytime position.
+
+    Args:
+        btn_config: Validated button config dict
+        keytime_index: Current keytime position (1-indexed)
+
+    Returns:
+        Dict with base values overridden by per-state values where present.
+        Overridable fields: cc, cc_on, cc_off, note, velocity_on, velocity_off, color, label.
+    """
+    # Start with base config
+    result = {}
+    for field in ("cc", "cc_on", "cc_off", "note", "velocity_on",
+                  "velocity_off", "color", "label", "program", "pc_step"):
+        if field in btn_config:
+            result[field] = btn_config[field]
+
+    # Apply per-state overrides if keytime_index is in range
+    states = btn_config.get("states", [])
+    if states and 0 < keytime_index <= len(states):
+        state = states[keytime_index - 1]
+        for field in ("cc", "cc_on", "cc_off", "note", "velocity_on",
+                      "velocity_off", "color", "label"):
+            if field in state:
+                result[field] = state[field]
+
+    return result
+
+
 def get_encoder_config(cfg):
     """Extract encoder configuration with defaults.
     

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -166,7 +166,7 @@ def get_button_state_config(btn_config, keytime_index):
 
     Returns:
         Dict with base values overridden by per-state values where present.
-        Overridable fields: cc, cc_on, cc_off, note, velocity_on, velocity_off, color, label.
+        Overridable fields: cc, cc_on, cc_off, note, velocity_on, velocity_off, program, pc_step, color, label.
     """
     # Start with base config
     result = {}
@@ -180,7 +180,7 @@ def get_button_state_config(btn_config, keytime_index):
     if states and 0 < keytime_index <= len(states):
         state = states[keytime_index - 1]
         for field in ("cc", "cc_on", "cc_off", "note", "velocity_on",
-                      "velocity_off", "color", "label"):
+                      "velocity_off", "color", "label", "program", "pc_step"):
             if field in state:
                 result[field] = state[field]
 

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -11,6 +11,7 @@ except ImportError:
     json = None
 
 VALID_TYPES = ("cc", "note", "pc", "pc_inc", "pc_dec")
+STATE_OVERRIDE_FIELDS = ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "program", "pc_step", "color", "label")
 
 
 def load_config(config_path="/config.json", button_count=10):
@@ -112,7 +113,7 @@ def validate_button(btn, index=0, global_channel=None):
             for state in states:
                 if isinstance(state, dict):
                     validated_state = {}
-                    for field in ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "color", "label"):
+                    for field in STATE_OVERRIDE_FIELDS:
                         if field in state:
                             validated_state[field] = state[field]
                     validated_states.append(validated_state)
@@ -170,8 +171,7 @@ def get_button_state_config(btn_config, keytime_index):
     """
     # Start with base config
     result = {}
-    for field in ("cc", "cc_on", "cc_off", "note", "velocity_on",
-                  "velocity_off", "color", "label", "program", "pc_step"):
+    for field in STATE_OVERRIDE_FIELDS:
         if field in btn_config:
             result[field] = btn_config[field]
 
@@ -179,8 +179,7 @@ def get_button_state_config(btn_config, keytime_index):
     states = btn_config.get("states", [])
     if states and 0 < keytime_index <= len(states):
         state = states[keytime_index - 1]
-        for field in ("cc", "cc_on", "cc_off", "note", "velocity_on",
-                      "velocity_off", "color", "label", "program", "pc_step"):
+        for field in STATE_OVERRIDE_FIELDS:
             if field in state:
                 result[field] = state[field]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,9 @@ def install_mocks():
     sys.modules["adafruit_st7789"] = StubModule()
     sys.modules["adafruit_midi"] = StubModule()
     sys.modules["adafruit_midi.control_change"] = StubModule()
+    sys.modules["adafruit_midi.program_change"] = StubModule()
+    sys.modules["adafruit_midi.note_on"] = StubModule()
+    sys.modules["adafruit_midi.note_off"] = StubModule()
 
 
 # Install mocks at import time (before tests run)

--- a/tests/test_button_state.py
+++ b/tests/test_button_state.py
@@ -200,15 +200,25 @@ class TestButtonStateKeytimes:
     def test_keytimes_one_behaves_as_standard_toggle(self):
         """keytimes=1 maintains standard toggle behavior."""
         btn = ButtonState(cc=20, mode="toggle", keytimes=1)
-        
+
         # Standard toggle on/off
         btn.on_press()
         assert btn.state == True
         assert btn.get_keytime() == 1
-        
+
         btn.on_press()
         assert btn.state == False
         assert btn.get_keytime() == 1
+
+    def test_keytimes_toggle_always_stays_on(self):
+        """When keytimes > 1, toggle mode always stays on — it cycles states, never turns off."""
+        btn = ButtonState(cc=20, mode="toggle", keytimes=3)
+        btn.on_press()
+        assert btn.state == True   # press 1 → on, keytime 2
+        btn.on_press()
+        assert btn.state == True   # press 2 → still on, keytime 3
+        btn.on_press()
+        assert btn.state == True   # press 3 → still on, keytime cycles back to 1
 
 
 class TestAdvanceKeytime:

--- a/tests/test_button_state.py
+++ b/tests/test_button_state.py
@@ -209,3 +209,38 @@ class TestButtonStateKeytimes:
         btn.on_press()
         assert btn.state == False
         assert btn.get_keytime() == 1
+
+
+class TestAdvanceKeytime:
+    """Tests for the advance_keytime() method."""
+
+    def test_advance_keytime_increments_position(self):
+        btn = ButtonState(cc=20, keytimes=3)
+        btn.advance_keytime()
+        assert btn.get_keytime() == 2
+
+    def test_advance_keytime_wraps_at_max(self):
+        btn = ButtonState(cc=20, keytimes=3)
+        btn.advance_keytime()
+        btn.advance_keytime()
+        btn.advance_keytime()
+        assert btn.get_keytime() == 1
+
+    def test_advance_keytime_no_op_when_keytimes_is_one(self):
+        btn = ButtonState(cc=20, keytimes=1)
+        btn.advance_keytime()
+        assert btn.get_keytime() == 1
+
+    def test_on_press_toggle_uses_advance_keytime(self):
+        """on_press() in toggle mode should call advance_keytime() internally."""
+        btn = ButtonState(cc=20, mode="toggle", keytimes=3)
+        btn.advance_keytime()  # → 2
+        btn.on_press()         # should also advance → 3
+        assert btn.get_keytime() == 3
+
+    def test_on_press_momentary_uses_advance_keytime(self):
+        """on_press() in momentary mode should call advance_keytime() internally."""
+        btn = ButtonState(cc=20, mode="momentary", keytimes=2)
+        btn.advance_keytime()  # → 2
+        btn.on_press()         # should also advance → wrap to 1
+        assert btn.get_keytime() == 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,6 +204,28 @@ class TestValidateButton:
         assert "states" in btn
         assert len(btn["states"]) == 3
 
+    def test_validate_button_clamps_invalid_cc_in_states(self):
+        """Out-of-range numeric state overrides are clamped, not passed through raw."""
+        btn = validate_button({
+            "type": "cc",
+            "cc": 20,
+            "keytimes": 2,
+            "states": [{"cc": 200, "cc_on": -10, "cc_off": 999}]
+        }, index=0)
+        assert btn["states"][0]["cc"] == 127      # clamped to max
+        assert btn["states"][0]["cc_on"] == 0     # clamped to min
+        assert btn["states"][0]["cc_off"] == 127  # clamped to max
+
+    def test_validate_button_clamps_invalid_note_in_states(self):
+        btn = validate_button({
+            "type": "note",
+            "note": 60,
+            "keytimes": 2,
+            "states": [{"note": 200, "velocity_on": -5}]
+        }, index=0)
+        assert btn["states"][0]["note"] == 127
+        assert btn["states"][0]["velocity_on"] == 0
+
     def test_validate_button_preserves_program_in_states(self):
         btn = validate_button({
             "type": "pc",
@@ -492,3 +514,9 @@ class TestGetButtonStateConfig:
     def test_pc_dec_state_overrides_pc_step(self):
         btn = {"type": "pc_dec", "pc_step": 1, "states": [{"pc_step": 3}]}
         assert get_button_state_config(btn, 1)["pc_step"] == 3
+
+    def test_no_color_key_in_result_when_not_in_config(self):
+        """color absent from btn_config means no color key in result — callers must use .get()."""
+        btn = {"type": "cc", "cc": 20}
+        result = get_button_state_config(btn, 1)
+        assert "color" not in result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -459,3 +459,16 @@ class TestGetButtonStateConfig:
         result = get_button_state_config(btn, 1)
         assert result["program"] == 5
         assert result["color"] == "red"
+
+    def test_pc_state_overrides_program(self):
+        btn = {"type": "pc", "program": 5, "states": [{"program": 10}, {"program": 20}]}
+        assert get_button_state_config(btn, 1)["program"] == 10
+        assert get_button_state_config(btn, 2)["program"] == 20
+
+    def test_pc_inc_state_overrides_pc_step(self):
+        btn = {"type": "pc_inc", "pc_step": 1, "states": [{"pc_step": 5}]}
+        assert get_button_state_config(btn, 1)["pc_step"] == 5
+
+    def test_pc_dec_state_overrides_pc_step(self):
+        btn = {"type": "pc_dec", "pc_step": 1, "states": [{"pc_step": 3}]}
+        assert get_button_state_config(btn, 1)["pc_step"] == 3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,6 +204,104 @@ class TestValidateButton:
         assert len(btn["states"]) == 3
 
 
+class TestButtonMessageTypes:
+    """Tests for multi-type button message support."""
+
+    def test_default_type_is_cc(self):
+        btn = validate_button({}, index=0)
+        assert btn["type"] == "cc"
+
+    def test_cc_type_explicit(self):
+        btn = validate_button({"type": "cc", "cc": 50}, index=0)
+        assert btn["type"] == "cc"
+        assert btn["cc"] == 50
+        assert btn["cc_on"] == 127
+        assert btn["cc_off"] == 0
+
+    def test_cc_type_no_note_fields(self):
+        btn = validate_button({"type": "cc"}, index=0)
+        assert "note" not in btn
+        assert "velocity_on" not in btn
+        assert "velocity_off" not in btn
+
+    def test_cc_type_no_pc_fields(self):
+        btn = validate_button({"type": "cc"}, index=0)
+        assert "program" not in btn
+        assert "pc_step" not in btn
+
+    def test_note_type(self):
+        btn = validate_button({"type": "note", "note": 60}, index=0)
+        assert btn["type"] == "note"
+        assert btn["note"] == 60
+        assert btn["velocity_on"] == 127
+        assert btn["velocity_off"] == 0
+
+    def test_note_type_defaults(self):
+        btn = validate_button({"type": "note"}, index=0)
+        assert btn["note"] == 60
+        assert btn["velocity_on"] == 127
+        assert btn["velocity_off"] == 0
+
+    def test_note_type_custom_velocity(self):
+        btn = validate_button({"type": "note", "note": 36, "velocity_on": 100, "velocity_off": 0}, index=0)
+        assert btn["velocity_on"] == 100
+        assert btn["velocity_off"] == 0
+
+    def test_note_type_no_cc_fields(self):
+        btn = validate_button({"type": "note"}, index=0)
+        assert "cc" not in btn
+        assert "cc_on" not in btn
+        assert "cc_off" not in btn
+
+    def test_pc_type(self):
+        btn = validate_button({"type": "pc", "program": 5}, index=0)
+        assert btn["type"] == "pc"
+        assert btn["program"] == 5
+
+    def test_pc_type_default_program(self):
+        btn = validate_button({"type": "pc"}, index=0)
+        assert btn["program"] == 0
+
+    def test_pc_type_no_cc_fields(self):
+        btn = validate_button({"type": "pc"}, index=0)
+        assert "cc" not in btn
+        assert "cc_on" not in btn
+        assert "cc_off" not in btn
+
+    def test_pc_inc_type(self):
+        btn = validate_button({"type": "pc_inc", "pc_step": 5}, index=0)
+        assert btn["type"] == "pc_inc"
+        assert btn["pc_step"] == 5
+
+    def test_pc_dec_type(self):
+        btn = validate_button({"type": "pc_dec", "pc_step": 2}, index=0)
+        assert btn["type"] == "pc_dec"
+        assert btn["pc_step"] == 2
+
+    def test_pc_inc_dec_default_step(self):
+        btn_inc = validate_button({"type": "pc_inc"}, index=0)
+        btn_dec = validate_button({"type": "pc_dec"}, index=0)
+        assert btn_inc["pc_step"] == 1
+        assert btn_dec["pc_step"] == 1
+
+    def test_invalid_type_falls_back_to_cc(self):
+        btn = validate_button({"type": "invalid_type"}, index=0)
+        assert btn["type"] == "cc"
+        assert "cc" in btn
+
+    def test_type_inherits_global_channel(self):
+        btn = validate_button({"type": "note", "note": 48}, index=0, global_channel=3)
+        assert btn["channel"] == 3
+
+    def test_keytimes_works_with_note_type(self):
+        btn = validate_button({"type": "note", "note": 60, "keytimes": 2}, index=0)
+        assert btn["keytimes"] == 2
+
+    def test_keytimes_works_with_cc_type(self):
+        btn = validate_button({"type": "cc", "cc": 20, "keytimes": 3}, index=0)
+        assert btn["keytimes"] == 3
+
+
 class TestValidateConfig:
     """Test validate_config function from core/config.py."""
     

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,7 @@ from core.config import (
     validate_config,
     get_encoder_config,
     get_expression_config,
+    get_button_state_config,
 )
 
 
@@ -412,3 +413,49 @@ class TestEncoderConfig:
         enc = get_encoder_config({"encoder": {"push": {}}})
         assert enc["push"]["cc_on"] == 127
         assert enc["push"]["cc_off"] == 0
+
+
+class TestGetButtonStateConfig:
+    def test_no_states_returns_base_cc_config(self):
+        btn = {"type": "cc", "cc": 20, "cc_on": 127, "cc_off": 0, "color": "white"}
+        result = get_button_state_config(btn, 1)
+        assert result["cc"] == 20
+        assert result["cc_on"] == 127
+        assert result["cc_off"] == 0
+
+    def test_state_overrides_cc_on(self):
+        btn = {"type": "cc", "cc": 20, "cc_on": 127, "cc_off": 0,
+               "states": [{"cc_on": 64}, {"cc_on": 96}]}
+        assert get_button_state_config(btn, 1)["cc_on"] == 64
+        assert get_button_state_config(btn, 2)["cc_on"] == 96
+
+    def test_state_cc_falls_back_to_base(self):
+        btn = {"type": "cc", "cc": 20, "cc_on": 127, "states": [{"cc_on": 64}]}
+        result = get_button_state_config(btn, 1)
+        assert result["cc"] == 20       # fallback
+        assert result["cc_on"] == 64    # override
+
+    def test_keytime_out_of_range_falls_back(self):
+        btn = {"type": "cc", "cc": 20, "cc_on": 127, "states": [{"cc_on": 64}]}
+        result = get_button_state_config(btn, 5)
+        assert result["cc_on"] == 127   # base
+
+    def test_note_state_overrides(self):
+        btn = {"type": "note", "note": 60, "velocity_on": 127, "velocity_off": 0,
+               "states": [{"note": 62, "velocity_on": 100}]}
+        result = get_button_state_config(btn, 1)
+        assert result["note"] == 62
+        assert result["velocity_on"] == 100
+        assert result["velocity_off"] == 0  # fallback
+
+    def test_color_overridable_for_all_types(self):
+        btn = {"type": "cc", "cc": 20, "cc_on": 127, "color": "blue",
+               "states": [{"color": "cyan"}]}
+        assert get_button_state_config(btn, 1)["color"] == "cyan"
+
+    def test_pc_type_returns_base_program(self):
+        btn = {"type": "pc", "program": 5, "color": "green",
+               "states": [{"color": "red"}]}
+        result = get_button_state_config(btn, 1)
+        assert result["program"] == 5
+        assert result["color"] == "red"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,6 +204,26 @@ class TestValidateButton:
         assert "states" in btn
         assert len(btn["states"]) == 3
 
+    def test_validate_button_preserves_program_in_states(self):
+        btn = validate_button({
+            "type": "pc",
+            "program": 5,
+            "keytimes": 2,
+            "states": [{"program": 10}, {"program": 20}]
+        }, index=0)
+        assert btn["states"][0]["program"] == 10
+        assert btn["states"][1]["program"] == 20
+
+    def test_validate_button_preserves_pc_step_in_states(self):
+        btn = validate_button({
+            "type": "pc_inc",
+            "pc_step": 1,
+            "keytimes": 2,
+            "states": [{"pc_step": 5}, {"pc_step": 10}]
+        }, index=0)
+        assert btn["states"][0]["pc_step"] == 5
+        assert btn["states"][1]["pc_step"] == 10
+
 
 class TestButtonMessageTypes:
     """Tests for multi-type button message support."""

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -229,6 +229,21 @@ rsync -av --checksum --inplace --itemize-changes \
     "$MOUNT_POINT/"
 
 # 2. Core modules, device definitions, and fonts
+# Clean up conflicting bytecode format before deploying. CircuitPython prefers
+# .mpy over .py, so the wrong format left on the device would shadow new files
+# and cause ImportErrors.
+#   dev context:  deploying .py  → remove any stale .mpy from device
+#   dist context: deploying .mpy → remove any stale .py  from device
+for dir in core devices; do
+    if [ -d "$MOUNT_POINT/$dir" ]; then
+        if [ "$CONTEXT" = "dev" ]; then
+            find "$MOUNT_POINT/$dir" -name '*.mpy' -delete
+        else
+            find "$MOUNT_POINT/$dir" -name '*.py' -delete
+        fi
+    fi
+done
+
 rsync -av --checksum --inplace --itemize-changes \
     --exclude='.DS_Store' \
     --exclude='*.pyc' \

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -265,13 +265,17 @@ rsync -av --checksum --inplace --itemize-changes \
     "$MOUNT_POINT/"
 
 # 2. Core modules, device definitions, and fonts
-rsync -av --checksum --inplace --itemize-changes \
+# --delete removes stale files from the device (e.g. old .py source when
+# deploying compiled .mpy from a package, or old .mpy when deploying .py
+# source from the dev repo). Without --delete, both forms can coexist on
+# the device and CircuitPython may load the wrong one, causing ImportErrors.
+rsync -av --checksum --inplace --itemize-changes --delete \
     --exclude='.DS_Store' \
     --exclude='*.pyc' \
     --exclude='__pycache__' \
     "$DEV_DIR/core/" "$MOUNT_POINT/core/"
 
-rsync -av --checksum --inplace --itemize-changes \
+rsync -av --checksum --inplace --itemize-changes --delete \
     --exclude='.DS_Store' \
     --exclude='*.pyc' \
     --exclude='__pycache__' \
@@ -319,9 +323,17 @@ rsync -av --checksum --inplace --itemize-changes \
     "$MOUNT_POINT/"
 
 # 6. Write VERSION file for firmware version display
-VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
-echo "$VERSION" > "$MOUNT_POINT/VERSION"
-echo "$VERSION" > "$DEV_DIR/VERSION"
+# Distributed packages include a pre-built VERSION file written by CI.
+# Use it directly rather than falling back to "dev" via git describe.
+if [ "$CONTEXT" = "dist" ] && [ -f "$DEV_DIR/VERSION" ]; then
+    VERSION=$(cat "$DEV_DIR/VERSION")
+    rsync -av --checksum --inplace --itemize-changes \
+        "$DEV_DIR/VERSION" "$MOUNT_POINT/VERSION"
+else
+    VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
+    echo "$VERSION" > "$MOUNT_POINT/VERSION"
+    echo "$VERSION" > "$DEV_DIR/VERSION"
+fi
 echo "📌 Version: $VERSION"
 
 # Sync filesystem
@@ -331,17 +343,29 @@ sync
 # The installer compares this against the firmware zip's manifest
 # to skip unchanged files on subsequent installs.
 echo "📋 Generating firmware manifest..."
-(
-  cd "$DEV_DIR"
-  find . -type f \
-    -not -name "*.pyc" \
-    -not -path "*/__pycache__/*" \
-    -not -path "*/experiments/*" \
-    -not -name "firmware.md5" \
-    -not -name ".DS_Store" \
-    | sort \
-    | xargs md5sum > "$MOUNT_POINT/firmware.md5"
-)
+# Detect checksum command: md5sum (Linux) or md5 -r (macOS)
+if command -v md5sum &>/dev/null; then
+    MD5_CMD="md5sum"
+elif command -v md5 &>/dev/null; then
+    MD5_CMD="md5 -r"
+else
+    MD5_CMD=""
+fi
+if [ -n "$MD5_CMD" ]; then
+    (
+      cd "$DEV_DIR"
+      find . -type f \
+        -not -name "*.pyc" \
+        -not -path "*/__pycache__/*" \
+        -not -path "*/experiments/*" \
+        -not -name "firmware.md5" \
+        -not -name ".DS_Store" \
+        | sort \
+        | xargs $MD5_CMD > "$MOUNT_POINT/firmware.md5"
+    )
+else
+    echo "⚠️  Skipping firmware manifest (neither md5sum nor md5 found)"
+fi
 
 echo ""
 

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -209,6 +209,42 @@ else
     CONFIG_FILE="$DEV_DIR/config.json"
 fi
 
+# Check if the device filesystem is writable before attempting deploy
+if ! touch "$MOUNT_POINT/.deploy_write_test" 2>/dev/null; then
+    echo -e "${RED}❌ Device filesystem is read-only${NC}"
+    echo ""
+    echo -e "${YELLOW}The MIDI Captain drive is mounted but not writable.${NC}"
+    echo ""
+    if [ -f "$MOUNT_POINT/boot.py" ]; then
+        # boot.py exists: firmware already installed, device is in performance mode
+        echo -e "${YELLOW}Our firmware is installed. To enable write access:${NC}"
+        echo "  1. Hold switch 1 (top-left footswitch) while plugging in USB"
+        echo "  2. The device will boot with USB write access enabled"
+        echo "  3. Run deploy.sh again"
+    else
+        # No boot.py: likely first-time install over OEM firmware
+        echo -e "${YELLOW}This looks like a first-time install.${NC}"
+        echo "The OEM firmware may have the USB drive in read-only mode."
+        echo ""
+        echo -e "${YELLOW}Option A — CircuitPython safe mode (easiest):${NC}"
+        echo "  1. Briefly short the RUN pin to GND twice in quick succession"
+        echo "     (or rapidly plug/unplug USB twice if no RUN pin access)"
+        echo "     Status LED will flash yellow — safe mode is active"
+        echo "  2. Run deploy.sh again — the drive will be writable"
+        echo ""
+        echo -e "${YELLOW}Option B — Hold the update button during power-on:${NC}"
+        echo "  1. Hold switch 1 (top-left footswitch) while plugging in USB"
+        echo "  2. Run deploy.sh again"
+        echo ""
+        echo -e "${YELLOW}Option C — Reinstall CircuitPython:${NC}"
+        echo "  1. Hold BOOTSEL while plugging in USB → RPI-RP2 drive appears"
+        echo "  2. Copy CircuitPython .uf2 to the RPI-RP2 drive"
+        echo "  3. Run deploy.sh again"
+    fi
+    exit 1
+fi
+rm -f "$MOUNT_POINT/.deploy_write_test" 2>/dev/null
+
 echo "🚀 Deploying changed files..."
 
 # Deploy dependencies first, code.py last. This ensures all imports are

--- a/tools/release_notes.md
+++ b/tools/release_notes.md
@@ -2,7 +2,7 @@ ${NOTES}
 
 ## Installation
 
-**Before doing any of this, if you haven't already, please back up your existing config and firmware in a safe place** for recovery or if you just want to go back to OEM code.
+**Before doing any of this, if you haven't already, please back up your existing config and firmware in a safe place** for recovery or to revert to OEM firmware.
 
 ### GUI Config Editor
 
@@ -10,10 +10,11 @@ Download the appropriate **MIDI-Captain-MAX-Config-Editor** installer file from 
 
 ### Device Firmware
 
-1. Download the firmware zip: [midi-captain-max-latest.zip](https://github.com/mcascone/midi-captain-max/releases/latest/download/midi-captain-max-latest.zip).
+1. Download the firmware zip: [midi-captain-max-latest.zip](https://github.com/MC-Music-Workshop/midi-captain-max/releases/latest/download/midi-captain-max-latest.zip).
 1. Extract the zip.
-1. Connect your MIDI Captain via USB. Power it on normally — no need to hold any buttons.
+1. Connect your MIDI Captain via USB. Power it on normally.
     - The device will mount as `CIRCUITPY` or `MIDICAPTAIN`.
+    - If the drive mounts as read-only, hold switch 1 (top-left footswitch) while plugging in USB to enable write access.
 
 #### macOS / Linux — deploy script (recommended)
 
@@ -33,7 +34,7 @@ Run the included `deploy.sh` script from the extracted zip folder:
 ./deploy.sh --fresh
 ```
 
-The script auto-detects your device and device type. Your `config.json` is always preserved unless you pass `--fresh`.
+The script auto-detects your device type (STD10 or Mini6) and preserves your `config.json` unless you pass `--fresh`.
 
 #### Windows — manual install
 
@@ -46,5 +47,4 @@ The script auto-detects your device and device type. Your `config.json` is alway
 
 ---
 
-Power-cycle the device to reload the firmware. If anything goes wrong, it's fully recoverable: mount the device, erase the contents, and copy your backed-up files back.
-
+Eject and reconnect the device to reload the firmware. If anything goes wrong, it's fully recoverable: mount the device, erase the contents, and copy your backed-up files back.


### PR DESCRIPTION
## What This Is

A **unified integration PR** that combines and extends three previously separate PRs (#51, #53, #56) into one cohesive implementation, adds full GUI support for all message types, keytimes/states cycling, and hardens the deploy tooling.

### Foundation: PR #50 (merged to `main`)

[PR #50](https://github.com/MC-Music-Workshop/midi-captain-max/pull/50) — *Add keytimes: multi-press button cycling* — was merged to `main` on 2026-03-01. It introduced:
- `ButtonState` objects replacing the boolean button state list
- `keytimes` cycling in firmware (`core/button.py`, `code.py`)
- Firmware-only — no GUI support for keytimes

This branch is based on that merged work.

---

### Integrated: PR #51 — PC Message Support

[PR #51](https://github.com/MC-Music-Workshop/midi-captain-max/pull/51) — *Add PC (Program Change) MIDI message support* — superseded by this branch. Changes incorporated and extended:
- `type` field on buttons: `"pc"`, `"pc_inc"`, `"pc_dec"`
- `validate_button()` handling for `program` / `pc_step` fields
- `handle_switches()` dispatch for all 3 PC modes
- Bidirectional sync: `handle_midi()` updates `pc_values` from host PC messages
- **This branch also adds missing GUI support** (not in PR #51)
- **Bug fix:** PC inc/dec counter now scoped per-channel (not per-button) so PC+ and PC− buttons on the same channel share state correctly

### Integrated: PR #53 — Note Message Support

[PR #53](https://github.com/MC-Music-Workshop/midi-captain-max/pull/53) — *Add MIDI Note message support alongside Control Change* — superseded by this branch. Changes incorporated:
- `type: "note"` with `note`, `velocity_on`, `velocity_off` fields
- `handle_switches()` sends `NoteOn`/`NoteOff` based on type and mode
- `handle_midi()` processes incoming `NoteOn`/`NoteOff` for bidirectional sync
- GUI: type selector dropdown in `ButtonRow`, conditional field rendering per type

### Integrated: PR #56 — Deploy Script Robustness

[PR #56](https://github.com/MC-Music-Workshop/midi-captain-max/pull/56) — *fix(deploy): eliminate post-deploy firmware crash and fix macOS manifest failure* — merged into this branch. Changes incorporated:
- Pre-deploy writability check with context-aware error messages
- `rsync --delete` for `core/` and `devices/` to eliminate stale `.mpy`/`.py` conflicts
- Preserve CI-written `VERSION` file in dist context
- macOS/Linux `md5` command detection for firmware manifest

---

### New in This Branch: Keytimes/States GUI + Full Integration

**Firmware**
- `get_button_state_config()` moved to testable `core/config.py`
- `STATE_OVERRIDE_FIELDS` constant as single source of truth
- `ButtonState.advance_keytime()` DRY method
- Per-state config lookups in `handle_switches()` for all 5 MIDI types
- `_clamp_state_field()` guards numeric MIDI values against malformed JSON

**Bug fixes (found during device testing)**
- CC/Note toggle always sent ON value — `btn_state.state` never written back after flip
- CC bidirectional sync regression — `on_midi_receive()` was dropped, leaving `btn_state._state` stale after host override; next local press sent wrong value
- `ButtonState` cc init used garbage value for non-CC buttons

**TypeScript / Config Editor**
- `MessageType` union type + type-specific optional fields on `ButtonConfig`
- `StateOverride` interface + `keytimes`/`states` on `ButtonConfig`
- Type-aware validators for `note`, `velocity`, `program`, `pc_step`
- `syncButtonStates()` in `formStore` — atomic keytimes+states array resize
- `ButtonRow`: type selector, conditional fields per type, keytimes input, per-state override rows

**Tests**
- 81 tests on `main` → **120 tests** on this branch (+39)

**Known issues logged for follow-up**
- #59 — State validation in `validation.ts` not type-gated
- #60 — Debounce race on rapid type+keytimes change
- #61 — Stale cross-type fields not cleaned on type change
- #62 — Stale assertion in `test_button_has_required_fields`

---

## Test Plan

- [x] Firmware tests: 120 passing
- [x] Device tested on Mini6: CC toggle, CC momentary, Note toggle, Note momentary, PC fixed, PC+, PC−, bidirectional CC sync, bidirectional Note sync
- [x] TS compile: `cd config-editor && npx tsc --noEmit`
- [x] Config editor: set button type to CC, Note, PC, PC+, PC− — verify correct fields appear
- [x] Config editor: set keytimes > 1, verify per-state rows appear with type-aware fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
👨 Updated by Max Cascone