### PR TITLE
GUI firmware installer #19

### DIFF
--- a/config-editor/src-tauri/Cargo.lock
+++ b/config-editor/src-tauri/Cargo.lock
@@ -465,6 +465,8 @@ name = "config-editor"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
+ "hex",
+ "md-5",
  "notify",
  "serde",
  "serde_json",
@@ -2050,6 +2052,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"

--- a/config-editor/src-tauri/Cargo.toml
+++ b/config-editor/src-tauri/Cargo.toml
@@ -30,6 +30,8 @@ serde_json = "1"
 notify = "6"
 dirs = "5"
 serialport = "4"
+md-5 = "0.10"
+hex = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "winbase", "winnt", "minwindef"] }

--- a/config-editor/src-tauri/src/commands.rs
+++ b/config-editor/src-tauri/src/commands.rs
@@ -76,6 +76,15 @@ pub struct ConfigError {
     pub details: Option<Vec<String>>,
 }
 
+impl ConfigError {
+    pub(crate) fn msg(msg: impl Into<String>) -> Self {
+        ConfigError {
+            message: msg.into(),
+            details: None,
+        }
+    }
+}
+
 impl From<std::io::Error> for ConfigError {
     fn from(e: std::io::Error) -> Self {
         ConfigError {
@@ -103,7 +112,7 @@ impl From<serde_json::Error> for ConfigError {
 ///    `usb_drive_name` matches the actual volume name (case-insensitive).
 ///    This limits the surface: an arbitrary volume won't pass validation
 ///    just because someone placed a config.json on it.
-fn validate_device_path(path: &str) -> Result<(), ConfigError> {
+pub(crate) fn validate_device_path(path: &str) -> Result<(), ConfigError> {
     let path = Path::new(path);
 
     // Canonicalize to resolve any .. or symlinks
@@ -201,7 +210,7 @@ fn get_volume_path(path: &Path) -> Option<PathBuf> {
 }
 
 /// Verify the device is still mounted before writing
-fn verify_device_connected(path: &Path) -> Result<(), ConfigError> {
+pub(crate) fn verify_device_connected(path: &Path) -> Result<(), ConfigError> {
     if let Some(volume_path) = get_volume_path(path) {
         if !is_volume_mounted(&volume_path) {
             return Err(ConfigError {
@@ -220,7 +229,7 @@ fn verify_device_connected(path: &Path) -> Result<(), ConfigError> {
 /// cycle immediately after save can race the flush and the device boots with
 /// stale data. Keeping the write handle open for `sync_all` before drop
 /// ensures the data reaches the device's flash.
-fn write_sync(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
+pub(crate) fn write_sync(path: &Path, data: &[u8]) -> Result<(), std::io::Error> {
     let mut file = OpenOptions::new().write(true).create(true).truncate(true).open(path)?;
     file.write_all(data)?;
     file.sync_all()?;

--- a/config-editor/src-tauri/src/commands.rs
+++ b/config-editor/src-tauri/src/commands.rs
@@ -376,35 +376,65 @@ fn find_device_serial_port(_device_path: &Path) -> Result<String, ConfigError> {
     }
 }
 
-/// Soft-reboot a CircuitPython device by sending Ctrl-C + Ctrl-D over serial.
-///
-/// Ctrl-C interrupts the running program, Ctrl-D triggers a soft reload
-/// that re-reads config.json and restarts code.py. The USB drive stays
-/// mounted throughout — no eject or power cycle needed.
-#[command]
-pub fn restart_device(path: String) -> Result<(), ConfigError> {
-    validate_device_path(&path)?;
-
-    let path_obj = Path::new(&path);
-    verify_device_connected(path_obj)?;
-
-    let serial_port = find_device_serial_port(path_obj)?;
-
-    let mut port = serialport::new(&serial_port, 115200)
+fn open_device_serial(path: &Path) -> Result<Box<dyn serialport::SerialPort>, ConfigError> {
+    let serial_port = find_device_serial_port(path)?;
+    serialport::new(&serial_port, 115200)
         .timeout(Duration::from_secs(2))
         .open()
         .map_err(|e| ConfigError {
             message: format!("Failed to open serial port {}: {}", serial_port, e),
             details: None,
-        })?;
+        })
+}
+
+/// Halt the running `code.py` and disable CircuitPython's auto-reload watcher
+/// for the rest of the session. Used as an installer pre-flight: without this,
+/// CP soft-reboots while the installer is still writing files, briefly remounts
+/// `CIRCUITPY` read-only, and the final manifest write blocks indefinitely.
+///
+/// Sequence:
+///   1. Ctrl-C — interrupt the running program, drop to REPL.
+///   2. `import supervisor; supervisor.runtime.autoreload = False`.
+///
+/// The autoreload-off setting reverts on next hard reset; we re-enable a
+/// clean reload at end of install with `soft_reboot_via_serial`.
+pub(crate) fn halt_and_disable_autoreload(path: &Path) -> Result<(), ConfigError> {
+    let mut port = open_device_serial(path)?;
+
+    // Ctrl-C: interrupt running program.
+    port.write_all(&[0x03]).map_err(|e| ConfigError {
+        message: format!("Failed to send interrupt: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Disable autoreload for the rest of the REPL session.
+    let cmd = b"import supervisor\rsupervisor.runtime.autoreload = False\r";
+    port.write_all(cmd).map_err(|e| ConfigError {
+        message: format!("Failed to send autoreload-off command: {}", e),
+        details: None,
+    })?;
+    port.flush().map_err(|e| ConfigError {
+        message: format!("Failed to flush serial port: {}", e),
+        details: None,
+    })?;
+
+    // Give CP a beat to process the command before we start writing files.
+    std::thread::sleep(Duration::from_millis(300));
+
+    Ok(())
+}
+
+/// Soft-reboot a CircuitPython device by sending Ctrl-C + Ctrl-D over serial.
+/// Ctrl-D resets supervisor state, including re-enabling autoreload.
+pub(crate) fn soft_reboot_via_serial(path: &Path) -> Result<(), ConfigError> {
+    let mut port = open_device_serial(path)?;
 
     // Ctrl-C: interrupt running program, drop to REPL
     port.write_all(&[0x03]).map_err(|e| ConfigError {
         message: format!("Failed to send interrupt: {}", e),
         details: None,
     })?;
-
-    // Wait for CircuitPython to stop the program and initialize the REPL
     std::thread::sleep(Duration::from_millis(500));
 
     // Ctrl-D: soft reload — restarts code.py with new config
@@ -417,11 +447,22 @@ pub fn restart_device(path: String) -> Result<(), ConfigError> {
         message: format!("Failed to flush serial port: {}", e),
         details: None,
     })?;
-
-    // Brief pause before closing so the byte is fully transmitted
     std::thread::sleep(Duration::from_millis(100));
 
     Ok(())
+}
+
+/// Soft-reboot a CircuitPython device by sending Ctrl-C + Ctrl-D over serial.
+///
+/// Ctrl-C interrupts the running program, Ctrl-D triggers a soft reload
+/// that re-reads config.json and restarts code.py. The USB drive stays
+/// mounted throughout — no eject or power cycle needed.
+#[command]
+pub fn restart_device(path: String) -> Result<(), ConfigError> {
+    validate_device_path(&path)?;
+    let path_obj = Path::new(&path);
+    verify_device_connected(path_obj)?;
+    soft_reboot_via_serial(path_obj)
 }
 
 /// Safely eject/unmount the device volume.

--- a/config-editor/src-tauri/src/commands.rs
+++ b/config-editor/src-tauri/src/commands.rs
@@ -401,15 +401,36 @@ fn open_device_serial(path: &Path) -> Result<Box<dyn serialport::SerialPort>, Co
 pub(crate) fn halt_and_disable_autoreload(path: &Path) -> Result<(), ConfigError> {
     let mut port = open_device_serial(path)?;
 
-    // Ctrl-C: interrupt running program.
+    // Ctrl-C: interrupt running program. CircuitPython then prints
+    // "Press any key to enter the REPL. Use CTRL-D to reload." and
+    // _consumes the next byte_ as that keypress.
     port.write_all(&[0x03]).map_err(|e| ConfigError {
         message: format!("Failed to send interrupt: {}", e),
         details: None,
     })?;
     std::thread::sleep(Duration::from_millis(500));
 
-    // Disable autoreload for the rest of the REPL session.
-    let cmd = b"import supervisor\rsupervisor.runtime.autoreload = False\r";
+    // Sacrificial CRLF — consumed as the "press any key" prompt. Without
+    // this, the first byte of our import command got eaten ("i" of
+    // "import") and CP saw `mport supervisor; ...` → SyntaxError, leaving
+    // autoreload enabled and the install hanging on manifest write.
+    port.write_all(b"\r\n").map_err(|e| ConfigError {
+        message: format!("Failed to enter REPL: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Disable autoreload for the rest of the REPL session. Single-line
+    // form — CP's REPL only executes a buffered line on CRLF.
+    //
+    // CP 7.x exposes the toggle as `supervisor.disable_autoreload()`
+    // (function); CP 8+ replaced it with the attribute
+    // `supervisor.runtime.autoreload = False` (the function still exists
+    // as a compat shim in some 8.x builds). The `getattr` fallback runs
+    // the function if present, otherwise pokes the attribute. Avoids
+    // multi-line try/except, which CP's line-mode REPL won't accept as
+    // one paste.
+    let cmd = b"import supervisor; getattr(supervisor, 'disable_autoreload', lambda: setattr(supervisor.runtime, 'autoreload', False))()\r\n";
     port.write_all(cmd).map_err(|e| ConfigError {
         message: format!("Failed to send autoreload-off command: {}", e),
         details: None,

--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -205,7 +205,7 @@ pub struct ExpressionPedals {
 }
 
 /// Device type
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceType {
     #[default]
@@ -214,6 +214,30 @@ pub enum DeviceType {
     Nano4,
     Duo2,
     One1,
+}
+
+impl DeviceType {
+    /// All supported device types, in a stable order.
+    pub const ALL: &'static [DeviceType] = &[
+        DeviceType::Std10,
+        DeviceType::Mini6,
+        DeviceType::Nano4,
+        DeviceType::Duo2,
+        DeviceType::One1,
+    ];
+
+    /// Parse the lowercase wire-format name used in `config.json`.
+    /// Returns `None` for unknown device names — callers decide how strict to be.
+    pub fn from_name(s: &str) -> Option<Self> {
+        match s {
+            "std10" => Some(DeviceType::Std10),
+            "mini6" => Some(DeviceType::Mini6),
+            "nano4" => Some(DeviceType::Nano4),
+            "duo2" => Some(DeviceType::Duo2),
+            "one1" => Some(DeviceType::One1),
+            _ => None,
+        }
+    }
 }
 
 /// Display text size settings

--- a/config-editor/src-tauri/src/device.rs
+++ b/config-editor/src-tauri/src/device.rs
@@ -26,7 +26,11 @@ pub fn is_midi_captain_config(config_path: &std::path::Path) -> bool {
     }
     let Ok(contents) = std::fs::read_to_string(config_path) else { return false };
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else { return false };
-    matches!(value.get("device").and_then(|v| v.as_str()), Some("std10") | Some("mini6") | Some("nano4") | Some("duo2") | Some("one1"))
+    value
+        .get("device")
+        .and_then(|v| v.as_str())
+        .and_then(crate::config::DeviceType::from_name)
+        .is_some()
 }
 
 /// Parse a config.json and return the explicitly declared `usb_drive_name` if set,
@@ -42,9 +46,7 @@ pub fn parse_midi_captain_config(config_path: &std::path::Path) -> Option<String
     let contents = std::fs::read_to_string(config_path).ok()?;
     let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
     let device = value.get("device").and_then(|v| v.as_str())?;
-    if device != "std10" && device != "mini6" && device != "nano4" && device != "duo2" && device != "one1" {
-        return None;
-    }
+    crate::config::DeviceType::from_name(device)?;
     // Return usb_drive_name only if explicitly set — no default fallback
     value
         .get("usb_drive_name")

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -211,6 +211,21 @@ enum Op {
     Delete { rel: String, dst: PathBuf },
 }
 
+/// True if `rel` looks like `name.py` and the bundle contains `name.mpy`
+/// in the same parent dir, or vice versa. Used to flag stray `foo.py`
+/// alongside our bundled `foo.mpy` for deletion before write.
+fn alternate_extension_exists(
+    bundle_rels: &BTreeMap<String, String>,
+    rel: &str,
+) -> bool {
+    let alt = match rel.rsplit_once('.') {
+        Some((stem, "py")) => format!("{}.mpy", stem),
+        Some((stem, "mpy")) => format!("{}.py", stem),
+        _ => return false,
+    };
+    bundle_rels.contains_key(&alt)
+}
+
 /// Build the ordered op list for the install. Top-level files always copy
 /// (skip decision happens later via manifest compare). Managed subdirs add
 /// per-file copies plus stale-file deletes.
@@ -232,24 +247,40 @@ fn build_plan(
 
     push_copy(&mut ops, "boot.py");
 
+    // Per managed subdir: emit deletes BEFORE copies. Reasoning:
+    //
+    //  - "Same-stem dup": if bundle has `foo.mpy` and the device's same dir
+    //    has both `foo.mpy` and `foo.py`, the `.py` is a stray (typically
+    //    left by `circup install --py` from older deploy.sh runs). CP's
+    //    module-resolution rules between coexisting forms are version- and
+    //    state-dependent, and the `.py` source often pulls in modules the
+    //    runtime CP doesn't have (e.g. `busdisplay` on CP 7). Drop the
+    //    alternate-extension twin first so the device only ever resolves
+    //    against the bundled form.
+    //
+    //  - "Pure stale": any file under the device subdir that the bundle
+    //    doesn't ship in any form.
+    //
+    // Doing deletes first means a partial-install crash leaves missing libs
+    // (loud ImportError on next boot) rather than a silent fall-through to
+    // an incompatible alternate form (the failure mode we just hit).
     for subdir in MANAGED_DIRS {
         let bundle_sub = firmware_src.join(subdir);
-        if bundle_sub.exists() {
-            let mut bundle_files = BTreeMap::new();
-            walk(&bundle_sub, &bundle_sub, &mut bundle_files)?;
-            for rel_in_sub in bundle_files.keys() {
-                let rel = format!("{}/{}", subdir, rel_in_sub);
-                push_copy(&mut ops, &rel);
-            }
-        }
-        // Stale-delete: any file under device's subdir that bundle doesn't have.
         let device_sub = device_path.join(subdir);
+
+        let mut bundle_files = BTreeMap::new();
+        if bundle_sub.exists() {
+            walk(&bundle_sub, &bundle_sub, &mut bundle_files)?;
+        }
+
         if device_sub.exists() {
             let mut device_files = BTreeMap::new();
             walk(&device_sub, &device_sub, &mut device_files).ok();
             for rel_in_sub in device_files.keys() {
                 let bundle_file = bundle_sub.join(rel_in_sub);
-                if !bundle_file.exists() {
+                let in_bundle = bundle_file.exists();
+                let alt_in_bundle = alternate_extension_exists(&bundle_files, rel_in_sub);
+                if !in_bundle || alt_in_bundle {
                     let rel = format!("{}/{}", subdir, rel_in_sub);
                     ops.push(Op::Delete {
                         rel: rel.clone(),
@@ -257,6 +288,11 @@ fn build_plan(
                     });
                 }
             }
+        }
+
+        for rel_in_sub in bundle_files.keys() {
+            let rel = format!("{}/{}", subdir, rel_in_sub);
+            push_copy(&mut ops, &rel);
         }
     }
 
@@ -646,6 +682,77 @@ mod tests {
             .modified()
             .unwrap();
         assert!(code_mtime >= boot_mtime);
+    }
+
+    #[test]
+    fn same_stem_py_is_deleted_when_bundle_ships_mpy() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        // Device has BOTH the .mpy (matching bundle) and a stray .py for the
+        // same module name — the failure mode that bricked a real device.
+        fs::create_dir_all(device.path().join("lib")).unwrap();
+        fs::write(
+            device.path().join("lib/adafruit_st7789.mpy"),
+            b"fakempy",
+        )
+        .unwrap();
+        fs::write(
+            device.path().join("lib/adafruit_st7789.py"),
+            b"raise ImportError('cp9 only')",
+        )
+        .unwrap();
+
+        let report = install(bundle.path(), device.path(), false);
+
+        assert!(
+            !device.path().join("lib/adafruit_st7789.py").exists(),
+            "stray .py twin must be removed when bundle ships the .mpy"
+        );
+        assert!(
+            device.path().join("lib/adafruit_st7789.mpy").exists(),
+            ".mpy from bundle must remain"
+        );
+        assert!(report.files_deleted >= 1);
+    }
+
+    #[test]
+    fn delete_ops_run_before_copy_ops_in_managed_dir() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        fs::create_dir_all(device.path().join("lib")).unwrap();
+        fs::write(device.path().join("lib/adafruit_st7789.py"), b"old").unwrap();
+
+        let mut events: Vec<InstallProgress> = Vec::new();
+        {
+            let mut sink = |p: InstallProgress| events.push(p);
+            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap();
+        }
+
+        // For the lib subdir: the Delete event for `lib/adafruit_st7789.py`
+        // must appear before any Copy event for `lib/adafruit_st7789.mpy`.
+        let del_idx = events
+            .iter()
+            .position(|p| matches!(p.phase, InstallPhase::Delete) && p.file == "lib/adafruit_st7789.py")
+            .expect("delete event for stray .py");
+        let copy_idx = events
+            .iter()
+            .position(|p| {
+                matches!(p.phase, InstallPhase::Copy | InstallPhase::Skip)
+                    && p.file == "lib/adafruit_st7789.mpy"
+            })
+            .expect("copy/skip event for bundled .mpy");
+        assert!(
+            del_idx < copy_idx,
+            "delete must precede copy in same managed subdir (del={}, copy={})",
+            del_idx,
+            copy_idx,
+        );
     }
 
     // ---- Phase 2b additions ----

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -17,7 +17,10 @@
 //! device has a `firmware.md5` from a prior install, files whose hash matches
 //! the bundle are skipped. Stale files inside managed subdirs are deleted.
 
-use crate::commands::{validate_device_path, verify_device_connected, ConfigError};
+use crate::commands::{
+    halt_and_disable_autoreload, soft_reboot_via_serial, validate_device_path,
+    verify_device_connected, ConfigError,
+};
 use crate::config::DeviceType;
 use md5::{Digest, Md5};
 use serde::Serialize;
@@ -464,6 +467,18 @@ pub fn install_firmware_from(
 /// blocking-pool thread. A sync `#[command]` would peg Tauri's IPC thread for
 /// the duration of the install (visible as a beach ball / unresponsive UI),
 /// and would also stall the Channel that feeds progress events back to JS.
+///
+/// Wraps the pure installer with two serial-port operations:
+///
+/// 1. **Pre-flight halt**: send Ctrl-C + `supervisor.runtime.autoreload = False`
+///    so CircuitPython doesn't soft-reboot mid-install. Without this, CP
+///    detects file changes, schedules a reload, briefly remounts CIRCUITPY
+///    read-only, and the final manifest write blocks indefinitely — the
+///    "never reaches Done phase" symptom.
+///
+/// 2. **Post-install soft reboot**: send Ctrl-C + Ctrl-D so the freshly
+///    installed firmware loads cleanly. Best-effort: a failure here doesn't
+///    invalidate a successful install (user can power-cycle).
 #[command]
 pub async fn install_firmware(
     app: AppHandle,
@@ -480,10 +495,19 @@ pub async fn install_firmware(
         let _guard = INSTALL_LOCK.try_lock().map_err(|_| {
             ConfigError::msg("A firmware install is already in progress on this app instance.")
         })?;
+
+        halt_and_disable_autoreload(&device)?;
+
         let mut emit = |p: InstallProgress| {
             let _ = on_progress.send(p);
         };
-        install_firmware_from(&firmware_src, &device, reset_config, &mut emit)
+        let report = install_firmware_from(&firmware_src, &device, reset_config, &mut emit)?;
+
+        // Best-effort: a soft-reboot failure here is non-fatal — the firmware
+        // is already on disk, user can power-cycle. We swallow the error.
+        let _ = soft_reboot_via_serial(&device);
+
+        Ok(report)
     })
     .await
     .map_err(|e| ConfigError::msg(format!("Install task panicked: {e}")))?

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -12,45 +12,23 @@
 //! Per-file `sync_all()` on the write handle ensures bytes reach USB flash
 //! before the function returns, matching `commands::write_sync`.
 
-use crate::commands::{
-    validate_device_path, verify_device_connected, write_sync, ConfigError,
-};
+use crate::commands::{validate_device_path, verify_device_connected, ConfigError};
+use crate::config::DeviceType;
 use serde::Serialize;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use tauri::{command, AppHandle, Manager};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum DeviceType {
-    Std10,
-    Mini6,
-    Nano4,
-    Duo2,
-    One1,
-}
-
-impl DeviceType {
-    /// Bundled filename of the default config for this device type.
-    fn config_source_name(self) -> &'static str {
-        match self {
-            DeviceType::Std10 => "config.json",
-            DeviceType::Mini6 => "config-mini6.json",
-            DeviceType::Nano4 => "config-nano4.json",
-            DeviceType::Duo2 => "config-duo2.json",
-            DeviceType::One1 => "config-one1.json",
-        }
-    }
-
-    fn parse(s: &str) -> Option<Self> {
-        match s {
-            "std10" => Some(DeviceType::Std10),
-            "mini6" => Some(DeviceType::Mini6),
-            "nano4" => Some(DeviceType::Nano4),
-            "duo2" => Some(DeviceType::Duo2),
-            "one1" => Some(DeviceType::One1),
-            _ => None,
-        }
+/// Bundled filename of the default config template for this device type.
+/// Kept here rather than on `DeviceType` itself so the config crate stays
+/// unaware of firmware-installer filesystem conventions.
+fn config_source_name(dt: DeviceType) -> &'static str {
+    match dt {
+        DeviceType::Std10 => "config.json",
+        DeviceType::Mini6 => "config-mini6.json",
+        DeviceType::Nano4 => "config-nano4.json",
+        DeviceType::Duo2 => "config-duo2.json",
+        DeviceType::One1 => "config-one1.json",
     }
 }
 
@@ -89,18 +67,26 @@ fn detect_device_type(device_root: &Path) -> Option<DeviceType> {
     let contents = fs::read_to_string(&config_path).ok()?;
     let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
     let dev = value.get("device").and_then(|v| v.as_str())?;
-    DeviceType::parse(dev)
+    DeviceType::from_name(dev)
 }
 
-/// Copy a single file, syncing the write to physical storage before returning.
+/// Stream-copy `src` to `dst`, then fsync the write handle before it drops.
+/// Avoids buffering the whole file in memory while still guaranteeing the
+/// bytes reach physical storage (same durability contract as `write_sync`).
 fn copy_file_synced(src: &Path, dst: &Path) -> Result<(), ConfigError> {
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)?;
     }
-    let data = fs::read(src).map_err(|e| ConfigError::msg(format!(
-        "Failed to read {}: {}", src.display(), e
-    )))?;
-    write_sync(dst, &data)?;
+    let mut reader = File::open(src).map_err(|e| {
+        ConfigError::msg(format!("Failed to open {}: {}", src.display(), e))
+    })?;
+    let mut writer = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(dst)?;
+    std::io::copy(&mut reader, &mut writer)?;
+    writer.sync_all()?;
     Ok(())
 }
 
@@ -128,15 +114,6 @@ fn copy_dir_synced(src: &Path, dst: &Path) -> Result<usize, ConfigError> {
     }
     Ok(count)
 }
-
-/// Reference configs deploy.sh pushes alongside the active `config.json`
-/// so every device type's template is available on the device for inspection.
-const REFERENCE_CONFIGS: &[&str] = &[
-    "config-one1.json",
-    "config-duo2.json",
-    "config-mini6.json",
-    "config-nano4.json",
-];
 
 /// Pure installer: takes resolved source and destination paths, no Tauri
 /// context. Callable from tests with tempdirs.
@@ -166,14 +143,12 @@ pub fn install_firmware_from(
 
     let mut files_copied = 0usize;
 
-    // 1. boot.py
     copy_file_synced(
         &firmware_src.join("boot.py"),
         &device_path.join("boot.py"),
     )?;
     files_copied += 1;
 
-    // 2. Core modules, device definitions, fonts, libraries — wipe + copy.
     for subdir in &["core", "devices", "fonts", "lib"] {
         let src_dir = firmware_src.join(subdir);
         if src_dir.exists() {
@@ -181,17 +156,23 @@ pub fn install_firmware_from(
         }
     }
 
-    // 3. config.json — preserve unless caller opts in to reset.
     let active_config = device_path.join("config.json");
     let config_preserved = active_config.exists() && !reset_config;
     if !config_preserved {
-        let src_config = firmware_src.join(device_type.config_source_name());
+        let src_config = firmware_src.join(config_source_name(device_type));
         copy_file_synced(&src_config, &active_config)?;
         files_copied += 1;
     }
 
-    // 4. Reference configs for every supported device.
-    for name in REFERENCE_CONFIGS {
+    // Reference configs for every supported device, except the active one
+    // (already copied above when not preserving).
+    for dt in DeviceType::ALL {
+        let name = config_source_name(*dt);
+        // Skip std10's "config.json" — that's the active-config slot, not a
+        // reference slot.
+        if *dt == DeviceType::Std10 {
+            continue;
+        }
         let src = firmware_src.join(name);
         if src.exists() {
             copy_file_synced(&src, &device_path.join(name))?;
@@ -199,22 +180,21 @@ pub fn install_firmware_from(
         }
     }
 
-    // 5. code.py LAST.
+    // code.py LAST — everything else is in place before the device reloads.
     copy_file_synced(
         &firmware_src.join("code.py"),
         &device_path.join("code.py"),
     )?;
     files_copied += 1;
 
-    // 6. VERSION.
     let version_src = firmware_src.join("VERSION");
-    let version = if version_src.exists() {
-        let v = fs::read_to_string(&version_src)?.trim().to_string();
-        copy_file_synced(&version_src, &device_path.join("VERSION"))?;
-        files_copied += 1;
-        v
-    } else {
-        "dev".to_string()
+    let version = match fs::read_to_string(&version_src) {
+        Ok(contents) => {
+            copy_file_synced(&version_src, &device_path.join("VERSION"))?;
+            files_copied += 1;
+            contents.trim().to_string()
+        }
+        Err(_) => "dev".to_string(),
     };
 
     Ok(InstallReport {
@@ -248,7 +228,7 @@ mod tests {
         fs::write(dir.join("boot.py"), b"# boot").unwrap();
         fs::write(dir.join("code.py"), b"# code").unwrap();
         fs::write(dir.join("config.json"), br#"{"device":"std10","from":"bundle"}"#).unwrap();
-        fs::write(dir.join("config-mini6.json"), br#"{"device":"mini6"}"#).unwrap();
+        fs::write(dir.join("config-mini6.json"), br#"{"device":"mini6","from":"bundle"}"#).unwrap();
         fs::write(dir.join("config-nano4.json"), br#"{"device":"nano4"}"#).unwrap();
         fs::write(dir.join("config-duo2.json"), br#"{"device":"duo2"}"#).unwrap();
         fs::write(dir.join("config-one1.json"), br#"{"device":"one1"}"#).unwrap();
@@ -318,28 +298,20 @@ mod tests {
     }
 
     #[test]
-    fn mini6_device_gets_mini6_default_config_on_fresh_install() {
+    fn mini6_device_gets_mini6_default_config_on_reset() {
         let bundle = TempDir::new().unwrap();
         let device = TempDir::new().unwrap();
         make_bundle(bundle.path());
-        // Seed a mini6 config, then delete it so detect_device_type falls back —
-        // simulating "device had config.json but user removed it". The test is
-        // really about: when we DO install a fresh config.json, is it the mini6 one?
-        seed_device(device.path(), "mini6");
-        let user_config = device.path().join("config.json");
-        // Detect type from user config first, then remove it to force fresh install.
-        let expected = detect_device_type(device.path()).unwrap();
-        assert_eq!(expected, DeviceType::Mini6);
-        fs::remove_file(&user_config).unwrap();
-        // Re-seed to let install succeed (detect needs a device)
         seed_device(device.path(), "mini6");
 
         let report = install_firmware_from(bundle.path(), device.path(), true).unwrap();
+
         assert_eq!(report.device_type, DeviceType::Mini6);
         let installed = fs::read_to_string(device.path().join("config.json")).unwrap();
-        // Bundled mini6 config contains `"device":"mini6"` and no `"custom"` field.
+        // The mini6 bundled config has `"from":"bundle"`; the seeded user config did not.
         assert!(installed.contains(r#""device":"mini6""#));
-        assert!(!installed.contains("custom"));
+        assert!(installed.contains(r#""from":"bundle""#), "should be the bundled mini6 template, not the user seed");
+        assert!(!installed.contains("user-edit"));
     }
 
     #[test]
@@ -351,7 +323,12 @@ mod tests {
 
         install_firmware_from(bundle.path(), device.path(), false).unwrap();
 
-        for name in REFERENCE_CONFIGS {
+        // Every non-std10 device's template should land on the device as a reference.
+        for dt in DeviceType::ALL {
+            if *dt == DeviceType::Std10 {
+                continue;
+            }
+            let name = config_source_name(*dt);
             assert!(device.path().join(name).exists(), "reference config {} missing", name);
         }
     }
@@ -363,7 +340,6 @@ mod tests {
         make_bundle(bundle.path());
         seed_device(device.path(), "std10");
 
-        // Simulate an older installation with a .mpy that's no longer in the bundle.
         fs::create_dir(device.path().join("core")).unwrap();
         fs::write(device.path().join("core/stale.mpy"), b"old").unwrap();
 
@@ -382,8 +358,8 @@ mod tests {
         fs::remove_file(bundle.path().join("boot.py")).unwrap();
 
         let err = install_firmware_from(bundle.path(), device.path(), false).unwrap_err();
-        assert!(err.message.contains("boot.py"), "error message should mention the missing file, got: {}", err.message);
-        // code.py on device should not have been written
+        assert!(err.message.contains("boot.py"), "error should mention the missing file, got: {}", err.message);
+        // No writes should have happened.
         assert!(!device.path().join("code.py").exists());
     }
 
@@ -400,14 +376,10 @@ mod tests {
     }
 
     #[test]
-    fn code_py_written_last() {
-        // If code.py exists on device before other files are copied, and the
-        // install fails midway, the device could try to import missing modules
-        // from core/. Verify ordering by staging a failure in the bundle after
-        // boot.py but before code.py. We do this by removing code.py from the
-        // bundle AFTER pre-flight. (Pre-flight catches it, so this test can't
-        // directly observe the order.) Instead, just assert code.py and VERSION
-        // modification times are >= boot.py's in a normal run.
+    fn code_py_mtime_at_or_after_boot_py() {
+        // Weak but real: if `code.py` were written before `boot.py`, a mid-install
+        // crash could leave a device that boots into incomplete firmware. Mtime
+        // comparison is coarse (filesystem resolution) but catches gross order swaps.
         let bundle = TempDir::new().unwrap();
         let device = TempDir::new().unwrap();
         make_bundle(bundle.path());
@@ -423,6 +395,6 @@ mod tests {
             .unwrap()
             .modified()
             .unwrap();
-        assert!(code_mtime >= boot_mtime, "code.py must be written at or after boot.py");
+        assert!(code_mtime >= boot_mtime);
     }
 }

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -1,0 +1,428 @@
+//! Firmware installer — copies the bundled CircuitPython firmware from the
+//! Tauri app's resource directory to a connected MIDI Captain device.
+//!
+//! Ordering mirrors `tools/deploy.sh`:
+//! 1. boot.py (keeps autoreload disabled on an existing install)
+//! 2. core/, devices/, fonts/, lib/ — directories replace their targets wholesale
+//! 3. config.json — only if missing or reset_config=true
+//! 4. config-<device>.json reference configs
+//! 5. code.py (LAST, so all imports are in place before the device reloads)
+//! 6. VERSION
+//!
+//! Per-file `sync_all()` on the write handle ensures bytes reach USB flash
+//! before the function returns, matching `commands::write_sync`.
+
+use crate::commands::{
+    validate_device_path, verify_device_connected, write_sync, ConfigError,
+};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::{command, AppHandle, Manager};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeviceType {
+    Std10,
+    Mini6,
+    Nano4,
+    Duo2,
+    One1,
+}
+
+impl DeviceType {
+    /// Bundled filename of the default config for this device type.
+    fn config_source_name(self) -> &'static str {
+        match self {
+            DeviceType::Std10 => "config.json",
+            DeviceType::Mini6 => "config-mini6.json",
+            DeviceType::Nano4 => "config-nano4.json",
+            DeviceType::Duo2 => "config-duo2.json",
+            DeviceType::One1 => "config-one1.json",
+        }
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "std10" => Some(DeviceType::Std10),
+            "mini6" => Some(DeviceType::Mini6),
+            "nano4" => Some(DeviceType::Nano4),
+            "duo2" => Some(DeviceType::Duo2),
+            "one1" => Some(DeviceType::One1),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct InstallReport {
+    pub device_type: DeviceType,
+    pub files_copied: usize,
+    pub version: String,
+    pub config_preserved: bool,
+}
+
+/// Resolve the bundled firmware directory inside the Tauri app resources.
+/// Phase 1 wires `config-editor/src-tauri/resources/firmware/**/*` into the
+/// bundle; the `resources/` glob prefix is preserved in the built layout, so
+/// the runtime path is `<resource_dir>/resources/firmware`.
+fn bundled_firmware_dir(app: &AppHandle) -> Result<PathBuf, ConfigError> {
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| ConfigError::msg(format!("Could not resolve app resource directory: {e}")))?;
+    let firmware_dir = resource_dir.join("resources").join("firmware");
+    if !firmware_dir.exists() {
+        return Err(ConfigError::msg(format!(
+            "Bundled firmware not found at {}",
+            firmware_dir.display()
+        )));
+    }
+    Ok(firmware_dir)
+}
+
+/// Read `<device_root>/config.json` and parse the `device` field.
+/// Returns `None` if the config is missing, unreadable, or declares an
+/// unknown device type.
+fn detect_device_type(device_root: &Path) -> Option<DeviceType> {
+    let config_path = device_root.join("config.json");
+    let contents = fs::read_to_string(&config_path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    let dev = value.get("device").and_then(|v| v.as_str())?;
+    DeviceType::parse(dev)
+}
+
+/// Copy a single file, syncing the write to physical storage before returning.
+fn copy_file_synced(src: &Path, dst: &Path) -> Result<(), ConfigError> {
+    if let Some(parent) = dst.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let data = fs::read(src).map_err(|e| ConfigError::msg(format!(
+        "Failed to read {}: {}", src.display(), e
+    )))?;
+    write_sync(dst, &data)?;
+    Ok(())
+}
+
+/// Wipe `dst` and re-populate it from `src` (recursive). Returns file count.
+///
+/// The wipe-first policy mirrors `deploy.sh`'s `rsync --delete` semantics —
+/// prevents stale `.py` / `.mpy` pairs from coexisting on the device and
+/// triggering `ImportError` on the wrong module form being loaded.
+fn copy_dir_synced(src: &Path, dst: &Path) -> Result<usize, ConfigError> {
+    if dst.exists() {
+        fs::remove_dir_all(dst)?;
+    }
+    fs::create_dir_all(dst)?;
+    let mut count = 0;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        let target = dst.join(entry.file_name());
+        if path.is_dir() {
+            count += copy_dir_synced(&path, &target)?;
+        } else {
+            copy_file_synced(&path, &target)?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+/// Reference configs deploy.sh pushes alongside the active `config.json`
+/// so every device type's template is available on the device for inspection.
+const REFERENCE_CONFIGS: &[&str] = &[
+    "config-one1.json",
+    "config-duo2.json",
+    "config-mini6.json",
+    "config-nano4.json",
+];
+
+/// Pure installer: takes resolved source and destination paths, no Tauri
+/// context. Callable from tests with tempdirs.
+pub fn install_firmware_from(
+    firmware_src: &Path,
+    device_path: &Path,
+    reset_config: bool,
+) -> Result<InstallReport, ConfigError> {
+    // Pre-flight: refuse to start writing if any required source file is missing.
+    for required in &["boot.py", "code.py"] {
+        let p = firmware_src.join(required);
+        if !p.exists() {
+            return Err(ConfigError::msg(format!(
+                "Bundled firmware is missing required file: {}",
+                required
+            )));
+        }
+    }
+
+    let device_type = detect_device_type(device_path).ok_or_else(|| {
+        ConfigError::msg(
+            "Could not detect device type from config.json on the device. \
+             Ensure the device has a valid config.json declaring a recognized \
+             'device' field (std10, mini6, nano4, duo2, one1).",
+        )
+    })?;
+
+    let mut files_copied = 0usize;
+
+    // 1. boot.py
+    copy_file_synced(
+        &firmware_src.join("boot.py"),
+        &device_path.join("boot.py"),
+    )?;
+    files_copied += 1;
+
+    // 2. Core modules, device definitions, fonts, libraries — wipe + copy.
+    for subdir in &["core", "devices", "fonts", "lib"] {
+        let src_dir = firmware_src.join(subdir);
+        if src_dir.exists() {
+            files_copied += copy_dir_synced(&src_dir, &device_path.join(subdir))?;
+        }
+    }
+
+    // 3. config.json — preserve unless caller opts in to reset.
+    let active_config = device_path.join("config.json");
+    let config_preserved = active_config.exists() && !reset_config;
+    if !config_preserved {
+        let src_config = firmware_src.join(device_type.config_source_name());
+        copy_file_synced(&src_config, &active_config)?;
+        files_copied += 1;
+    }
+
+    // 4. Reference configs for every supported device.
+    for name in REFERENCE_CONFIGS {
+        let src = firmware_src.join(name);
+        if src.exists() {
+            copy_file_synced(&src, &device_path.join(name))?;
+            files_copied += 1;
+        }
+    }
+
+    // 5. code.py LAST.
+    copy_file_synced(
+        &firmware_src.join("code.py"),
+        &device_path.join("code.py"),
+    )?;
+    files_copied += 1;
+
+    // 6. VERSION.
+    let version_src = firmware_src.join("VERSION");
+    let version = if version_src.exists() {
+        let v = fs::read_to_string(&version_src)?.trim().to_string();
+        copy_file_synced(&version_src, &device_path.join("VERSION"))?;
+        files_copied += 1;
+        v
+    } else {
+        "dev".to_string()
+    };
+
+    Ok(InstallReport {
+        device_type,
+        files_copied,
+        version,
+        config_preserved,
+    })
+}
+
+/// Tauri command: install bundled firmware onto the connected device.
+#[command]
+pub fn install_firmware(
+    app: AppHandle,
+    device_path: String,
+    reset_config: bool,
+) -> Result<InstallReport, ConfigError> {
+    validate_device_path(&device_path)?;
+    let device = PathBuf::from(&device_path);
+    verify_device_connected(&device)?;
+    let firmware_src = bundled_firmware_dir(&app)?;
+    install_firmware_from(&firmware_src, &device, reset_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_bundle(dir: &Path) {
+        fs::write(dir.join("boot.py"), b"# boot").unwrap();
+        fs::write(dir.join("code.py"), b"# code").unwrap();
+        fs::write(dir.join("config.json"), br#"{"device":"std10","from":"bundle"}"#).unwrap();
+        fs::write(dir.join("config-mini6.json"), br#"{"device":"mini6"}"#).unwrap();
+        fs::write(dir.join("config-nano4.json"), br#"{"device":"nano4"}"#).unwrap();
+        fs::write(dir.join("config-duo2.json"), br#"{"device":"duo2"}"#).unwrap();
+        fs::write(dir.join("config-one1.json"), br#"{"device":"one1"}"#).unwrap();
+        fs::write(dir.join("VERSION"), b"v0.0.0-test\n").unwrap();
+
+        fs::create_dir(dir.join("core")).unwrap();
+        fs::write(dir.join("core/config.py"), b"# core.config").unwrap();
+        fs::write(dir.join("core/button.py"), b"# core.button").unwrap();
+
+        fs::create_dir(dir.join("devices")).unwrap();
+        fs::write(dir.join("devices/std10.py"), b"# std10").unwrap();
+        fs::write(dir.join("devices/mini6.py"), b"# mini6").unwrap();
+
+        fs::create_dir(dir.join("fonts")).unwrap();
+        fs::write(dir.join("fonts/PTSans.pcf"), b"fakepcf").unwrap();
+
+        fs::create_dir(dir.join("lib")).unwrap();
+        fs::write(dir.join("lib/adafruit_st7789.mpy"), b"fakempy").unwrap();
+    }
+
+    fn seed_device(dir: &Path, device: &str) {
+        fs::write(
+            dir.join("config.json"),
+            format!(r#"{{"device":"{}","custom":"user-edit"}}"#, device).as_bytes(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn device_type_detected_from_device_config() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "mini6");
+
+        let report = install_firmware_from(bundle.path(), device.path(), false).unwrap();
+        assert_eq!(report.device_type, DeviceType::Mini6);
+    }
+
+    #[test]
+    fn preserves_existing_config_by_default() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        let report = install_firmware_from(bundle.path(), device.path(), false).unwrap();
+
+        assert!(report.config_preserved);
+        let cfg = fs::read_to_string(device.path().join("config.json")).unwrap();
+        assert!(cfg.contains(r#""custom":"user-edit""#), "user config must survive");
+    }
+
+    #[test]
+    fn reset_config_overwrites_user_edits() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        let report = install_firmware_from(bundle.path(), device.path(), true).unwrap();
+
+        assert!(!report.config_preserved);
+        let cfg = fs::read_to_string(device.path().join("config.json")).unwrap();
+        assert!(cfg.contains(r#""from":"bundle""#), "bundled config must replace user's");
+        assert!(!cfg.contains("user-edit"));
+    }
+
+    #[test]
+    fn mini6_device_gets_mini6_default_config_on_fresh_install() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        // Seed a mini6 config, then delete it so detect_device_type falls back —
+        // simulating "device had config.json but user removed it". The test is
+        // really about: when we DO install a fresh config.json, is it the mini6 one?
+        seed_device(device.path(), "mini6");
+        let user_config = device.path().join("config.json");
+        // Detect type from user config first, then remove it to force fresh install.
+        let expected = detect_device_type(device.path()).unwrap();
+        assert_eq!(expected, DeviceType::Mini6);
+        fs::remove_file(&user_config).unwrap();
+        // Re-seed to let install succeed (detect needs a device)
+        seed_device(device.path(), "mini6");
+
+        let report = install_firmware_from(bundle.path(), device.path(), true).unwrap();
+        assert_eq!(report.device_type, DeviceType::Mini6);
+        let installed = fs::read_to_string(device.path().join("config.json")).unwrap();
+        // Bundled mini6 config contains `"device":"mini6"` and no `"custom"` field.
+        assert!(installed.contains(r#""device":"mini6""#));
+        assert!(!installed.contains("custom"));
+    }
+
+    #[test]
+    fn reference_configs_always_written() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        install_firmware_from(bundle.path(), device.path(), false).unwrap();
+
+        for name in REFERENCE_CONFIGS {
+            assert!(device.path().join(name).exists(), "reference config {} missing", name);
+        }
+    }
+
+    #[test]
+    fn stale_core_files_are_removed() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        // Simulate an older installation with a .mpy that's no longer in the bundle.
+        fs::create_dir(device.path().join("core")).unwrap();
+        fs::write(device.path().join("core/stale.mpy"), b"old").unwrap();
+
+        install_firmware_from(bundle.path(), device.path(), false).unwrap();
+
+        assert!(!device.path().join("core/stale.mpy").exists(), "stale file must be removed");
+        assert!(device.path().join("core/config.py").exists(), "new file must be present");
+    }
+
+    #[test]
+    fn missing_boot_py_fails_before_writing() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+        fs::remove_file(bundle.path().join("boot.py")).unwrap();
+
+        let err = install_firmware_from(bundle.path(), device.path(), false).unwrap_err();
+        assert!(err.message.contains("boot.py"), "error message should mention the missing file, got: {}", err.message);
+        // code.py on device should not have been written
+        assert!(!device.path().join("code.py").exists());
+    }
+
+    #[test]
+    fn unknown_device_type_refuses_install() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        fs::write(device.path().join("config.json"), br#"{"device":"unknown"}"#).unwrap();
+
+        let err = install_firmware_from(bundle.path(), device.path(), false).unwrap_err();
+        assert!(err.message.to_lowercase().contains("device type"));
+        assert!(!device.path().join("boot.py").exists());
+    }
+
+    #[test]
+    fn code_py_written_last() {
+        // If code.py exists on device before other files are copied, and the
+        // install fails midway, the device could try to import missing modules
+        // from core/. Verify ordering by staging a failure in the bundle after
+        // boot.py but before code.py. We do this by removing code.py from the
+        // bundle AFTER pre-flight. (Pre-flight catches it, so this test can't
+        // directly observe the order.) Instead, just assert code.py and VERSION
+        // modification times are >= boot.py's in a normal run.
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        install_firmware_from(bundle.path(), device.path(), false).unwrap();
+
+        let boot_mtime = fs::metadata(device.path().join("boot.py"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        let code_mtime = fs::metadata(device.path().join("code.py"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert!(code_mtime >= boot_mtime, "code.py must be written at or after boot.py");
+    }
+}

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -333,14 +333,20 @@ pub fn install_firmware_from(
     let mut files_copied = 0usize;
     let mut files_skipped = 0usize;
     let mut files_deleted = 0usize;
+    // Final manifest reflects what actually ends up on the device, not the
+    // full bundle. Built up as ops execute so it can't disagree with reality.
+    let mut final_manifest: BTreeMap<String, String> = BTreeMap::new();
 
     for (idx, op) in plan.iter().enumerate() {
         let current = idx + 1;
         match op {
             Op::Copy { rel, src, dst } => {
-                let bundle_hex = bundle_manifest.get(rel);
+                let bundle_hex = bundle_manifest.get(rel).cloned();
                 let device_hex = device_manifest.get(rel);
-                let same_hash = matches!((bundle_hex, device_hex), (Some(a), Some(b)) if a == b);
+                let same_hash = matches!(
+                    (bundle_hex.as_ref(), device_hex),
+                    (Some(a), Some(b)) if a == b
+                );
                 if same_hash && dst.exists() {
                     files_skipped += 1;
                     progress(InstallProgress {
@@ -359,6 +365,9 @@ pub fn install_firmware_from(
                         file: rel.clone(),
                     });
                 }
+                if let Some(hex) = bundle_hex {
+                    final_manifest.insert(rel.clone(), hex);
+                }
             }
             Op::Delete { rel, dst } => {
                 if dst.exists() {
@@ -375,7 +384,15 @@ pub fn install_firmware_from(
         }
     }
 
-    write_device_manifest(device_path, &bundle_manifest)?;
+    // Preserved config.json is on the device but not in the plan; hash the
+    // actual on-device bytes so the manifest reflects what's there.
+    if config_preserved {
+        if let Ok(hex) = hash_file(&active_config) {
+            final_manifest.insert("config.json".to_string(), hex);
+        }
+    }
+
+    write_device_manifest(device_path, &final_manifest)?;
     progress(InstallProgress {
         phase: InstallPhase::Manifest,
         current: total,
@@ -721,6 +738,59 @@ mod tests {
                 assert_eq!(p.total, first.total);
             }
         }
+    }
+
+    #[test]
+    fn manifest_excludes_bundle_files_not_in_plan() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        // Add a bundle file that isn't part of the install plan.
+        fs::write(
+            bundle.path().join("config-example-extra.json"),
+            br#"{"device":"std10","kind":"example"}"#,
+        )
+        .unwrap();
+        seed_device(device.path(), "std10");
+
+        install(bundle.path(), device.path(), false);
+
+        let manifest = fs::read_to_string(device.path().join("firmware.md5")).unwrap();
+        assert!(
+            !manifest.contains("config-example-extra.json"),
+            "manifest must only list files actually installed, got:\n{}",
+            manifest
+        );
+        assert!(manifest.contains("boot.py"));
+        assert!(manifest.contains("config.json"), "preserved config.json must be in manifest");
+    }
+
+    #[test]
+    fn manifest_preserved_config_uses_device_bytes_hash() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        install(bundle.path(), device.path(), false);
+
+        // Compute hash of bundle's std10 template vs. the actual device config.
+        let bundle_hash = hash_file(&bundle.path().join("config.json")).unwrap();
+        let device_hash = hash_file(&device.path().join("config.json")).unwrap();
+        assert_ne!(
+            bundle_hash, device_hash,
+            "test premise: seeded user config differs from bundle template"
+        );
+
+        let manifest = fs::read_to_string(device.path().join("firmware.md5")).unwrap();
+        assert!(manifest.contains(&device_hash), "manifest should record device-bytes hash for preserved config.json");
+        // Find the config.json line specifically — bundle hash must not appear next to config.json.
+        let config_line = manifest
+            .lines()
+            .find(|l| l.ends_with("  config.json"))
+            .expect("config.json line in manifest");
+        assert!(config_line.starts_with(&device_hash));
+        assert!(!config_line.starts_with(&bundle_hash));
     }
 
     #[test]

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -195,16 +195,21 @@ fn write_device_manifest(
     manifest: &BTreeMap<String, String>,
 ) -> Result<(), ConfigError> {
     let path = device_root.join("firmware.md5");
-    let mut writer = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(&path)?;
-    use std::io::Write as _;
+    // Build the full payload in memory, write in one fs::write call (open +
+    // write_all + close), no per-line writeln! and no sync_all. The manifest
+    // is purely an optimization for the next install — losing it on power
+    // loss is harmless. Earlier we ended every install with `sync_all()`
+    // here, but on a CircuitPython USB MSC volume that fsync can hang the
+    // whole install for tens of seconds while the device's serial REPL is
+    // active — visible in the GUI as "Writing manifest" never completing.
+    let mut payload = String::with_capacity(manifest.len() * 64);
     for (rel, hex) in manifest {
-        writeln!(writer, "{}  {}", hex, rel)?;
+        payload.push_str(hex);
+        payload.push_str("  ");
+        payload.push_str(rel);
+        payload.push('\n');
     }
-    writer.sync_all()?;
+    fs::write(&path, payload)?;
     Ok(())
 }
 
@@ -431,13 +436,17 @@ pub fn install_firmware_from(
         }
     }
 
-    write_device_manifest(device_path, &final_manifest)?;
+    // Fire a Manifest event _before_ the write so the UI can show "Writing
+    // manifest" while it's in flight (and so we can tell from the last-seen
+    // event whether a hang happened in the write itself or somewhere
+    // earlier).
     progress(InstallProgress {
         phase: InstallPhase::Manifest,
         current: total,
         total,
         file: "firmware.md5".to_string(),
     });
+    write_device_manifest(device_path, &final_manifest)?;
 
     let version = fs::read_to_string(firmware_src.join("VERSION"))
         .map(|s| s.trim().to_string())
@@ -457,6 +466,45 @@ pub fn install_firmware_from(
         files_deleted,
         version,
         config_preserved,
+    })
+}
+
+/// Read a firmware version from a `VERSION` file in `dir`. Returns the file's
+/// trimmed contents or `None` if the file is missing/unreadable.
+fn read_version_file(dir: &Path) -> Option<String> {
+    fs::read_to_string(dir.join("VERSION"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FirmwareVersions {
+    /// Version on the device, if a `VERSION` file is present at the device
+    /// root. `None` indicates an OEM / unmanaged install — the device wasn't
+    /// flashed by us (or the file was deleted).
+    pub device: Option<String>,
+    /// Version of the firmware bundled in this app build.
+    pub bundled: String,
+}
+
+/// Tauri command: report the installed firmware version on the device and the
+/// version of the bundled firmware this app would install. Used by the UI to
+/// show "OEM" / "v1.x.y → v1.x.z" before the user clicks Install.
+#[command]
+pub fn get_firmware_versions(
+    app: AppHandle,
+    device_path: String,
+) -> Result<FirmwareVersions, ConfigError> {
+    validate_device_path(&device_path)?;
+    let device = PathBuf::from(&device_path);
+    verify_device_connected(&device)?;
+    let firmware_src = bundled_firmware_dir(&app)?;
+
+    Ok(FirmwareVersions {
+        device: read_version_file(&device),
+        bundled: read_version_file(&firmware_src).unwrap_or_else(|| "dev".to_string()),
     })
 }
 

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -3,32 +3,37 @@
 //!
 //! Ordering mirrors `tools/deploy.sh`:
 //! 1. boot.py (keeps autoreload disabled on an existing install)
-//! 2. core/, devices/, fonts/, lib/ — directories replace their targets wholesale
+//! 2. core/, devices/, fonts/, lib/ — files copied per-file; stale files removed
 //! 3. config.json — only if missing or reset_config=true
 //! 4. config-<device>.json reference configs
 //! 5. code.py (LAST, so all imports are in place before the device reloads)
 //! 6. VERSION
+//! 7. firmware.md5 — manifest of installed bytes, used for incremental updates
 //!
 //! Per-file `sync_all()` on the write handle ensures bytes reach USB flash
 //! before the function returns, matching `commands::write_sync`.
+//!
+//! Incremental updates: bundle manifest is computed at install time. If the
+//! device has a `firmware.md5` from a prior install, files whose hash matches
+//! the bundle are skipped. Stale files inside managed subdirs are deleted.
 
 use crate::commands::{validate_device_path, verify_device_connected, ConfigError};
 use crate::config::DeviceType;
+use md5::{Digest, Md5};
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use tauri::ipc::Channel;
 use tauri::{command, AppHandle, Manager};
 
+/// Subdirectories the installer fully manages — stale files inside these are
+/// deleted to mirror `deploy.sh`'s `rsync --delete` semantics.
+const MANAGED_DIRS: &[&str] = &["core", "devices", "fonts", "lib"];
+
 /// Bundled filename of the default config template for this device type.
-/// Kept here rather than on `DeviceType` itself so the config crate stays
-/// unaware of firmware-installer filesystem conventions.
-///
-/// Note: `Std10` returns `"config.json"` — that filename serves double duty
-/// as both the Std10 template in the bundle *and* the active-config slot on
-/// every device. The reference-config loop below skips the active device's
-/// template to avoid a double-write that would otherwise be a no-op for
-/// Std10 but still a wasted sync on other devices.
 fn config_source_name(dt: DeviceType) -> &'static str {
     match dt {
         DeviceType::Std10 => "config.json",
@@ -39,23 +44,41 @@ fn config_source_name(dt: DeviceType) -> &'static str {
     }
 }
 
-/// Single-install lock: prevents a concurrent `install_firmware` invocation
-/// (e.g. double-click, or two tabs of the same app) from interleaving writes
-/// to the same device.
 static INSTALL_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Serialize)]
 pub struct InstallReport {
     pub device_type: DeviceType,
     pub files_copied: usize,
+    pub files_skipped: usize,
+    pub files_deleted: usize,
     pub version: String,
     pub config_preserved: bool,
 }
 
-/// Resolve the bundled firmware directory inside the Tauri app resources.
-/// Phase 1 wires `config-editor/src-tauri/resources/firmware/**/*` into the
-/// bundle; the `resources/` glob prefix is preserved in the built layout, so
-/// the runtime path is `<resource_dir>/resources/firmware`.
+/// Streaming progress event. Sent for every planned op (copy or delete),
+/// including ops that turn into no-op skips. `current` and `total` count ops,
+/// not bytes.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallProgress {
+    pub phase: InstallPhase,
+    pub current: usize,
+    pub total: usize,
+    pub file: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InstallPhase {
+    Planning,
+    Copy,
+    Skip,
+    Delete,
+    Manifest,
+    Done,
+}
+
 fn bundled_firmware_dir(app: &AppHandle) -> Result<PathBuf, ConfigError> {
     let resource_dir = app
         .path()
@@ -71,9 +94,6 @@ fn bundled_firmware_dir(app: &AppHandle) -> Result<PathBuf, ConfigError> {
     Ok(firmware_dir)
 }
 
-/// Read `<device_root>/config.json` and parse the `device` field.
-/// Returns `None` if the config is missing, unreadable, or declares an
-/// unknown device type.
 fn detect_device_type(device_root: &Path) -> Option<DeviceType> {
     let config_path = device_root.join("config.json");
     let contents = fs::read_to_string(&config_path).ok()?;
@@ -82,9 +102,6 @@ fn detect_device_type(device_root: &Path) -> Option<DeviceType> {
     DeviceType::from_name(dev)
 }
 
-/// Stream-copy `src` to `dst`, then fsync the write handle before it drops.
-/// Avoids buffering the whole file in memory while still guaranteeing the
-/// bytes reach physical storage (same durability contract as `write_sync`).
 fn copy_file_synced(src: &Path, dst: &Path) -> Result<(), ConfigError> {
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)?;
@@ -102,39 +119,183 @@ fn copy_file_synced(src: &Path, dst: &Path) -> Result<(), ConfigError> {
     Ok(())
 }
 
-/// Wipe `dst` and re-populate it from `src` (recursive). Returns file count.
-///
-/// The wipe-first policy mirrors `deploy.sh`'s `rsync --delete` semantics —
-/// prevents stale `.py` / `.mpy` pairs from coexisting on the device and
-/// triggering `ImportError` on the wrong module form being loaded.
-fn copy_dir_synced(src: &Path, dst: &Path) -> Result<usize, ConfigError> {
-    if dst.exists() {
-        fs::remove_dir_all(dst)?;
-    }
-    fs::create_dir_all(dst)?;
-    let mut count = 0;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let path = entry.path();
-        let target = dst.join(entry.file_name());
-        if path.is_dir() {
-            count += copy_dir_synced(&path, &target)?;
-        } else {
-            copy_file_synced(&path, &target)?;
-            count += 1;
-        }
-    }
-    Ok(count)
+/// Compute md5 of a file as lowercase hex.
+fn hash_file(path: &Path) -> Result<String, ConfigError> {
+    let mut f = File::open(path)
+        .map_err(|e| ConfigError::msg(format!("Failed to open {}: {}", path.display(), e)))?;
+    let mut hasher = Md5::new();
+    std::io::copy(&mut f, &mut hasher)?;
+    Ok(hex::encode(hasher.finalize()))
 }
 
-/// Pure installer: takes resolved source and destination paths, no Tauri
-/// context. Callable from tests with tempdirs.
+/// Walk `root` recursively, returning relative-path → md5-hex map. Paths use
+/// forward slashes for cross-platform manifest stability.
+fn compute_manifest(root: &Path) -> Result<BTreeMap<String, String>, ConfigError> {
+    let mut out = BTreeMap::new();
+    walk(root, root, &mut out)?;
+    Ok(out)
+}
+
+fn walk(
+    root: &Path,
+    dir: &Path,
+    out: &mut BTreeMap<String, String>,
+) -> Result<(), ConfigError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk(root, &path, out)?;
+        } else {
+            // Skip the manifest itself if present in bundle.
+            if path.file_name().map(|n| n == "firmware.md5").unwrap_or(false) {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(root)
+                .map_err(|e| ConfigError::msg(format!("strip_prefix failed: {e}")))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.insert(rel, hash_file(&path)?);
+        }
+    }
+    Ok(())
+}
+
+/// Read device's `firmware.md5`. Accepts md5sum format (`<hex>  <relpath>`)
+/// with optional leading `./` and any whitespace separation. Missing or
+/// unparseable file yields an empty map (forces full install).
+fn read_device_manifest(device_root: &Path) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let path = device_root.join("firmware.md5");
+    let Ok(file) = File::open(&path) else {
+        return out;
+    };
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(2, char::is_whitespace);
+        let Some(hex) = parts.next() else { continue };
+        let Some(rest) = parts.next() else { continue };
+        let rel = rest.trim_start().trim_start_matches("./").to_string();
+        if !hex.is_empty() && !rel.is_empty() {
+            out.insert(rel, hex.to_lowercase());
+        }
+    }
+    out
+}
+
+fn write_device_manifest(
+    device_root: &Path,
+    manifest: &BTreeMap<String, String>,
+) -> Result<(), ConfigError> {
+    let path = device_root.join("firmware.md5");
+    let mut writer = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)?;
+    use std::io::Write as _;
+    for (rel, hex) in manifest {
+        writeln!(writer, "{}  {}", hex, rel)?;
+    }
+    writer.sync_all()?;
+    Ok(())
+}
+
+#[derive(Debug)]
+enum Op {
+    Copy { rel: String, src: PathBuf, dst: PathBuf },
+    Delete { rel: String, dst: PathBuf },
+}
+
+/// Build the ordered op list for the install. Top-level files always copy
+/// (skip decision happens later via manifest compare). Managed subdirs add
+/// per-file copies plus stale-file deletes.
+fn build_plan(
+    firmware_src: &Path,
+    device_path: &Path,
+    device_type: DeviceType,
+    config_preserved: bool,
+) -> Result<Vec<Op>, ConfigError> {
+    let mut ops: Vec<Op> = Vec::new();
+
+    let push_copy = |ops: &mut Vec<Op>, rel: &str| {
+        ops.push(Op::Copy {
+            rel: rel.to_string(),
+            src: firmware_src.join(rel),
+            dst: device_path.join(rel),
+        });
+    };
+
+    push_copy(&mut ops, "boot.py");
+
+    for subdir in MANAGED_DIRS {
+        let bundle_sub = firmware_src.join(subdir);
+        if bundle_sub.exists() {
+            let mut bundle_files = BTreeMap::new();
+            walk(&bundle_sub, &bundle_sub, &mut bundle_files)?;
+            for rel_in_sub in bundle_files.keys() {
+                let rel = format!("{}/{}", subdir, rel_in_sub);
+                push_copy(&mut ops, &rel);
+            }
+        }
+        // Stale-delete: any file under device's subdir that bundle doesn't have.
+        let device_sub = device_path.join(subdir);
+        if device_sub.exists() {
+            let mut device_files = BTreeMap::new();
+            walk(&device_sub, &device_sub, &mut device_files).ok();
+            for rel_in_sub in device_files.keys() {
+                let bundle_file = bundle_sub.join(rel_in_sub);
+                if !bundle_file.exists() {
+                    let rel = format!("{}/{}", subdir, rel_in_sub);
+                    ops.push(Op::Delete {
+                        rel: rel.clone(),
+                        dst: device_path.join(&rel),
+                    });
+                }
+            }
+        }
+    }
+
+    if !config_preserved {
+        let bundled = config_source_name(device_type);
+        ops.push(Op::Copy {
+            rel: "config.json".to_string(),
+            src: firmware_src.join(bundled),
+            dst: device_path.join("config.json"),
+        });
+    }
+
+    for dt in DeviceType::ALL {
+        if *dt == DeviceType::Std10 {
+            continue;
+        }
+        let name = config_source_name(*dt);
+        if firmware_src.join(name).exists() {
+            push_copy(&mut ops, name);
+        }
+    }
+
+    push_copy(&mut ops, "code.py");
+
+    if firmware_src.join("VERSION").exists() {
+        push_copy(&mut ops, "VERSION");
+    }
+
+    Ok(ops)
+}
+
+/// Pure installer. `progress` is invoked for every op (copy/skip/delete) plus
+/// a final `Manifest` and `Done` event.
 pub fn install_firmware_from(
     firmware_src: &Path,
     device_path: &Path,
     reset_config: bool,
+    progress: &mut dyn FnMut(InstallProgress),
 ) -> Result<InstallReport, ConfigError> {
-    // Pre-flight: refuse to start writing if any required source file is missing.
     for required in &["boot.py", "code.py"] {
         let p = firmware_src.join(required);
         if !p.exists() {
@@ -153,86 +314,104 @@ pub fn install_firmware_from(
         )
     })?;
 
-    let mut files_copied = 0usize;
+    progress(InstallProgress {
+        phase: InstallPhase::Planning,
+        current: 0,
+        total: 0,
+        file: "computing manifest".to_string(),
+    });
 
-    copy_file_synced(
-        &firmware_src.join("boot.py"),
-        &device_path.join("boot.py"),
-    )?;
-    files_copied += 1;
-
-    for subdir in &["core", "devices", "fonts", "lib"] {
-        let src_dir = firmware_src.join(subdir);
-        if src_dir.exists() {
-            files_copied += copy_dir_synced(&src_dir, &device_path.join(subdir))?;
-        }
-    }
+    let bundle_manifest = compute_manifest(firmware_src)?;
+    let device_manifest = read_device_manifest(device_path);
 
     let active_config = device_path.join("config.json");
     let config_preserved = active_config.exists() && !reset_config;
-    if !config_preserved {
-        let src_config = firmware_src.join(config_source_name(device_type));
-        copy_file_synced(&src_config, &active_config)?;
-        files_copied += 1;
+
+    let plan = build_plan(firmware_src, device_path, device_type, config_preserved)?;
+    let total = plan.len();
+
+    let mut files_copied = 0usize;
+    let mut files_skipped = 0usize;
+    let mut files_deleted = 0usize;
+
+    for (idx, op) in plan.iter().enumerate() {
+        let current = idx + 1;
+        match op {
+            Op::Copy { rel, src, dst } => {
+                let bundle_hex = bundle_manifest.get(rel);
+                let device_hex = device_manifest.get(rel);
+                let same_hash = matches!((bundle_hex, device_hex), (Some(a), Some(b)) if a == b);
+                if same_hash && dst.exists() {
+                    files_skipped += 1;
+                    progress(InstallProgress {
+                        phase: InstallPhase::Skip,
+                        current,
+                        total,
+                        file: rel.clone(),
+                    });
+                } else {
+                    copy_file_synced(src, dst)?;
+                    files_copied += 1;
+                    progress(InstallProgress {
+                        phase: InstallPhase::Copy,
+                        current,
+                        total,
+                        file: rel.clone(),
+                    });
+                }
+            }
+            Op::Delete { rel, dst } => {
+                if dst.exists() {
+                    fs::remove_file(dst)?;
+                    files_deleted += 1;
+                }
+                progress(InstallProgress {
+                    phase: InstallPhase::Delete,
+                    current,
+                    total,
+                    file: rel.clone(),
+                });
+            }
+        }
     }
 
-    // Reference configs for every non-Std10 device, so users can see the
-    // templates for other devices alongside their active config. Std10 is
-    // skipped because its template filename is `config.json` — the active
-    // slot, not a reference slot. Copying it here would clobber the active
-    // config we just wrote (critical when device_type != Std10).
-    //
-    // For a non-Std10 active device (e.g. Mini6), we *do* re-copy the same
-    // bytes to `config-mini6.json` as a reference. Same content, different
-    // filename; a minor redundant write that matches deploy.sh's behavior.
-    for dt in DeviceType::ALL {
-        if *dt == DeviceType::Std10 {
-            continue;
-        }
-        let name = config_source_name(*dt);
-        let src = firmware_src.join(name);
-        if src.exists() {
-            copy_file_synced(&src, &device_path.join(name))?;
-            files_copied += 1;
-        }
-    }
+    write_device_manifest(device_path, &bundle_manifest)?;
+    progress(InstallProgress {
+        phase: InstallPhase::Manifest,
+        current: total,
+        total,
+        file: "firmware.md5".to_string(),
+    });
 
-    // code.py LAST — everything else is in place before the device reloads.
-    copy_file_synced(
-        &firmware_src.join("code.py"),
-        &device_path.join("code.py"),
-    )?;
-    files_copied += 1;
+    let version = fs::read_to_string(firmware_src.join("VERSION"))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|_| "dev".to_string());
 
-    let version_src = firmware_src.join("VERSION");
-    let version = match fs::read_to_string(&version_src) {
-        Ok(contents) => {
-            copy_file_synced(&version_src, &device_path.join("VERSION"))?;
-            files_copied += 1;
-            contents.trim().to_string()
-        }
-        Err(_) => "dev".to_string(),
-    };
+    progress(InstallProgress {
+        phase: InstallPhase::Done,
+        current: total,
+        total,
+        file: String::new(),
+    });
 
     Ok(InstallReport {
         device_type,
         files_copied,
+        files_skipped,
+        files_deleted,
         version,
         config_preserved,
     })
 }
 
 /// Tauri command: install bundled firmware onto the connected device.
-///
-/// A process-wide `try_lock` guards against the double-click / re-entrant
-/// case. A second invocation while one is in flight returns an error rather
-/// than blocking — the UI should disable the button during install, and the
-/// lock is a belt-and-braces backstop.
+/// `on_progress` receives streaming `InstallProgress` events.
 #[command]
 pub fn install_firmware(
     app: AppHandle,
     device_path: String,
     reset_config: bool,
+    on_progress: Channel<InstallProgress>,
 ) -> Result<InstallReport, ConfigError> {
     let _guard = INSTALL_LOCK.try_lock().map_err(|_| {
         ConfigError::msg("A firmware install is already in progress on this app instance.")
@@ -241,7 +420,10 @@ pub fn install_firmware(
     let device = PathBuf::from(&device_path);
     verify_device_connected(&device)?;
     let firmware_src = bundled_firmware_dir(&app)?;
-    install_firmware_from(&firmware_src, &device, reset_config)
+    let mut emit = |p: InstallProgress| {
+        let _ = on_progress.send(p);
+    };
+    install_firmware_from(&firmware_src, &device, reset_config, &mut emit)
 }
 
 #[cfg(test)]
@@ -282,6 +464,11 @@ mod tests {
         .unwrap();
     }
 
+    fn install(bundle: &Path, device: &Path, reset: bool) -> InstallReport {
+        let mut sink = |_p: InstallProgress| {};
+        install_firmware_from(bundle, device, reset, &mut sink).unwrap()
+    }
+
     #[test]
     fn device_type_detected_from_device_config() {
         let bundle = TempDir::new().unwrap();
@@ -289,7 +476,7 @@ mod tests {
         make_bundle(bundle.path());
         seed_device(device.path(), "mini6");
 
-        let report = install_firmware_from(bundle.path(), device.path(), false).unwrap();
+        let report = install(bundle.path(), device.path(), false);
         assert_eq!(report.device_type, DeviceType::Mini6);
     }
 
@@ -300,7 +487,7 @@ mod tests {
         make_bundle(bundle.path());
         seed_device(device.path(), "std10");
 
-        let report = install_firmware_from(bundle.path(), device.path(), false).unwrap();
+        let report = install(bundle.path(), device.path(), false);
 
         assert!(report.config_preserved);
         let cfg = fs::read_to_string(device.path().join("config.json")).unwrap();
@@ -314,7 +501,7 @@ mod tests {
         make_bundle(bundle.path());
         seed_device(device.path(), "std10");
 
-        let report = install_firmware_from(bundle.path(), device.path(), true).unwrap();
+        let report = install(bundle.path(), device.path(), true);
 
         assert!(!report.config_preserved);
         let cfg = fs::read_to_string(device.path().join("config.json")).unwrap();
@@ -329,13 +516,12 @@ mod tests {
         make_bundle(bundle.path());
         seed_device(device.path(), "mini6");
 
-        let report = install_firmware_from(bundle.path(), device.path(), true).unwrap();
+        let report = install(bundle.path(), device.path(), true);
 
         assert_eq!(report.device_type, DeviceType::Mini6);
         let installed = fs::read_to_string(device.path().join("config.json")).unwrap();
-        // The mini6 bundled config has `"from":"bundle"`; the seeded user config did not.
         assert!(installed.contains(r#""device":"mini6""#));
-        assert!(installed.contains(r#""from":"bundle""#), "should be the bundled mini6 template, not the user seed");
+        assert!(installed.contains(r#""from":"bundle""#));
         assert!(!installed.contains("user-edit"));
     }
 
@@ -346,12 +532,11 @@ mod tests {
         make_bundle(bundle.path());
         seed_device(device.path(), "std10");
 
-        install_firmware_from(bundle.path(), device.path(), false).unwrap();
+        install(bundle.path(), device.path(), false);
 
-        // Every non-active device's template should land on the device as a reference.
         for dt in DeviceType::ALL {
             if *dt == DeviceType::Std10 {
-                continue; // active device in this test
+                continue;
             }
             let name = config_source_name(*dt);
             assert!(device.path().join(name).exists(), "reference config {} missing", name);
@@ -360,21 +545,16 @@ mod tests {
 
     #[test]
     fn std10_template_never_clobbers_non_std10_active_config() {
-        // Regression guard: Std10's template filename is `config.json`, the
-        // same filename as the active-config slot. If the reference-config
-        // loop copied Std10's template, it would overwrite the Mini6 active
-        // config we just wrote. Symptom if the skip breaks: device's
-        // config.json ends up with `"device":"std10"` on a Mini6 device.
         let bundle = TempDir::new().unwrap();
         let device = TempDir::new().unwrap();
         make_bundle(bundle.path());
         seed_device(device.path(), "mini6");
 
-        install_firmware_from(bundle.path(), device.path(), true).unwrap();
+        install(bundle.path(), device.path(), true);
 
         let active = fs::read_to_string(device.path().join("config.json")).unwrap();
-        assert!(active.contains(r#""device":"mini6""#), "active config must remain the Mini6 template, got: {}", active);
-        assert!(!active.contains(r#""device":"std10""#), "Std10 template must not clobber the active slot");
+        assert!(active.contains(r#""device":"mini6""#), "got: {}", active);
+        assert!(!active.contains(r#""device":"std10""#));
     }
 
     #[test]
@@ -387,10 +567,11 @@ mod tests {
         fs::create_dir(device.path().join("core")).unwrap();
         fs::write(device.path().join("core/stale.mpy"), b"old").unwrap();
 
-        install_firmware_from(bundle.path(), device.path(), false).unwrap();
+        let report = install(bundle.path(), device.path(), false);
 
-        assert!(!device.path().join("core/stale.mpy").exists(), "stale file must be removed");
-        assert!(device.path().join("core/config.py").exists(), "new file must be present");
+        assert!(!device.path().join("core/stale.mpy").exists());
+        assert!(device.path().join("core/config.py").exists());
+        assert!(report.files_deleted >= 1);
     }
 
     #[test]
@@ -401,9 +582,9 @@ mod tests {
         seed_device(device.path(), "std10");
         fs::remove_file(bundle.path().join("boot.py")).unwrap();
 
-        let err = install_firmware_from(bundle.path(), device.path(), false).unwrap_err();
-        assert!(err.message.contains("boot.py"), "error should mention the missing file, got: {}", err.message);
-        // No writes should have happened.
+        let mut sink = |_p: InstallProgress| {};
+        let err = install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
+        assert!(err.message.contains("boot.py"), "got: {}", err.message);
         assert!(!device.path().join("code.py").exists());
     }
 
@@ -414,22 +595,20 @@ mod tests {
         make_bundle(bundle.path());
         fs::write(device.path().join("config.json"), br#"{"device":"unknown"}"#).unwrap();
 
-        let err = install_firmware_from(bundle.path(), device.path(), false).unwrap_err();
+        let mut sink = |_p: InstallProgress| {};
+        let err = install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
         assert!(err.message.to_lowercase().contains("device type"));
         assert!(!device.path().join("boot.py").exists());
     }
 
     #[test]
     fn code_py_mtime_at_or_after_boot_py() {
-        // Weak but real: if `code.py` were written before `boot.py`, a mid-install
-        // crash could leave a device that boots into incomplete firmware. Mtime
-        // comparison is coarse (filesystem resolution) but catches gross order swaps.
         let bundle = TempDir::new().unwrap();
         let device = TempDir::new().unwrap();
         make_bundle(bundle.path());
         seed_device(device.path(), "std10");
 
-        install_firmware_from(bundle.path(), device.path(), false).unwrap();
+        install(bundle.path(), device.path(), false);
 
         let boot_mtime = fs::metadata(device.path().join("boot.py"))
             .unwrap()
@@ -440,5 +619,140 @@ mod tests {
             .modified()
             .unwrap();
         assert!(code_mtime >= boot_mtime);
+    }
+
+    // ---- Phase 2b additions ----
+
+    #[test]
+    fn manifest_written_after_install() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        install(bundle.path(), device.path(), false);
+
+        let manifest_path = device.path().join("firmware.md5");
+        assert!(manifest_path.exists(), "firmware.md5 must be written");
+        let contents = fs::read_to_string(&manifest_path).unwrap();
+        assert!(contents.contains("boot.py"));
+        assert!(contents.contains("code.py"));
+        assert!(contents.contains("core/config.py"));
+        // Two-space md5sum format
+        for line in contents.lines() {
+            assert!(line.contains("  "), "line should be md5sum-format: {}", line);
+        }
+    }
+
+    #[test]
+    fn incremental_skips_unchanged_files() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        // First install populates manifest.
+        let r1 = install(bundle.path(), device.path(), false);
+        assert!(r1.files_copied > 0);
+        assert_eq!(r1.files_skipped, 0);
+
+        // Second install: nothing changed in bundle → all files skip.
+        let r2 = install(bundle.path(), device.path(), false);
+        assert!(r2.files_skipped > 0, "expected skips, got {:?}", r2);
+        // boot.py/code.py/configs/version + core/devices/fonts/lib all skip.
+        assert_eq!(r2.files_copied, 0, "no copies expected on no-op reinstall");
+    }
+
+    #[test]
+    fn incremental_copies_changed_files_only() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        install(bundle.path(), device.path(), false);
+
+        // Mutate one bundle file.
+        fs::write(bundle.path().join("core/button.py"), b"# updated").unwrap();
+
+        let r2 = install(bundle.path(), device.path(), false);
+        assert_eq!(r2.files_copied, 1, "only changed file should copy, got {:?}", r2);
+        assert!(r2.files_skipped > 0);
+
+        let installed = fs::read(device.path().join("core/button.py")).unwrap();
+        assert_eq!(installed, b"# updated");
+    }
+
+    #[test]
+    fn progress_events_fire_in_order() {
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        let mut events: Vec<InstallProgress> = Vec::new();
+        {
+            let mut sink = |p: InstallProgress| events.push(p);
+            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap();
+        }
+
+        assert!(matches!(events.first().unwrap().phase, InstallPhase::Planning));
+        assert!(matches!(events.last().unwrap().phase, InstallPhase::Done));
+
+        let manifest_seen = events
+            .iter()
+            .any(|p| matches!(p.phase, InstallPhase::Manifest));
+        assert!(manifest_seen, "manifest event must fire");
+
+        // current monotonic among in-plan ops.
+        let in_plan: Vec<_> = events
+            .iter()
+            .filter(|p| matches!(
+                p.phase,
+                InstallPhase::Copy | InstallPhase::Skip | InstallPhase::Delete
+            ))
+            .collect();
+        for w in in_plan.windows(2) {
+            assert!(w[1].current >= w[0].current, "current must be monotonic");
+        }
+        // All in-plan ops share the same total.
+        if let Some(first) = in_plan.first() {
+            for p in &in_plan {
+                assert_eq!(p.total, first.total);
+            }
+        }
+    }
+
+    #[test]
+    fn manifest_roundtrip_skips_after_external_rewrite() {
+        // Hand-craft a manifest and verify reads parse it.
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "std10");
+
+        // Compute bundle manifest, write it to device pre-install, also copy
+        // every bundle file onto the device with matching bytes. Now first
+        // install should be a full no-op-skip.
+        let bm = compute_manifest(bundle.path()).unwrap();
+        for rel in bm.keys() {
+            let src = bundle.path().join(rel);
+            let dst = device.path().join(rel);
+            if let Some(parent) = dst.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::copy(&src, &dst).unwrap();
+        }
+        // Overwrite device config.json with the seeded user edit again, but
+        // its hash now differs from the bundle template — so the active
+        // config copy step is gated by `config_preserved`, not the manifest.
+        seed_device(device.path(), "std10");
+        write_device_manifest(device.path(), &bm).unwrap();
+
+        let r = install(bundle.path(), device.path(), false);
+        // config.json is preserved (config_preserved=true), so it isn't in the plan.
+        // Every other file matches → all skips.
+        assert_eq!(r.files_copied, 0);
+        assert!(r.files_skipped > 0);
     }
 }

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -17,11 +17,18 @@ use crate::config::DeviceType;
 use serde::Serialize;
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use tauri::{command, AppHandle, Manager};
 
 /// Bundled filename of the default config template for this device type.
 /// Kept here rather than on `DeviceType` itself so the config crate stays
 /// unaware of firmware-installer filesystem conventions.
+///
+/// Note: `Std10` returns `"config.json"` — that filename serves double duty
+/// as both the Std10 template in the bundle *and* the active-config slot on
+/// every device. The reference-config loop below skips the active device's
+/// template to avoid a double-write that would otherwise be a no-op for
+/// Std10 but still a wasted sync on other devices.
 fn config_source_name(dt: DeviceType) -> &'static str {
     match dt {
         DeviceType::Std10 => "config.json",
@@ -31,6 +38,11 @@ fn config_source_name(dt: DeviceType) -> &'static str {
         DeviceType::One1 => "config-one1.json",
     }
 }
+
+/// Single-install lock: prevents a concurrent `install_firmware` invocation
+/// (e.g. double-click, or two tabs of the same app) from interleaving writes
+/// to the same device.
+static INSTALL_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Serialize)]
 pub struct InstallReport {
@@ -164,15 +176,20 @@ pub fn install_firmware_from(
         files_copied += 1;
     }
 
-    // Reference configs for every supported device, except the active one
-    // (already copied above when not preserving).
+    // Reference configs for every non-Std10 device, so users can see the
+    // templates for other devices alongside their active config. Std10 is
+    // skipped because its template filename is `config.json` — the active
+    // slot, not a reference slot. Copying it here would clobber the active
+    // config we just wrote (critical when device_type != Std10).
+    //
+    // For a non-Std10 active device (e.g. Mini6), we *do* re-copy the same
+    // bytes to `config-mini6.json` as a reference. Same content, different
+    // filename; a minor redundant write that matches deploy.sh's behavior.
     for dt in DeviceType::ALL {
-        let name = config_source_name(*dt);
-        // Skip std10's "config.json" — that's the active-config slot, not a
-        // reference slot.
         if *dt == DeviceType::Std10 {
             continue;
         }
+        let name = config_source_name(*dt);
         let src = firmware_src.join(name);
         if src.exists() {
             copy_file_synced(&src, &device_path.join(name))?;
@@ -206,12 +223,20 @@ pub fn install_firmware_from(
 }
 
 /// Tauri command: install bundled firmware onto the connected device.
+///
+/// A process-wide `try_lock` guards against the double-click / re-entrant
+/// case. A second invocation while one is in flight returns an error rather
+/// than blocking — the UI should disable the button during install, and the
+/// lock is a belt-and-braces backstop.
 #[command]
 pub fn install_firmware(
     app: AppHandle,
     device_path: String,
     reset_config: bool,
 ) -> Result<InstallReport, ConfigError> {
+    let _guard = INSTALL_LOCK.try_lock().map_err(|_| {
+        ConfigError::msg("A firmware install is already in progress on this app instance.")
+    })?;
     validate_device_path(&device_path)?;
     let device = PathBuf::from(&device_path);
     verify_device_connected(&device)?;
@@ -323,14 +348,33 @@ mod tests {
 
         install_firmware_from(bundle.path(), device.path(), false).unwrap();
 
-        // Every non-std10 device's template should land on the device as a reference.
+        // Every non-active device's template should land on the device as a reference.
         for dt in DeviceType::ALL {
             if *dt == DeviceType::Std10 {
-                continue;
+                continue; // active device in this test
             }
             let name = config_source_name(*dt);
             assert!(device.path().join(name).exists(), "reference config {} missing", name);
         }
+    }
+
+    #[test]
+    fn std10_template_never_clobbers_non_std10_active_config() {
+        // Regression guard: Std10's template filename is `config.json`, the
+        // same filename as the active-config slot. If the reference-config
+        // loop copied Std10's template, it would overwrite the Mini6 active
+        // config we just wrote. Symptom if the skip breaks: device's
+        // config.json ends up with `"device":"std10"` on a Mini6 device.
+        let bundle = TempDir::new().unwrap();
+        let device = TempDir::new().unwrap();
+        make_bundle(bundle.path());
+        seed_device(device.path(), "mini6");
+
+        install_firmware_from(bundle.path(), device.path(), true).unwrap();
+
+        let active = fs::read_to_string(device.path().join("config.json")).unwrap();
+        assert!(active.contains(r#""device":"mini6""#), "active config must remain the Mini6 template, got: {}", active);
+        assert!(!active.contains(r#""device":"std10""#), "Std10 template must not clobber the active slot");
     }
 
     #[test]

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -423,24 +423,34 @@ pub fn install_firmware_from(
 
 /// Tauri command: install bundled firmware onto the connected device.
 /// `on_progress` receives streaming `InstallProgress` events.
+///
+/// `async` + `spawn_blocking` offloads the per-file `sync_all()` storm to a
+/// blocking-pool thread. A sync `#[command]` would peg Tauri's IPC thread for
+/// the duration of the install (visible as a beach ball / unresponsive UI),
+/// and would also stall the Channel that feeds progress events back to JS.
 #[command]
-pub fn install_firmware(
+pub async fn install_firmware(
     app: AppHandle,
     device_path: String,
     reset_config: bool,
     on_progress: Channel<InstallProgress>,
 ) -> Result<InstallReport, ConfigError> {
-    let _guard = INSTALL_LOCK.try_lock().map_err(|_| {
-        ConfigError::msg("A firmware install is already in progress on this app instance.")
-    })?;
     validate_device_path(&device_path)?;
     let device = PathBuf::from(&device_path);
     verify_device_connected(&device)?;
     let firmware_src = bundled_firmware_dir(&app)?;
-    let mut emit = |p: InstallProgress| {
-        let _ = on_progress.send(p);
-    };
-    install_firmware_from(&firmware_src, &device, reset_config, &mut emit)
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let _guard = INSTALL_LOCK.try_lock().map_err(|_| {
+            ConfigError::msg("A firmware install is already in progress on this app instance.")
+        })?;
+        let mut emit = |p: InstallProgress| {
+            let _ = on_progress.send(p);
+        };
+        install_firmware_from(&firmware_src, &device, reset_config, &mut emit)
+    })
+    .await
+    .map_err(|e| ConfigError::msg(format!("Install task panicked: {e}")))?
 }
 
 #[cfg(test)]

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -172,20 +172,46 @@ fn read_device_manifest(device_root: &Path) -> BTreeMap<String, String> {
     let mut out = BTreeMap::new();
     let path = device_root.join("firmware.md5");
     let Ok(file) = File::open(&path) else {
+        // Missing manifest is the expected "first-time install" path. Log a
+        // single line so a user complaining "why does my reinstall copy
+        // everything?" can spot it in stderr.
+        eprintln!(
+            "installer: no firmware.md5 at {} — full install (no incremental skips)",
+            path.display()
+        );
         return out;
     };
+    let mut parsed = 0usize;
+    let mut skipped = 0usize;
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         let line = line.trim();
         if line.is_empty() {
             continue;
         }
         let mut parts = line.splitn(2, char::is_whitespace);
-        let Some(hex) = parts.next() else { continue };
-        let Some(rest) = parts.next() else { continue };
+        let Some(hex) = parts.next() else {
+            skipped += 1;
+            continue;
+        };
+        let Some(rest) = parts.next() else {
+            skipped += 1;
+            continue;
+        };
         let rel = rest.trim_start().trim_start_matches("./").to_string();
         if !hex.is_empty() && !rel.is_empty() {
             out.insert(rel, hex.to_lowercase());
+            parsed += 1;
+        } else {
+            skipped += 1;
         }
+    }
+    if skipped > 0 {
+        eprintln!(
+            "installer: device manifest at {} parsed {} entries, skipped {} malformed lines",
+            path.display(),
+            parsed,
+            skipped
+        );
     }
     out
 }
@@ -202,7 +228,10 @@ fn write_device_manifest(
     // here, but on a CircuitPython USB MSC volume that fsync can hang the
     // whole install for tens of seconds while the device's serial REPL is
     // active — visible in the GUI as "Writing manifest" never completing.
-    let mut payload = String::with_capacity(manifest.len() * 64);
+    // 80 chars/entry: md5 hex (32) + two-space separator + path (~46). Tight
+    // paths re-allocate; long ones cap at one realloc. Avoids the
+    // `len * 64` underestimate that triggers a reallocation on every install.
+    let mut payload = String::with_capacity(manifest.len() * 80);
     for (rel, hex) in manifest {
         payload.push_str(hex);
         payload.push_str("  ");

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -544,7 +544,18 @@ pub async fn install_firmware(
             ConfigError::msg("A firmware install is already in progress on this app instance.")
         })?;
 
-        halt_and_disable_autoreload(&device)?;
+        // Best-effort: bundled `boot.py` already calls
+        // `supervisor.disable_autoreload()` on flashed devices, so the
+        // pre-flight is redundant in steady state. Hard-failing here would
+        // also abort the install whenever another process holds the serial
+        // port (tio, screen, devtools serial console), which is too brittle.
+        // The downside on a fresh install with autoreload still on: CP may
+        // soft-reboot mid-write — but `boot.py` is the FIRST file we copy,
+        // so the autoreload-off setting takes effect before the bulk of
+        // writes. Worst case is a partial install on the very first flash;
+        // the manifest-based incremental retry on the next install fills
+        // any gaps.
+        let _ = halt_and_disable_autoreload(&device);
 
         let mut emit = |p: InstallProgress| {
             let _ = on_progress.send(p);

--- a/config-editor/src-tauri/src/lib.rs
+++ b/config-editor/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod installer;
 
 use commands::{eject_device, read_config, read_config_raw, restart_device, validate_config, write_config, write_config_raw};
 use device::{scan_devices, start_device_watcher, stop_device_watcher};
-use installer::install_firmware;
+use installer::{get_firmware_versions, install_firmware};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -24,7 +24,8 @@ pub fn run() {
             scan_devices,
             start_device_watcher,
             stop_device_watcher,
-            install_firmware
+            install_firmware,
+            get_firmware_versions
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/config-editor/src-tauri/src/lib.rs
+++ b/config-editor/src-tauri/src/lib.rs
@@ -1,9 +1,11 @@
 mod commands;
 mod config;
 mod device;
+mod installer;
 
 use commands::{eject_device, read_config, read_config_raw, restart_device, validate_config, write_config, write_config_raw};
 use device::{scan_devices, start_device_watcher, stop_device_watcher};
+use installer::install_firmware;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -21,7 +23,8 @@ pub fn run() {
             eject_device,
             scan_devices,
             start_device_watcher,
-            stop_device_watcher
+            stop_device_watcher,
+            install_firmware
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/config-editor/src/lib/api.ts
+++ b/config-editor/src/lib/api.ts
@@ -5,6 +5,7 @@ import { listen } from '@tauri-apps/api/event';
 import type {
   MidiCaptainConfig,
   DetectedDevice,
+  FirmwareVersions,
   InstallProgress,
   InstallReport,
 } from './types';
@@ -48,6 +49,10 @@ export async function startDeviceWatcher(): Promise<void> {
 }
 
 // Firmware installer
+export async function getFirmwareVersions(devicePath: string): Promise<FirmwareVersions> {
+  return invoke('get_firmware_versions', { devicePath });
+}
+
 export async function installFirmware(
   devicePath: string,
   resetConfig: boolean,

--- a/config-editor/src/lib/api.ts
+++ b/config-editor/src/lib/api.ts
@@ -1,8 +1,13 @@
 // Tauri command wrappers
 
-import { invoke } from '@tauri-apps/api/core';
+import { invoke, Channel } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import type { MidiCaptainConfig, DetectedDevice } from './types';
+import type {
+  MidiCaptainConfig,
+  DetectedDevice,
+  InstallProgress,
+  InstallReport,
+} from './types';
 
 // Config operations
 export async function readConfig(path: string): Promise<MidiCaptainConfig> {
@@ -40,6 +45,21 @@ export async function scanDevices(): Promise<DetectedDevice[]> {
 
 export async function startDeviceWatcher(): Promise<void> {
   return invoke('start_device_watcher');
+}
+
+// Firmware installer
+export async function installFirmware(
+  devicePath: string,
+  resetConfig: boolean,
+  onProgress: (p: InstallProgress) => void,
+): Promise<InstallReport> {
+  const channel = new Channel<InstallProgress>();
+  channel.onmessage = onProgress;
+  return invoke('install_firmware', {
+    devicePath,
+    resetConfig,
+    onProgress: channel,
+  });
 }
 
 // Event listeners

--- a/config-editor/src/lib/components/FirmwareInstaller.svelte
+++ b/config-editor/src/lib/components/FirmwareInstaller.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { ask, message } from '@tauri-apps/plugin-dialog';
-  import { installFirmware } from '$lib/api';
-  import type { DetectedDevice, InstallProgress, InstallReport } from '$lib/types';
+  import { getFirmwareVersions, installFirmware } from '$lib/api';
+  import type {
+    DetectedDevice,
+    FirmwareVersions,
+    InstallProgress,
+    InstallReport,
+  } from '$lib/types';
 
   interface Props {
     device: DetectedDevice | null;
@@ -16,6 +21,32 @@
   let progress = $state<InstallProgress | null>(null);
   let report = $state<InstallReport | null>(null);
   let errorMsg = $state('');
+  let versions = $state<FirmwareVersions | null>(null);
+
+  // Re-fetch versions whenever the selected device changes or after a fresh
+  // install so the UI reflects what's actually on disk now.
+  async function refreshVersions(d: DetectedDevice | null) {
+    if (!d) {
+      versions = null;
+      return;
+    }
+    try {
+      versions = await getFirmwareVersions(d.path);
+    } catch {
+      versions = null;
+    }
+  }
+
+  $effect(() => {
+    refreshVersions(device);
+  });
+
+  let isUpgrade = $derived(
+    versions !== null && versions.device !== null && versions.device !== versions.bundled,
+  );
+  let isUpToDate = $derived(
+    versions !== null && versions.device === versions.bundled,
+  );
 
   let percent = $derived(
     progress && progress.total > 0
@@ -52,6 +83,7 @@
         progress = p;
       });
       onInstalled?.();
+      await refreshVersions(device);
     } catch (e: any) {
       errorMsg = e?.message ?? String(e);
       await message(`Firmware install failed:\n\n${errorMsg}`, { title: 'Install Failed', kind: 'error' });
@@ -75,6 +107,30 @@
 
 <section class="installer">
   <h3>Firmware Installation</h3>
+
+  {#if versions}
+    <div class="versions">
+      <div class="version-row">
+        <span class="version-label">Installed:</span>
+        {#if versions.device === null}
+          <span class="version-value oem">OEM (no VERSION file)</span>
+        {:else}
+          <span class="version-value">{versions.device}</span>
+        {/if}
+      </div>
+      <div class="version-row">
+        <span class="version-label">Available:</span>
+        <span class="version-value">{versions.bundled}</span>
+        {#if isUpToDate}
+          <span class="badge up-to-date">up to date</span>
+        {:else if isUpgrade}
+          <span class="badge upgrade">upgrade</span>
+        {:else if versions.device === null}
+          <span class="badge first-install">first install</span>
+        {/if}
+      </div>
+    </div>
+  {/if}
 
   <label class="reset-toggle">
     <input type="checkbox" bind:checked={resetConfig} disabled={installing} />
@@ -126,6 +182,60 @@
     background: var(--bg-secondary);
     border: 1px solid var(--border-color);
     border-radius: 4px;
+  }
+
+  .versions {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 13px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .version-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+
+  .version-label {
+    color: var(--text-secondary);
+    min-width: 80px;
+  }
+
+  .version-value {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--text-primary);
+  }
+
+  .version-value.oem {
+    font-style: italic;
+    color: var(--text-secondary);
+    font-family: inherit;
+  }
+
+  .badge {
+    font-size: 11px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .badge.up-to-date {
+    background: rgba(74, 124, 78, 0.2);
+    color: var(--success);
+  }
+
+  .badge.upgrade {
+    background: rgba(240, 173, 78, 0.2);
+    color: var(--warning);
+  }
+
+  .badge.first-install {
+    background: rgba(0, 120, 212, 0.2);
+    color: var(--accent);
   }
 
   h3 {

--- a/config-editor/src/lib/components/FirmwareInstaller.svelte
+++ b/config-editor/src/lib/components/FirmwareInstaller.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { ask, message } from '@tauri-apps/plugin-dialog';
+  import { installFirmware } from '$lib/api';
+  import type { DetectedDevice, InstallProgress, InstallReport } from '$lib/types';
+
+  interface Props {
+    device: DetectedDevice | null;
+    hasUnsavedChanges: boolean;
+    onInstalled?: () => void;
+  }
+
+  let { device, hasUnsavedChanges, onInstalled }: Props = $props();
+
+  let resetConfig = $state(false);
+  let installing = $state(false);
+  let progress = $state<InstallProgress | null>(null);
+  let report = $state<InstallReport | null>(null);
+  let errorMsg = $state('');
+
+  let percent = $derived(
+    progress && progress.total > 0
+      ? Math.round((progress.current / progress.total) * 100)
+      : 0,
+  );
+
+  async function startInstall() {
+    if (!device) return;
+
+    if (hasUnsavedChanges) {
+      const proceed = await ask(
+        'You have unsaved config changes. Install firmware anyway? Unsaved edits to config.json will be discarded.',
+        { title: 'Unsaved Changes', kind: 'warning', okLabel: 'Install', cancelLabel: 'Cancel' },
+      );
+      if (!proceed) return;
+    }
+
+    if (resetConfig) {
+      const proceed = await ask(
+        'Reset config will overwrite the device\'s config.json with the bundled template. Your customizations will be lost. Continue?',
+        { title: 'Reset Config', kind: 'warning', okLabel: 'Reset and Install', cancelLabel: 'Cancel' },
+      );
+      if (!proceed) return;
+    }
+
+    installing = true;
+    progress = null;
+    report = null;
+    errorMsg = '';
+
+    try {
+      report = await installFirmware(device.path, resetConfig, (p) => {
+        progress = p;
+      });
+      onInstalled?.();
+    } catch (e: any) {
+      errorMsg = e?.message ?? String(e);
+      await message(`Firmware install failed:\n\n${errorMsg}`, { title: 'Install Failed', kind: 'error' });
+    } finally {
+      installing = false;
+    }
+  }
+
+  function phaseLabel(phase: string): string {
+    switch (phase) {
+      case 'planning': return 'Preparing';
+      case 'copy': return 'Copying';
+      case 'skip': return 'Skipping';
+      case 'delete': return 'Removing';
+      case 'manifest': return 'Writing manifest';
+      case 'done': return 'Done';
+      default: return phase;
+    }
+  }
+</script>
+
+<section class="installer">
+  <h3>Firmware Installation</h3>
+
+  <label class="reset-toggle">
+    <input type="checkbox" bind:checked={resetConfig} disabled={installing} />
+    Reset config.json to bundled defaults
+  </label>
+
+  <button onclick={startInstall} disabled={!device || installing}>
+    {installing ? 'Installing...' : 'Install Firmware'}
+  </button>
+
+  {#if installing && progress}
+    <div class="progress">
+      <progress value={percent} max="100"></progress>
+      <div class="progress-label">
+        <span class="phase">{phaseLabel(progress.phase)}</span>
+        <span class="counts">{progress.current} / {progress.total}</span>
+      </div>
+      {#if progress.file}
+        <div class="file" title={progress.file}>{progress.file}</div>
+      {/if}
+    </div>
+  {/if}
+
+  {#if report && !installing}
+    <div class="result success">
+      <strong>Installed firmware {report.version}</strong>
+      <ul>
+        <li>Copied: {report.files_copied}</li>
+        <li>Skipped (unchanged): {report.files_skipped}</li>
+        <li>Removed (stale): {report.files_deleted}</li>
+        <li>Config: {report.config_preserved ? 'preserved' : 'reset'}</li>
+      </ul>
+    </div>
+  {/if}
+
+  {#if errorMsg}
+    <div class="result error">
+      <strong>Error:</strong> {errorMsg}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .installer {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .reset-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text-primary);
+  }
+
+  button {
+    align-self: flex-start;
+    padding: 8px 16px;
+    font-size: 14px;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  button:disabled {
+    background: var(--disabled-bg);
+    cursor: not-allowed;
+  }
+
+  button:hover:not(:disabled) {
+    background: var(--accent-hover);
+  }
+
+  .progress {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  progress {
+    width: 100%;
+    height: 8px;
+  }
+
+  .progress-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .phase {
+    text-transform: capitalize;
+  }
+
+  .file {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .result {
+    padding: 10px 12px;
+    border-radius: 4px;
+    font-size: 13px;
+  }
+
+  .result.success {
+    background: rgba(74, 124, 78, 0.15);
+    border: 1px solid var(--success);
+    color: var(--text-primary);
+  }
+
+  .result.error {
+    background: var(--error-bg);
+    border: 1px solid var(--error-border);
+    color: var(--error-text);
+  }
+
+  .result ul {
+    margin: 6px 0 0 0;
+    padding-left: 20px;
+  }
+</style>

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -46,6 +46,13 @@ export interface InstallProgress {
   file: string;
 }
 
+export interface FirmwareVersions {
+  /** Version on the device, or `null` for an OEM / unmanaged install. */
+  device: string | null;
+  /** Bundled firmware version this app would install. */
+  bundled: string;
+}
+
 export interface InstallReport {
   device_type: DeviceType;
   files_copied: number;

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -37,6 +37,24 @@ export interface ConfigError {
   details?: string[];
 }
 
+export type InstallPhase = 'planning' | 'copy' | 'skip' | 'delete' | 'manifest' | 'done';
+
+export interface InstallProgress {
+  phase: InstallPhase;
+  current: number;
+  total: number;
+  file: string;
+}
+
+export interface InstallReport {
+  device_type: DeviceType;
+  files_copied: number;
+  files_skipped: number;
+  files_deleted: number;
+  version: string;
+  config_preserved: boolean;
+}
+
 // Color mapping for UI
 export const BUTTON_COLORS: Record<ButtonColor, string> = {
   red: '#ff0000',

--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -18,6 +18,7 @@
   import EncoderSection from '$lib/components/EncoderSection.svelte';
   import ExpressionSection from '$lib/components/ExpressionSection.svelte';
   import DisplaySection from '$lib/components/DisplaySection.svelte';
+  import FirmwareInstaller from '$lib/components/FirmwareInstaller.svelte';
   import { loadConfig, validate, normalizeConfig, config } from '$lib/formStore';
 
   let appVersion = $state('');
@@ -334,6 +335,11 @@
         <EncoderSection />
         <ExpressionSection />
         <DisplaySection />
+        <FirmwareInstaller
+          device={$selectedDevice}
+          hasUnsavedChanges={$hasUnsavedChanges}
+          onInstalled={reloadFromDevice}
+        />
       </ConfigForm>
     {:else if $isLoading}
       <div class="loading">Loading config...</div>

--- a/tools/deploy.ps1
+++ b/tools/deploy.ps1
@@ -175,20 +175,20 @@ if ($Install) {
 
     # Install each library
     # --path: target the device mount point
-    # --allow-unsupported: we target CP 7.x which circup considers EOL
+    # --allow-unsupported: we target CP 7.x which circup considers EOL.
+    #
+    # We deliberately do NOT pass `--py`. Mixing circup's `.py` source with
+    # the bundle's `.mpy` puts both forms in /lib for the same module, which
+    # is fragile: any disturbance to mtime / directory entry order can flip
+    # which form CircuitPython loads, and the `.py` form often pulls in
+    # newer-CP-only modules (e.g. `busdisplay`) that crash on CP 7.
     foreach ($lib in $RequiredLibs) {
         Write-Host "  Installing $lib... " -NoNewline
-        $result = & circup --path $MountPoint --allow-unsupported install $lib --py 2>&1
+        $result = & circup --path $MountPoint --allow-unsupported install $lib 2>&1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "done" -ForegroundColor Green
         } else {
-            # Try without --py flag for compiled libs
-            $result = & circup --path $MountPoint --allow-unsupported install $lib 2>&1
-            if ($LASTEXITCODE -eq 0) {
-                Write-Host "done" -ForegroundColor Green
-            } else {
-                Write-Host "(already installed)" -ForegroundColor Yellow
-            }
+            Write-Host "(already installed)" -ForegroundColor Yellow
         }
     }
     Write-Host "Libraries installed" -ForegroundColor Green

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -242,19 +242,20 @@ if [ "$DO_INSTALL" = true ]; then
     echo -e "${GREEN}✓ circup available${NC}"
 
     # Install each library (--path must come before the subcommand)
-    # --allow-unsupported: we target CP 7.x which circup considers EOL
+    # --allow-unsupported: we target CP 7.x which circup considers EOL.
+    #
+    # We deliberately do NOT pass `--py`. Mixing circup's `.py` source with
+    # the bundle's `.mpy` puts both forms in /lib for the same module, which
+    # is fragile: any disturbance to mtime / directory entry order can flip
+    # which form CircuitPython loads, and the `.py` form often pulls in
+    # newer-CP-only modules (e.g. `busdisplay`) that crash on CP 7.
     CIRCUP="circup --path $MOUNT_POINT --allow-unsupported"
     for lib in "${REQUIRED_LIBS[@]}"; do
         echo -n "  Installing $lib... "
-        if $CIRCUP install "$lib" --py 2>/dev/null; then
+        if $CIRCUP install "$lib" 2>/dev/null; then
             echo -e "${GREEN}✓${NC}"
         else
-            # Try without --py flag for compiled libs
-            if $CIRCUP install "$lib" 2>/dev/null; then
-                echo -e "${GREEN}✓${NC}"
-            else
-                echo -e "${YELLOW}(already installed)${NC}"
-            fi
+            echo -e "${YELLOW}(already installed)${NC}"
         fi
     done
     echo -e "${GREEN}✓ Libraries installed${NC}"


### PR DESCRIPTION
## Summary

- **Phase 2b**: incremental Rust installer with md5 manifest, per-file plan, stale-delete + same-stem dedupe, progress events via `Channel<InstallProgress>`, blocking-pool dispatch.
- **Phase 3**: Svelte `FirmwareInstaller` component with progress bar, copy/skip/delete summary, reset-config toggle, installed-vs-available version row (with OEM / first-install / upgrade / up-to-date badges).
- **Hardening from session debugging**: serial REPL pre-flight (Ctrl-C + `disable_autoreload`, CP 7 + 8 compat) and post-install Ctrl-D soft reboot; `tools/deploy.{sh,ps1}` no longer pass `circup --py` (root cause of stray `.py` libs that bricked a real device).
- 51/51 `cargo test --lib`; `npm run check` + `npm run build` clean.

Closes the implementation portion of #19. Hardware-tested on a NANO4 (CP 7.3.1) — full upgrade install, incremental no-op, partial-diff, post-install soft reboot.

## Known scope gaps (follow-up issues)

- **First-flash on OEM device**: `detect_device_type` requires an existing `config.json`, so a brand-new device with no config refuses install. Spike's device picker not implemented. Use `tools/deploy.sh --device <type>` for first flash; GUI installer is for upgrades.
- **`onInstalled` config reload race**: JS reloads config from device immediately after Ctrl-D soft reboot fires. Works in practice; minor UX flicker possible.
- **`InstallReport` field naming**: serialized snake_case while `InstallProgress` is camelCase. Functional, worth unifying later.

## Test plan

- [x] `cargo test --lib` — 51 passing
- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean
- [x] Hardware: full install on CP 7.3.1 NANO4
- [x] Hardware: incremental no-op (all skips)
- [x] Hardware: incremental partial (mutate one bundle file, verify only that file copies)
- [ ] Hardware: install on Mini6 / Std10 / Duo2 / One1
- [ ] Hardware: reset-config flow
- [ ] Hardware: install with another process holding the serial port (tio) — should still complete (best-effort halt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)