### PR TITLE
Add MIDI Thru routing matrix (4 independent USB/DIN routes)

### DIFF
--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -324,6 +324,12 @@ pub struct MidiCaptainConfig {
     /// needing to hold Switch 1.  Defaults to false (performance mode).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_mode: Option<bool>,
+    /// Forward USB-received MIDI messages to the 5-pin DIN output. Default: true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_usb: Option<bool>,
+    /// Forward 5-pin DIN-received MIDI messages to the USB MIDI output. Default: true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_din: Option<bool>,
     pub buttons: Vec<ButtonConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoder: Option<EncoderConfig>,
@@ -720,6 +726,36 @@ mod tests {
         let reserialized = serde_json::to_string(&config).unwrap();
         let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
         assert_eq!(config2.dev_mode, Some(true));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_usb() {
+        let json = r#"{
+            "buttons": [],
+            "midi_thru_usb": false
+        }"#;
+
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_usb, Some(false));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_usb, Some(false));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_din() {
+        let json = r#"{
+            "buttons": [],
+            "midi_thru_din": false
+        }"#;
+
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_din, Some(false));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_din, Some(false));
     }
 
     /// Round-trip every shipped firmware config file: parse → serialize → parse,

--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -324,12 +324,21 @@ pub struct MidiCaptainConfig {
     /// needing to hold Switch 1.  Defaults to false (performance mode).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_mode: Option<bool>,
-    /// Forward USB-received MIDI messages to the 5-pin DIN output. Default: true.
+    /// MIDI Thru: USB input -> 5-pin DIN output (cross-thru). Default: true.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub midi_thru_usb: Option<bool>,
-    /// Forward 5-pin DIN-received MIDI messages to the USB MIDI output. Default: true.
+    pub midi_thru_usb_to_din: Option<bool>,
+    /// MIDI Thru: 5-pin DIN input -> USB output (cross-thru). Default: true.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub midi_thru_din: Option<bool>,
+    pub midi_thru_din_to_usb: Option<bool>,
+    /// MIDI Thru: 5-pin DIN input -> 5-pin DIN output (classic MIDI THRU
+    /// pass-through for daisy-chaining controllers downstream). Default: true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_din_to_din: Option<bool>,
+    /// MIDI Thru: USB input -> USB output (host loopback). Default: false —
+    /// enabling can cause duplicate notes or feedback when the DAW also has
+    /// MIDI echo enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_usb_to_usb: Option<bool>,
     pub buttons: Vec<ButtonConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoder: Option<EncoderConfig>,
@@ -729,33 +738,47 @@ mod tests {
     }
 
     #[test]
-    fn test_roundtrip_midi_thru_usb() {
-        let json = r#"{
-            "buttons": [],
-            "midi_thru_usb": false
-        }"#;
-
+    fn test_roundtrip_midi_thru_usb_to_din() {
+        let json = r#"{ "buttons": [], "midi_thru_usb_to_din": false }"#;
         let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.midi_thru_usb, Some(false));
+        assert_eq!(config.midi_thru_usb_to_din, Some(false));
 
         let reserialized = serde_json::to_string(&config).unwrap();
         let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
-        assert_eq!(config2.midi_thru_usb, Some(false));
+        assert_eq!(config2.midi_thru_usb_to_din, Some(false));
     }
 
     #[test]
-    fn test_roundtrip_midi_thru_din() {
-        let json = r#"{
-            "buttons": [],
-            "midi_thru_din": false
-        }"#;
-
+    fn test_roundtrip_midi_thru_din_to_usb() {
+        let json = r#"{ "buttons": [], "midi_thru_din_to_usb": false }"#;
         let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.midi_thru_din, Some(false));
+        assert_eq!(config.midi_thru_din_to_usb, Some(false));
 
         let reserialized = serde_json::to_string(&config).unwrap();
         let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
-        assert_eq!(config2.midi_thru_din, Some(false));
+        assert_eq!(config2.midi_thru_din_to_usb, Some(false));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_din_to_din() {
+        let json = r#"{ "buttons": [], "midi_thru_din_to_din": false }"#;
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_din_to_din, Some(false));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_din_to_din, Some(false));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_usb_to_usb() {
+        let json = r#"{ "buttons": [], "midi_thru_usb_to_usb": true }"#;
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_usb_to_usb, Some(true));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_usb_to_usb, Some(true));
     }
 
     /// Round-trip every shipped firmware config file: parse → serialize → parse,

