### PR TITLE
USB Drive name field in UI

### DIFF
--- a/config-editor/src/lib/components/DeviceSection.svelte
+++ b/config-editor/src/lib/components/DeviceSection.svelte
@@ -18,7 +18,9 @@
 
   function handleUsbDriveNameChange(e: Event) {
     const target = e.target as HTMLInputElement;
-    updateField('usb_drive_name', target.value || undefined);
+    const raw = target.value.toUpperCase().replace(/[^A-Z0-9_]/g, '');
+    target.value = raw;
+    updateField('usb_drive_name', raw || undefined);
   }
 
   function handleDevModeChange(e: Event) {
@@ -84,10 +86,6 @@
       </p>
     </div>
 
-    <!-- USB Drive Name: hidden until CircuitPython 8.x upgrade ships.
-         The backend plumbing (config field, boot.py label= support) is intact.
-         On CP 7.x, storage.remount() doesn't accept label=, so this has no effect.
-         Re-enable this block once the CP upgrade is deployed to users.
     <div class="field-group">
       <label for="usb-drive-name">USB Drive Name:</label>
       <input
@@ -100,11 +98,10 @@
         placeholder="MIDICAPTAIN"
       />
       <p class="help-text">
-        Name shown when the drive mounts on your computer (max 11 chars,
-        letters/numbers/underscores). Leave blank to use "MIDICAPTAIN".
+        This name must match the device's actual mounted drive name.
+        The Config Editor saves this value to config.json, but renaming the drive itself is a manual step.
       </p>
     </div>
-    -->
 
     <div class="field-group">
       <div class="checkbox-row">
@@ -162,6 +159,16 @@
     border: 1px solid var(--border-color, #ccc);
     border-radius: 4px;
     font-size: 0.875rem;
+  }
+
+  .input-text {
+    padding: 0.5rem;
+    border: 1px solid var(--border-color, #ccc);
+    border-radius: 4px;
+    font-size: 0.875rem;
+    font-family: monospace;
+    max-width: 150px;
+    text-transform: uppercase;
   }
 
   .channel-input-group {

--- a/config-editor/src/lib/components/DeviceSection.svelte
+++ b/config-editor/src/lib/components/DeviceSection.svelte
@@ -91,15 +91,16 @@
       <input
         id="usb-drive-name"
         type="text"
-        class="input-text"
+        class="usb-drive-name-input"
         value={usbDriveName}
         onblur={handleUsbDriveNameChange}
         maxlength="11"
         placeholder="MIDICAPTAIN"
       />
       <p class="help-text">
-        This name must match the device's actual mounted drive name.
-        The Config Editor saves this value to config.json, but renaming the drive itself is a manual step.
+        Set this to the device's USB drive name (max 11 chars, letters/numbers/underscores).
+        Renaming the physical drive must be done manually for now.
+        Leave blank to use "MIDICAPTAIN".
       </p>
     </div>
 
@@ -161,7 +162,7 @@
     font-size: 0.875rem;
   }
 
-  .input-text {
+  .usb-drive-name-input {
     padding: 0.5rem;
     border: 1px solid var(--border-color, #ccc);
     border-radius: 4px;

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -89,6 +89,12 @@ export const validators = {
     if (value < 0 || value > 15) return 'Channel must be between 1 and 16';
     return null;
   },
+
+  usbDriveName: (value: string): string | null => {
+    if (value.length > 11) return 'Drive name must be 11 characters or less';
+    if (!/^[A-Z0-9_]*$/.test(value)) return 'Drive name may only contain A–Z, 0–9, and underscore';
+    return null;
+  },
 };
 
 export function validateConfig(config: MidiCaptainConfig): ValidationResult {
@@ -141,6 +147,12 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
     }
   }
   
+  // Validate usb_drive_name
+  if (config.usb_drive_name) {
+    const err = validators.usbDriveName(config.usb_drive_name);
+    if (err) errors.set('usb_drive_name', err);
+  }
+
   // Validate all buttons
   config.buttons.forEach((btn, idx) => {
     const labelError = validators.label(btn.label);

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -92,7 +92,7 @@ export const validators = {
 
   usbDriveName: (value: string): string | null => {
     if (value.length > 11) return 'Drive name must be 11 characters or less';
-    if (!/^[A-Z0-9_]*$/.test(value)) return 'Drive name may only contain A–Z, 0–9, and underscore';
+    if (!/^[A-Za-z0-9_]*$/.test(value)) return 'Drive name may only contain A–Z, 0–9, and underscore';
     return null;
   },
 };


### PR DESCRIPTION
- Expose `usb_drive_name` in GUI to make custom device name configurations easier.

Until we can upgrade the OS to circuitpython >= 8, we can't change the device name directly from the editor gui. It must be done manually on the user's system. This PR's change makes editing the device's `config.json` possible through the GUI, which is much easier than expecting the user to open the file in an editor manually.