--- a/config-editor/src/lib/components/MidiThruSection.svelte
+++ b/config-editor/src/lib/components/MidiThruSection.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import Accordion from './Accordion.svelte';
+  import { config, updateField } from '$lib/formStore';
+
+  let thruUsb = $derived($config.midi_thru_usb ?? true);
+  let thruDin = $derived($config.midi_thru_din ?? true);
+
+  function handleThruUsbChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    updateField('midi_thru_usb', target.checked);
+  }
+
+  function handleThruDinChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    updateField('midi_thru_din', target.checked);
+  }
+</script>
+
+<Accordion title="MIDI Thru">
+  <div class="midi-thru-section">
+    <p class="section-help">
+      MIDI Thru routes incoming messages from one port to the other — useful for
+      chaining devices. Both ports are enabled by default.
+    </p>
+
+    <div class="field-group">
+      <div class="checkbox-row">
+        <input
+          id="midi-thru-usb"
+          type="checkbox"
+          checked={thruUsb}
+          onchange={handleThruUsbChange}
+        />
+        <label for="midi-thru-usb">USB → 5-pin DIN</label>
+      </div>
+      <p class="help-text">
+        {#if thruUsb}
+          <strong>Enabled:</strong> Messages received on USB MIDI are forwarded to the 5-pin DIN output.
+        {:else}
+          <strong>Disabled:</strong> USB MIDI input is not forwarded to the 5-pin DIN output.
+        {/if}
+      </p>
+    </div>
+
+    <div class="field-group">
+      <div class="checkbox-row">
+        <input
+          id="midi-thru-din"
+          type="checkbox"
+          checked={thruDin}
+          onchange={handleThruDinChange}
+        />
+        <label for="midi-thru-din">5-pin DIN → USB</label>
+      </div>
+      <p class="help-text">
+        {#if thruDin}
+          <strong>Enabled:</strong> Messages received on the 5-pin DIN input are forwarded to the USB MIDI output.
+        {:else}
+          <strong>Disabled:</strong> 5-pin DIN input is not forwarded to the USB MIDI output.
+        {/if}
+      </p>
+    </div>
+  </div>
+</Accordion>
+
+<style>
+  .midi-thru-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .section-help {
+    font-size: 0.875rem;
+    color: var(--text-secondary, #666);
+    margin: 0 0 0.25rem 0;
+  }
+
+  .field-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .checkbox-row input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+
+  .checkbox-row label {
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .help-text {
+    font-size: 0.875rem;
+    color: var(--text-secondary, #666);
+    margin: 0;
+  }
+</style>

--- a/config-editor/src/lib/components/MidiThruSection.svelte
+++ b/config-editor/src/lib/components/MidiThruSection.svelte
@@ -2,64 +2,102 @@
   import Accordion from './Accordion.svelte';
   import { config, updateField } from '$lib/formStore';
 
-  let thruUsb = $derived($config.midi_thru_usb ?? true);
-  let thruDin = $derived($config.midi_thru_din ?? true);
+  // Defaults: cross-thru on, DIN->DIN on (classic MIDI THRU), USB->USB off (loopback risk).
+  let usbToDin = $derived($config.midi_thru_usb_to_din ?? true);
+  let dinToUsb = $derived($config.midi_thru_din_to_usb ?? true);
+  let dinToDin = $derived($config.midi_thru_din_to_din ?? true);
+  let usbToUsb = $derived($config.midi_thru_usb_to_usb ?? false);
 
-  function handleThruUsbChange(e: Event) {
+  function onChange(field: string, e: Event) {
     const target = e.target as HTMLInputElement;
-    updateField('midi_thru_usb', target.checked);
-  }
-
-  function handleThruDinChange(e: Event) {
-    const target = e.target as HTMLInputElement;
-    updateField('midi_thru_din', target.checked);
+    updateField(field, target.checked);
   }
 </script>
 
 <Accordion title="MIDI Thru">
   <div class="midi-thru-section">
     <p class="section-help">
-      MIDI Thru routes incoming messages from one port to the other — useful for
-      chaining devices. Both ports are enabled by default.
+      Route incoming MIDI between USB and 5-pin DIN ports. Each cell of the matrix
+      controls one path from an input (row) to an output (column). Cross-thru and
+      DIN&nbsp;→&nbsp;DIN (classic MIDI THRU pass-through) are on by default.
     </p>
 
-    <div class="field-group">
-      <div class="checkbox-row">
-        <input
-          id="midi-thru-usb"
-          type="checkbox"
-          checked={thruUsb}
-          onchange={handleThruUsbChange}
-        />
-        <label for="midi-thru-usb">USB → 5-pin DIN</label>
-      </div>
-      <p class="help-text">
-        {#if thruUsb}
-          <strong>Enabled:</strong> Messages received on USB MIDI are forwarded to the 5-pin DIN output.
-        {:else}
-          <strong>Disabled:</strong> USB MIDI input is not forwarded to the 5-pin DIN output.
-        {/if}
-      </p>
-    </div>
+    <table class="thru-matrix" aria-label="MIDI Thru routing matrix">
+      <thead>
+        <tr>
+          <th scope="col" class="corner">From&nbsp;\&nbsp;To</th>
+          <th scope="col">USB</th>
+          <th scope="col">5-pin DIN</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">USB</th>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={usbToUsb}
+                onchange={(e) => onChange('midi_thru_usb_to_usb', e)}
+              />
+              <span>USB → USB</span>
+            </label>
+          </td>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={usbToDin}
+                onchange={(e) => onChange('midi_thru_usb_to_din', e)}
+              />
+              <span>USB → DIN</span>
+            </label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">5-pin DIN</th>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={dinToUsb}
+                onchange={(e) => onChange('midi_thru_din_to_usb', e)}
+              />
+              <span>DIN → USB</span>
+            </label>
+          </td>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={dinToDin}
+                onchange={(e) => onChange('midi_thru_din_to_din', e)}
+              />
+              <span>DIN → DIN</span>
+            </label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
-    <div class="field-group">
-      <div class="checkbox-row">
-        <input
-          id="midi-thru-din"
-          type="checkbox"
-          checked={thruDin}
-          onchange={handleThruDinChange}
-        />
-        <label for="midi-thru-din">5-pin DIN → USB</label>
+    {#if usbToUsb}
+      <div class="warning" role="alert">
+        <strong>⚠ USB loopback enabled.</strong>
+        Messages received on USB MIDI will be echoed back to the host. If your
+        DAW also has MIDI echo / through enabled on the same port, this will
+        cause duplicate notes or a feedback loop. Most users should leave this off.
       </div>
-      <p class="help-text">
-        {#if thruDin}
-          <strong>Enabled:</strong> Messages received on the 5-pin DIN input are forwarded to the USB MIDI output.
-        {:else}
-          <strong>Disabled:</strong> 5-pin DIN input is not forwarded to the USB MIDI output.
-        {/if}
-      </p>
-    </div>
+    {/if}
+
+    <details class="routing-help">
+      <summary>What does each route do?</summary>
+      <ul>
+        <li><strong>USB → DIN:</strong> forward MIDI from the computer to gear plugged into the 5-pin DIN output.</li>
+        <li><strong>DIN → USB:</strong> forward MIDI from a 5-pin source (e.g. another foot controller) to the computer.</li>
+        <li><strong>DIN → DIN:</strong> classic MIDI THRU. Forward incoming 5-pin MIDI to the 5-pin output for daisy-chaining controllers downstream.</li>
+        <li><strong>USB → USB:</strong> echo USB MIDI back to the host. Niche; off by default to avoid feedback with DAW MIDI echo.</li>
+      </ul>
+    </details>
   </div>
 </Accordion>
 
@@ -67,7 +105,7 @@
   .midi-thru-section {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 1rem;
   }
 
   .section-help {
@@ -76,32 +114,75 @@
     margin: 0 0 0.25rem 0;
   }
 
-  .field-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  .thru-matrix {
+    border-collapse: collapse;
+    align-self: flex-start;
+    font-size: 0.9rem;
   }
 
-  .checkbox-row {
-    display: flex;
+  .thru-matrix th,
+  .thru-matrix td {
+    border: 1px solid var(--border, #d0d0d0);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  .thru-matrix thead th {
+    background: var(--surface-muted, #f3f3f3);
+    font-weight: 600;
+  }
+
+  .thru-matrix tbody th {
+    background: var(--surface-muted, #f8f8f8);
+    font-weight: 600;
+  }
+
+  .thru-matrix .corner {
+    background: transparent;
+    border: none;
+    font-weight: 500;
+    color: var(--text-secondary, #888);
+  }
+
+  .cell {
+    display: inline-flex;
     align-items: center;
     gap: 0.5rem;
+    cursor: pointer;
   }
 
-  .checkbox-row input[type="checkbox"] {
+  .cell input[type='checkbox'] {
     width: 16px;
     height: 16px;
     cursor: pointer;
   }
 
-  .checkbox-row label {
+  .warning {
+    border: 1px solid #c89200;
+    background: #fff7e0;
+    color: #5a4400;
+    padding: 0.6rem 0.8rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    line-height: 1.4;
+  }
+
+  .routing-help {
+    font-size: 0.875rem;
+    color: var(--text-secondary, #555);
+  }
+
+  .routing-help summary {
     cursor: pointer;
     font-weight: 500;
   }
 
-  .help-text {
-    font-size: 0.875rem;
-    color: var(--text-secondary, #666);
-    margin: 0;
+  .routing-help ul {
+    margin: 0.5rem 0 0 1.25rem;
+    padding: 0;
+  }
+
+  .routing-help li {
+    margin-bottom: 0.25rem;
   }
 </style>

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -46,13 +46,21 @@ export interface MIDICaptainConfig {
   expression?: ExpressionPedals;
   display?: DisplayConfig;
   /**
-   * MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output. Default true.
+   * MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output (cross-thru). Default true.
    */
-  midi_thru_usb?: boolean;
+  midi_thru_usb_to_din?: boolean;
   /**
-   * MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output. Default true.
+   * MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output (cross-thru). Default true.
    */
-  midi_thru_din?: boolean;
+  midi_thru_din_to_usb?: boolean;
+  /**
+   * MIDI Thru: forward messages received on the 5-pin DIN input to the 5-pin DIN output (classic MIDI THRU pass-through, for daisy-chaining controllers downstream). Default true.
+   */
+  midi_thru_din_to_din?: boolean;
+  /**
+   * MIDI Thru: echo messages received on USB MIDI back to the USB output (host loopback). Default false; enabling can cause duplicate notes or feedback when the DAW has MIDI echo enabled.
+   */
+  midi_thru_usb_to_usb?: boolean;
 }
 export interface ButtonConfig {
   /**

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -45,6 +45,14 @@ export interface MIDICaptainConfig {
   encoder?: EncoderConfig;
   expression?: ExpressionPedals;
   display?: DisplayConfig;
+  /**
+   * MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output. Default true.
+   */
+  midi_thru_usb?: boolean;
+  /**
+   * MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output. Default true.
+   */
+  midi_thru_din?: boolean;
 }
 export interface ButtonConfig {
   /**

--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -18,6 +18,7 @@
   import EncoderSection from '$lib/components/EncoderSection.svelte';
   import ExpressionSection from '$lib/components/ExpressionSection.svelte';
   import DisplaySection from '$lib/components/DisplaySection.svelte';
+  import MidiThruSection from '$lib/components/MidiThruSection.svelte';
   import FirmwareInstaller from '$lib/components/FirmwareInstaller.svelte';
   import { loadConfig, validate, normalizeConfig, config } from '$lib/formStore';
 
@@ -335,6 +336,7 @@
         <EncoderSection />
         <ExpressionSection />
         <DisplaySection />
+        <MidiThruSection />
         <FirmwareInstaller
           device={$selectedDevice}
           hasUnsavedChanges={$hasUnsavedChanges}

--- a/config.schema.json
+++ b/config.schema.json
@@ -48,15 +48,25 @@
       "$ref": "#/definitions/DisplayConfig",
       "description": "Display and text rendering settings."
     },
-    "midi_thru_usb": {
+    "midi_thru_usb_to_din": {
       "type": "boolean",
       "default": true,
-      "description": "MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output. Default true."
+      "description": "MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output (cross-thru). Default true."
     },
-    "midi_thru_din": {
+    "midi_thru_din_to_usb": {
       "type": "boolean",
       "default": true,
-      "description": "MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output. Default true."
+      "description": "MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output (cross-thru). Default true."
+    },
+    "midi_thru_din_to_din": {
+      "type": "boolean",
+      "default": true,
+      "description": "MIDI Thru: forward messages received on the 5-pin DIN input to the 5-pin DIN output (classic MIDI THRU pass-through, for daisy-chaining controllers downstream). Default true."
+    },
+    "midi_thru_usb_to_usb": {
+      "type": "boolean",
+      "default": false,
+      "description": "MIDI Thru: echo messages received on USB MIDI back to the USB output (host loopback). Default false; enabling can cause duplicate notes or feedback when the DAW has MIDI echo enabled."
     }
   },
   "additionalProperties": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -47,6 +47,16 @@
     "display": {
       "$ref": "#/definitions/DisplayConfig",
       "description": "Display and text rendering settings."
+    },
+    "midi_thru_usb": {
+      "type": "boolean",
+      "default": true,
+      "description": "MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output. Default true."
+    },
+    "midi_thru_din": {
+      "type": "boolean",
+      "default": true,
+      "description": "MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output. Default true."
     }
   },
   "additionalProperties": false,

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -39,7 +39,16 @@ from adafruit_midi.note_off import NoteOff
 
 # Import core modules (testable logic)
 from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display
-from core.config import load_config as _load_config_from_file, validate_config, get_display_config, get_button_state_config, get_midi_thru_usb, get_midi_thru_din
+from core.config import (
+    load_config as _load_config_from_file,
+    validate_config,
+    get_display_config,
+    get_button_state_config,
+    get_midi_thru_usb_to_din,
+    get_midi_thru_din_to_usb,
+    get_midi_thru_din_to_din,
+    get_midi_thru_usb_to_usb,
+)
 from core.button import Switch, ButtonState
 from core.hid import dispatch_hid
 
@@ -265,10 +274,16 @@ config = load_config()
 buttons = config.get("buttons", [])
 print(f"Loaded {len(buttons)} button configs")
 
-# MIDI Thru settings (read once at boot; default True if omitted)
-MIDI_THRU_USB = get_midi_thru_usb(config)  # forward USB->DIN
-MIDI_THRU_DIN = get_midi_thru_din(config)  # forward DIN->USB
-print(f"MIDI thru: USB->DIN={MIDI_THRU_USB}, DIN->USB={MIDI_THRU_DIN}")
+# MIDI Thru routing matrix (read once at boot).
+# Cross routes default True; USB->USB defaults False (host loopback risk).
+MIDI_THRU_USB_TO_DIN = get_midi_thru_usb_to_din(config)
+MIDI_THRU_DIN_TO_USB = get_midi_thru_din_to_usb(config)
+MIDI_THRU_DIN_TO_DIN = get_midi_thru_din_to_din(config)
+MIDI_THRU_USB_TO_USB = get_midi_thru_usb_to_usb(config)
+print(
+    f"MIDI thru: USB->DIN={MIDI_THRU_USB_TO_DIN}, DIN->USB={MIDI_THRU_DIN_TO_USB}, "
+    f"DIN->DIN={MIDI_THRU_DIN_TO_DIN}, USB->USB={MIDI_THRU_USB_TO_USB}"
+)
 
 # =============================================================================
 # Fonts
@@ -927,15 +942,21 @@ def _process_midi_msg(msg, source="USB"):
 
 
 def handle_midi():
-    """Handle incoming MIDI messages and MIDI thru."""
+    """Handle incoming MIDI messages and MIDI thru (4-route matrix)."""
     # --- USB MIDI in ---
     usb_msg = midi.receive()
     if usb_msg:
         _process_midi_msg(usb_msg, source="USB")
-        # Thru: forward USB -> DIN (gated by config)
-        if MIDI_THRU_USB and midi_serial is not None:
+        # USB -> DIN (cross)
+        if MIDI_THRU_USB_TO_DIN and midi_serial is not None:
             try:
                 midi_serial.send(usb_msg)
+            except Exception:
+                pass
+        # USB -> USB (loopback to host; opt-in)
+        if MIDI_THRU_USB_TO_USB:
+            try:
+                midi.send(usb_msg)
             except Exception:
                 pass
 
@@ -944,10 +965,16 @@ def handle_midi():
         din_msg = midi_serial.receive()
         if din_msg:
             _process_midi_msg(din_msg, source="DIN")
-            # Thru: forward DIN -> USB (gated by config)
-            if MIDI_THRU_DIN:
+            # DIN -> USB (cross)
+            if MIDI_THRU_DIN_TO_USB:
                 try:
                     midi.send(din_msg)
+                except Exception:
+                    pass
+            # DIN -> DIN (classic MIDI THRU pass-through)
+            if MIDI_THRU_DIN_TO_DIN:
+                try:
+                    midi_serial.send(din_msg)
                 except Exception:
                     pass
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -39,7 +39,7 @@ from adafruit_midi.note_off import NoteOff
 
 # Import core modules (testable logic)
 from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display
-from core.config import load_config as _load_config_from_file, validate_config, get_display_config, get_button_state_config
+from core.config import load_config as _load_config_from_file, validate_config, get_display_config, get_button_state_config, get_midi_thru_usb, get_midi_thru_din
 from core.button import Switch, ButtonState
 from core.hid import dispatch_hid
 
@@ -264,6 +264,11 @@ def load_config():
 config = load_config()
 buttons = config.get("buttons", [])
 print(f"Loaded {len(buttons)} button configs")
+
+# MIDI Thru settings (read once at boot; default True if omitted)
+MIDI_THRU_USB = get_midi_thru_usb(config)  # forward USB->DIN
+MIDI_THRU_DIN = get_midi_thru_din(config)  # forward DIN->USB
+print(f"MIDI thru: USB->DIN={MIDI_THRU_USB}, DIN->USB={MIDI_THRU_DIN}")
 
 # =============================================================================
 # Fonts
@@ -927,8 +932,8 @@ def handle_midi():
     usb_msg = midi.receive()
     if usb_msg:
         _process_midi_msg(usb_msg, source="USB")
-        # Thru: forward USB → 5-pin
-        if midi_serial is not None:
+        # Thru: forward USB -> DIN (gated by config)
+        if MIDI_THRU_USB and midi_serial is not None:
             try:
                 midi_serial.send(usb_msg)
             except Exception:
@@ -939,11 +944,12 @@ def handle_midi():
         din_msg = midi_serial.receive()
         if din_msg:
             _process_midi_msg(din_msg, source="DIN")
-            # Thru: forward 5-pin → USB
-            try:
-                midi.send(din_msg)
-            except Exception:
-                pass
+            # Thru: forward DIN -> USB (gated by config)
+            if MIDI_THRU_DIN:
+                try:
+                    midi.send(din_msg)
+                except Exception:
+                    pass
 
 
 def handle_switches():

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -359,6 +359,22 @@ def get_display_config(cfg):
     }
 
 
+def get_midi_thru_usb(cfg):
+    """Whether to forward USB-received MIDI messages to the 5-pin DIN output.
+
+    Returns True if USB->DIN MIDI thru is enabled (default), False if disabled.
+    """
+    return bool(cfg.get("midi_thru_usb", True))
+
+
+def get_midi_thru_din(cfg):
+    """Whether to forward 5-pin DIN-received MIDI messages to the USB MIDI output.
+
+    Returns True if DIN->USB MIDI thru is enabled (default), False if disabled.
+    """
+    return bool(cfg.get("midi_thru_din", True))
+
+
 def get_dev_mode(cfg):
     """Extract development mode setting from config.
 

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -359,20 +359,27 @@ def get_display_config(cfg):
     }
 
 
-def get_midi_thru_usb(cfg):
-    """Whether to forward USB-received MIDI messages to the 5-pin DIN output.
-
-    Returns True if USB->DIN MIDI thru is enabled (default), False if disabled.
-    """
-    return bool(cfg.get("midi_thru_usb", True))
+def get_midi_thru_usb_to_din(cfg):
+    """USB input -> 5-pin DIN output (cross-thru). Default True."""
+    return bool(cfg.get("midi_thru_usb_to_din", True))
 
 
-def get_midi_thru_din(cfg):
-    """Whether to forward 5-pin DIN-received MIDI messages to the USB MIDI output.
+def get_midi_thru_din_to_usb(cfg):
+    """5-pin DIN input -> USB output (cross-thru). Default True."""
+    return bool(cfg.get("midi_thru_din_to_usb", True))
 
-    Returns True if DIN->USB MIDI thru is enabled (default), False if disabled.
-    """
-    return bool(cfg.get("midi_thru_din", True))
+
+def get_midi_thru_din_to_din(cfg):
+    """5-pin DIN input -> 5-pin DIN output (classic MIDI THRU pass-through
+    for daisy-chaining controllers downstream). Default True (matches OEM)."""
+    return bool(cfg.get("midi_thru_din_to_din", True))
+
+
+def get_midi_thru_usb_to_usb(cfg):
+    """USB input -> USB output (loopback to host). Default False — echoing
+    back to the host can cause duplicate notes or feedback when the DAW also
+    has MIDI echo enabled. Opt-in for niche routing setups."""
+    return bool(cfg.get("midi_thru_usb_to_usb", False))
 
 
 def get_dev_mode(cfg):

--- a/tests/test_usb_drive_name.py
+++ b/tests/test_usb_drive_name.py
@@ -12,8 +12,10 @@ from core.config import (
     validate_usb_drive_name,
     get_usb_drive_name,
     get_dev_mode,
-    get_midi_thru_usb,
-    get_midi_thru_din,
+    get_midi_thru_usb_to_din,
+    get_midi_thru_din_to_usb,
+    get_midi_thru_din_to_din,
+    get_midi_thru_usb_to_usb,
 )
 
 
@@ -119,64 +121,77 @@ def test_get_dev_mode_falsy_values():
     assert get_dev_mode({"dev_mode": None}) is False
 
 
-# ── midi_thru_usb tests ───────────────────────────────────────────────────────
-
-def test_get_midi_thru_usb_default_true():
-    """midi_thru_usb defaults to True when absent from config (back-compat)."""
-    assert get_midi_thru_usb({}) is True
+# ── midi_thru routing matrix tests ────────────────────────────────────────────
+# Routes: USB->DIN, DIN->USB, DIN->DIN default True (classic / cross-thru).
+# USB->USB defaults False (host loopback feedback risk).
 
 
-def test_get_midi_thru_usb_explicit_true():
-    """midi_thru_usb returns True when explicitly set to true."""
-    assert get_midi_thru_usb({"midi_thru_usb": True}) is True
+def test_get_midi_thru_usb_to_din_default_true():
+    assert get_midi_thru_usb_to_din({}) is True
 
 
-def test_get_midi_thru_usb_explicit_false():
-    """midi_thru_usb returns False when explicitly set to false."""
-    assert get_midi_thru_usb({"midi_thru_usb": False}) is False
+def test_get_midi_thru_usb_to_din_explicit_false():
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": False}) is False
 
 
-def test_get_midi_thru_usb_truthy_values():
-    """midi_thru_usb coerces truthy non-bool values to True."""
-    assert get_midi_thru_usb({"midi_thru_usb": 1}) is True
+def test_get_midi_thru_usb_to_din_coercion():
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": 1}) is True
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": 0}) is False
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": None}) is False
 
 
-def test_get_midi_thru_usb_falsy_values():
-    """midi_thru_usb coerces falsy non-bool values to False."""
-    assert get_midi_thru_usb({"midi_thru_usb": 0}) is False
-    assert get_midi_thru_usb({"midi_thru_usb": None}) is False
+def test_get_midi_thru_din_to_usb_default_true():
+    assert get_midi_thru_din_to_usb({}) is True
 
 
-# ── midi_thru_din tests ───────────────────────────────────────────────────────
-
-def test_get_midi_thru_din_default_true():
-    """midi_thru_din defaults to True when absent from config (back-compat)."""
-    assert get_midi_thru_din({}) is True
+def test_get_midi_thru_din_to_usb_explicit_false():
+    assert get_midi_thru_din_to_usb({"midi_thru_din_to_usb": False}) is False
 
 
-def test_get_midi_thru_din_explicit_true():
-    """midi_thru_din returns True when explicitly set to true."""
-    assert get_midi_thru_din({"midi_thru_din": True}) is True
+def test_get_midi_thru_din_to_usb_coercion():
+    assert get_midi_thru_din_to_usb({"midi_thru_din_to_usb": 1}) is True
+    assert get_midi_thru_din_to_usb({"midi_thru_din_to_usb": 0}) is False
 
 
-def test_get_midi_thru_din_explicit_false():
-    """midi_thru_din returns False when explicitly set to false."""
-    assert get_midi_thru_din({"midi_thru_din": False}) is False
+def test_get_midi_thru_din_to_din_default_true():
+    """DIN->DIN is the classic MIDI THRU pass-through; defaults True (matches OEM)."""
+    assert get_midi_thru_din_to_din({}) is True
 
 
-def test_get_midi_thru_din_truthy_values():
-    """midi_thru_din coerces truthy non-bool values to True."""
-    assert get_midi_thru_din({"midi_thru_din": 1}) is True
+def test_get_midi_thru_din_to_din_explicit_false():
+    assert get_midi_thru_din_to_din({"midi_thru_din_to_din": False}) is False
 
 
-def test_get_midi_thru_din_falsy_values():
-    """midi_thru_din coerces falsy non-bool values to False."""
-    assert get_midi_thru_din({"midi_thru_din": 0}) is False
-    assert get_midi_thru_din({"midi_thru_din": None}) is False
+def test_get_midi_thru_din_to_din_coercion():
+    assert get_midi_thru_din_to_din({"midi_thru_din_to_din": 1}) is True
+    assert get_midi_thru_din_to_din({"midi_thru_din_to_din": 0}) is False
 
 
-def test_midi_thru_usb_and_din_independent():
-    """Toggles are independent — setting one does not affect the other."""
-    assert get_midi_thru_usb({"midi_thru_din": False}) is True
-    assert get_midi_thru_din({"midi_thru_usb": False}) is True
+def test_get_midi_thru_usb_to_usb_default_false():
+    """USB->USB defaults False — host loopback can cause DAW feedback. Opt-in only."""
+    assert get_midi_thru_usb_to_usb({}) is False
+
+
+def test_get_midi_thru_usb_to_usb_explicit_true():
+    assert get_midi_thru_usb_to_usb({"midi_thru_usb_to_usb": True}) is True
+
+
+def test_get_midi_thru_usb_to_usb_coercion():
+    assert get_midi_thru_usb_to_usb({"midi_thru_usb_to_usb": 1}) is True
+    assert get_midi_thru_usb_to_usb({"midi_thru_usb_to_usb": 0}) is False
+
+
+def test_midi_thru_routes_independent():
+    """Each route is gated independently — setting one does not affect any other."""
+    cfg = {"midi_thru_usb_to_din": False}
+    assert get_midi_thru_usb_to_din(cfg) is False
+    assert get_midi_thru_din_to_usb(cfg) is True
+    assert get_midi_thru_din_to_din(cfg) is True
+    assert get_midi_thru_usb_to_usb(cfg) is False  # default
+
+    cfg = {"midi_thru_usb_to_usb": True}
+    assert get_midi_thru_usb_to_usb(cfg) is True
+    assert get_midi_thru_usb_to_din(cfg) is True  # default
+    assert get_midi_thru_din_to_usb(cfg) is True
+    assert get_midi_thru_din_to_din(cfg) is True
 

--- a/tests/test_usb_drive_name.py
+++ b/tests/test_usb_drive_name.py
@@ -8,7 +8,13 @@ import os
 # Add firmware/dev to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../firmware/dev"))
 
-from core.config import validate_usb_drive_name, get_usb_drive_name, get_dev_mode
+from core.config import (
+    validate_usb_drive_name,
+    get_usb_drive_name,
+    get_dev_mode,
+    get_midi_thru_usb,
+    get_midi_thru_din,
+)
 
 
 def test_validate_usb_drive_name_valid():
@@ -111,4 +117,66 @@ def test_get_dev_mode_falsy_values():
     """dev_mode coerces falsy non-bool values to False."""
     assert get_dev_mode({"dev_mode": 0}) is False
     assert get_dev_mode({"dev_mode": None}) is False
+
+
+# ── midi_thru_usb tests ───────────────────────────────────────────────────────
+
+def test_get_midi_thru_usb_default_true():
+    """midi_thru_usb defaults to True when absent from config (back-compat)."""
+    assert get_midi_thru_usb({}) is True
+
+
+def test_get_midi_thru_usb_explicit_true():
+    """midi_thru_usb returns True when explicitly set to true."""
+    assert get_midi_thru_usb({"midi_thru_usb": True}) is True
+
+
+def test_get_midi_thru_usb_explicit_false():
+    """midi_thru_usb returns False when explicitly set to false."""
+    assert get_midi_thru_usb({"midi_thru_usb": False}) is False
+
+
+def test_get_midi_thru_usb_truthy_values():
+    """midi_thru_usb coerces truthy non-bool values to True."""
+    assert get_midi_thru_usb({"midi_thru_usb": 1}) is True
+
+
+def test_get_midi_thru_usb_falsy_values():
+    """midi_thru_usb coerces falsy non-bool values to False."""
+    assert get_midi_thru_usb({"midi_thru_usb": 0}) is False
+    assert get_midi_thru_usb({"midi_thru_usb": None}) is False
+
+
+# ── midi_thru_din tests ───────────────────────────────────────────────────────
+
+def test_get_midi_thru_din_default_true():
+    """midi_thru_din defaults to True when absent from config (back-compat)."""
+    assert get_midi_thru_din({}) is True
+
+
+def test_get_midi_thru_din_explicit_true():
+    """midi_thru_din returns True when explicitly set to true."""
+    assert get_midi_thru_din({"midi_thru_din": True}) is True
+
+
+def test_get_midi_thru_din_explicit_false():
+    """midi_thru_din returns False when explicitly set to false."""
+    assert get_midi_thru_din({"midi_thru_din": False}) is False
+
+
+def test_get_midi_thru_din_truthy_values():
+    """midi_thru_din coerces truthy non-bool values to True."""
+    assert get_midi_thru_din({"midi_thru_din": 1}) is True
+
+
+def test_get_midi_thru_din_falsy_values():
+    """midi_thru_din coerces falsy non-bool values to False."""
+    assert get_midi_thru_din({"midi_thru_din": 0}) is False
+    assert get_midi_thru_din({"midi_thru_din": None}) is False
+
+
+def test_midi_thru_usb_and_din_independent():
+    """Toggles are independent — setting one does not affect the other."""
+    assert get_midi_thru_usb({"midi_thru_din": False}) is True
+    assert get_midi_thru_din({"midi_thru_usb": False}) is True
 


### PR DESCRIPTION
## Summary

Adds configurable MIDI Thru routing to the firmware as a 2x2 matrix of independent toggles, exposed in the config editor UI as a routing grid. Closes #124.

| | USB out | DIN out |
|---|---|---|
| **USB in** | `midi_thru_usb_to_usb` (default **false**) | `midi_thru_usb_to_din` (default true) |
| **DIN in** | `midi_thru_din_to_usb` (default true) | `midi_thru_din_to_din` (default true) |

- Cross-thru routes (USB↔DIN) and DIN→DIN (classic MIDI THRU pass-through) default **on**.
- USB→USB (host loopback) defaults **off** and shows a warning banner in the UI when enabled — echoing USB input back to the host causes duplicate notes or feedback when the DAW also has MIDI echo turned on.

## Motivation

User report on r/paintaudiomidicaptain: a Midi Duo chained into the Captain's 5-pin DIN input did not pass through to the downstream device, because the OEM's "midithrough" feature is DIN→DIN only and the Captain firmware did not implement that route at all. The fix needed all four routes to be explicit so users can wire any combination of USB-host, foot controllers, and downstream gear without surprises.

Discussion: https://www.reddit.com/r/paintaudiomidicaptain/comments/1tbnv8f/midi_captain_midi_thru_not_working/

## Changes

- **Firmware**: `core/config.py` exposes four getters; `code.py` reads them once at boot and gates each forward path independently in `handle_midi()`.
- **Schema + types**: four new boolean properties in `config.schema.json`; Rust `MidiCaptainConfig` struct gains four `Option<bool>` fields with per-field round-trip tests; TypeScript types regenerated from the schema.
- **UI**: `MidiThruSection.svelte` rebuilt as an accessible 2x2 routing table (rows = From, cols = To). Yellow warning banner appears when USB→USB is enabled. Collapsible per-route help section explains each path.
- **Tests**: 13 pytest cases covering defaults, explicit values, type coercion, and route independence (changing one toggle does not perturb the others' defaults); 4 Rust round-trip tests verifying serialization for each field.

This branch has not been merged, so the older two-toggle design (`midi_thru_usb` / `midi_thru_din`) introduced earlier in this branch was removed outright instead of being aliased. No migration shim is required for shipped configs since the fields default to sensible values when absent.

## Test plan

- [x] `python3 -m pytest tests/` — 427 passed
- [x] `cargo test` in `config-editor/src-tauri` — 55 passed
- [x] caveman code review on `264231b..d7976be` — no issues
- [ ] Manual: load a config in the editor, toggle each cell of the matrix, save and reload; verify the JSON contains exactly the toggled keys
- [ ] Manual: enable USB→USB, confirm warning banner renders
- [ ] Hardware: chain a 5-pin source into MIDI Captain DIN-in with `midi_thru_din_to_din=true`; verify downstream gear receives the source's MIDI

🤖 Generated with [Claude Code](https://claude.com/claude-code)