### PR TITLE
Add mode: "keytimes" — press-timing-based button dispatch (#48)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Track features and bugs via [GitHub Issues](https://github.com/MC-Music-Workshop
 - [ ] Windows Signing Cert
 - [ ] Custom display layouts
 - [ ] SysEx protocol documentation
-- [ ] Keytimes / multi-press cycling, double-press, long-press detection
+- [x] Keytimes / multi-press cycling, double-press, long-press detection — landed as `mode: "keytimes"` (#48). Legacy `keytimes`/`states` fields on toggle/momentary are deprecated in v2.0 and will be removed in v3.0; the validator prints a boot-time warning.
 - [ ] Pages / banks
 - [ ] Firmware press-handler unit tests for select-mode (`handle_pc_select_press`, `handle_cc_select_press`, `update_select_group`, and the RX hooks in `_process_midi_msg`). Validator coverage exists; runtime coverage does not. Mock infrastructure in `tests/mocks/` should support this.
 - [ ] Tighten `pyproject.toml` ruff ignores: `F401` is currently global; should be scoped via `[tool.ruff.lint.per-file-ignores]` so genuinely-unused imports in production code get caught. Test-mock re-exports under `tests/mocks/**` are the legitimate use.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ cd config-editor && npm run generate:types       # regenerate types from schema
 
 Lint is folded into `./tools/test-all.sh`, which runs `ruff` (Python) and `cargo clippy` (Rust) alongside the test suites. Run that script at the verification checkpoint — once before claiming completion or requesting review, not after every edit.
 
-`pyproject.toml` configures ruff to ignore four rules that flag deliberate codebase patterns (`E402`, `E712`, `F401`, `F403`); see the comments in that file for rationale before adding new exceptions. `cargo clippy` runs warnings-only — there are two pre-existing warnings on untouched code that should be addressed in a separate cleanup pass, not silently muted.
+`pyproject.toml` configures ruff to ignore four rules that flag deliberate codebase patterns (`E402`, `E712`, `F401`, `F403`); see the comments in that file for rationale before adding new exceptions. `cargo clippy` runs warnings-only; the tree is currently clean.
 
 To run lint alone (without the full test suite):
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Momentary and toggle modes are currently supported. Many more features are comin
 - **Dev Mode** - Quickly test config changes without remounting the device
 - **Custom Drive Names** - Useful when managing multiple Captains
 - **HID Messages** - send keyboard and mouse messages in addition to MIDI
+- **Short / Long Press (Keytimes mode)** — Each button can fire different messages on short tap vs long hold, with independent multi-state cycles per timing class. See [`firmware/dev/config-example-keytimes-mode.json`](firmware/dev/config-example-keytimes-mode.json) for examples and [`docs/plans/2026-05-13-issue-48-press-timings.md`](docs/plans/2026-05-13-issue-48-press-timings.md) for the full design.
 - **Signed Installation Packages** — Install without security warnings or manual overrides (macOS and Linux)
 - **Stage-ready** — No unexpected resets, no crashes, no surprises
 

--- a/config-editor/AGENTS.md
+++ b/config-editor/AGENTS.md
@@ -104,8 +104,22 @@ Key constraints from `config.schema.json`:
 
 ## `mode` vs `off_mode`
 
-- **`mode` (toggle/momentary/flash)**: applies to CC, Note, and PC types. For PC types, MIDI is always sent on press regardless of mode. Flash option only appears for PC types in the GUI.
-- **`off_mode` (dim/off)**: LED appearance when button is "off" — applies to all types.
+- **`mode` (toggle/momentary/flash/select/keytimes)**: applies to CC, Note, and PC types. For PC types, MIDI is always sent on press regardless of mode. Flash option only appears for PC types in the GUI.
+- **`off_mode` (dim/off)**: LED appearance when button is "off" — applies to non-keytimes modes only.
+
+## `mode: "keytimes"` (#48)
+
+The keytimes mode is rendered by `KeytimesEditor.svelte`, which composes per-cycle editors and `KeytimesMessageEditor.svelte` for individual Message entries. When a button is in keytimes mode:
+
+- The legacy CC/Note/PC/HID per-button fields are hidden in `ButtonRow.svelte` (they don't apply — message data lives inside `short[].down[]` / `up[]` Message objects)
+- The Type selector is still shown but has no effect (it's used by other modes)
+- The legacy `keytimes` spinner is hidden (deprecated in favor of `short[]`/`long[]` array lengths)
+- `off_mode` is hidden (color/dim live per cycle entry instead)
+- `KeytimesEditor` renders threshold input, short cycle entries, long cycle entries
+
+Mutations on the nested structure (add/remove entry, add/remove message, change message type) go through dedicated `formStore` helpers (`addKeytimesEntry`, `removeKeytimesEntry`, `addKeytimesMessage`, `removeKeytimesMessage`, `setKeytimesMessageType`) because `updateField()` requires intermediate path components to already exist. Leaf-value edits (color, dim, label, individual message field values) use `updateField()`.
+
+`normalizeButton` strips legacy per-type fields when `mode === 'keytimes'` so save output stays clean even if the button was toggled through other modes before settling on keytimes. For non-keytimes modes, it strips the `short`/`long`/`long_press_threshold_ms` fields.
 
 ## Accessibility Conventions
 

--- a/config-editor/package.json
+++ b/config-editor/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "svelte-kit sync && vite dev",
     "build": "svelte-kit sync && vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -501,7 +501,7 @@ impl MidiCaptainConfig {
                 }
             }
             if let Some(ms) = button.flash_ms {
-                if ms < 50 || ms > 5000 {
+                if !(50..=5000).contains(&ms) {
                     errors.push(format!("Button {} flash_ms {} out of range (50-5000)", i + 1, ms));
                 }
             }

--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -453,6 +453,13 @@ impl MidiCaptainConfig {
             }
         }
 
+        // Validate global long-press threshold (50-5000ms per schema)
+        if let Some(ms) = self.long_press_threshold_ms {
+            if !(50..=5000).contains(&ms) {
+                errors.push(format!("Global long_press_threshold_ms {} out of range (50-5000)", ms));
+            }
+        }
+
         // Check button count matches device
         let expected_buttons = match self.device {
             DeviceType::Std10 => 10,
@@ -503,6 +510,22 @@ impl MidiCaptainConfig {
             if let Some(ms) = button.flash_ms {
                 if !(50..=5000).contains(&ms) {
                     errors.push(format!("Button {} flash_ms {} out of range (50-5000)", i + 1, ms));
+                }
+            }
+            if let Some(ms) = button.long_press_threshold_ms {
+                if !(50..=5000).contains(&ms) {
+                    errors.push(format!("Button {} long_press_threshold_ms {} out of range (50-5000)", i + 1, ms));
+                }
+            }
+            // mode='keytimes' carries its cycle data in short[]/long[]; the legacy
+            // keytimes/states fields are meaningless there and forbidden by the editor.
+            // Other modes still accept them with a runtime deprecation warning from the firmware.
+            if button.mode == ButtonMode::Keytimes {
+                if button.keytimes.is_some() {
+                    errors.push(format!("Button {} 'keytimes' field is not allowed on mode='keytimes' (use short[]/long[])", i + 1));
+                }
+                if button.states.is_some() {
+                    errors.push(format!("Button {} 'states' field is not allowed on mode='keytimes' (use short[]/long[])", i + 1));
                 }
             }
         }
@@ -988,6 +1011,100 @@ mod tests {
                 );
             }
         }
+    }
+
+    // --- Validation tests for keytimes-mode and long_press_threshold_ms (#48 review fixes) ---
+
+    fn _std10_minimal() -> MidiCaptainConfig {
+        let mut buttons = Vec::new();
+        for i in 0..10 {
+            buttons.push(ButtonConfig {
+                label: format!("B{}", i + 1),
+                color: ButtonColor::Red,
+                message_type: MessageType::Cc,
+                mode: ButtonMode::Toggle,
+                off_mode: OffMode::Dim,
+                channel: None, cc: Some(20 + i as u8), cc_on: None, cc_off: None,
+                note: None, velocity_on: None, velocity_off: None,
+                program: None, pc_step: None, flash_ms: None,
+                select_group: None, select_repress: None,
+                keytimes: None, states: None,
+                hid_action: None, hid_key: None, hid_modifier: None, hid_delay_ms: None,
+                short: None, long: None, long_press_threshold_ms: None,
+            });
+        }
+        MidiCaptainConfig {
+            device: DeviceType::Std10, global_channel: None, usb_drive_name: None,
+            dev_mode: None, midi_thru_usb_to_din: None, midi_thru_din_to_usb: None,
+            midi_thru_din_to_din: None, midi_thru_usb_to_usb: None,
+            buttons, encoder: None, expression: None, display: None,
+            long_press_threshold_ms: None,
+        }
+    }
+
+    #[test]
+    fn test_validate_global_long_press_threshold_ms_in_range() {
+        let mut cfg = _std10_minimal();
+        cfg.long_press_threshold_ms = Some(500);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_global_long_press_threshold_ms_below_range() {
+        let mut cfg = _std10_minimal();
+        cfg.long_press_threshold_ms = Some(49);
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("Global long_press_threshold_ms 49")));
+    }
+
+    #[test]
+    fn test_validate_global_long_press_threshold_ms_above_range() {
+        let mut cfg = _std10_minimal();
+        cfg.long_press_threshold_ms = Some(5001);
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("Global long_press_threshold_ms 5001")));
+    }
+
+    #[test]
+    fn test_validate_per_button_long_press_threshold_ms_out_of_range() {
+        let mut cfg = _std10_minimal();
+        cfg.buttons[0].long_press_threshold_ms = Some(10);
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("Button 1 long_press_threshold_ms 10")));
+    }
+
+    #[test]
+    fn test_validate_per_button_long_press_threshold_ms_in_range() {
+        let mut cfg = _std10_minimal();
+        cfg.buttons[0].long_press_threshold_ms = Some(750);
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_keytimes_field_rejected_on_keytimes_mode() {
+        let mut cfg = _std10_minimal();
+        cfg.buttons[0].mode = ButtonMode::Keytimes;
+        cfg.buttons[0].keytimes = Some(3);
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("Button 1 'keytimes' field is not allowed on mode='keytimes'")));
+    }
+
+    #[test]
+    fn test_validate_states_field_rejected_on_keytimes_mode() {
+        let mut cfg = _std10_minimal();
+        cfg.buttons[0].mode = ButtonMode::Keytimes;
+        cfg.buttons[0].states = Some(Vec::new());
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("Button 1 'states' field is not allowed on mode='keytimes'")));
+    }
+
+    #[test]
+    fn test_validate_keytimes_field_allowed_on_toggle_mode() {
+        // Legacy field still accepted on non-keytimes modes (firmware emits deprecation warning).
+        let mut cfg = _std10_minimal();
+        cfg.buttons[0].mode = ButtonMode::Toggle;
+        cfg.buttons[0].keytimes = Some(3);
+        assert!(cfg.validate().is_ok());
     }
 
     #[test]

--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -413,6 +413,21 @@ pub struct MidiCaptainConfig {
     /// needing to hold Switch 1.  Defaults to false (performance mode).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_mode: Option<bool>,
+    /// MIDI Thru: USB input -> 5-pin DIN output (cross-thru). Default: true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_usb_to_din: Option<bool>,
+    /// MIDI Thru: 5-pin DIN input -> USB output (cross-thru). Default: true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_din_to_usb: Option<bool>,
+    /// MIDI Thru: 5-pin DIN input -> 5-pin DIN output (classic MIDI THRU
+    /// pass-through for daisy-chaining controllers downstream). Default: true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_din_to_din: Option<bool>,
+    /// MIDI Thru: USB input -> USB output (host loopback). Default: false —
+    /// enabling can cause duplicate notes or feedback when the DAW also has
+    /// MIDI echo enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub midi_thru_usb_to_usb: Option<bool>,
     pub buttons: Vec<ButtonConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoder: Option<EncoderConfig>,
@@ -813,6 +828,50 @@ mod tests {
         let reserialized = serde_json::to_string(&config).unwrap();
         let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
         assert_eq!(config2.dev_mode, Some(true));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_usb_to_din() {
+        let json = r#"{ "buttons": [], "midi_thru_usb_to_din": false }"#;
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_usb_to_din, Some(false));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_usb_to_din, Some(false));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_din_to_usb() {
+        let json = r#"{ "buttons": [], "midi_thru_din_to_usb": false }"#;
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_din_to_usb, Some(false));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_din_to_usb, Some(false));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_din_to_din() {
+        let json = r#"{ "buttons": [], "midi_thru_din_to_din": false }"#;
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_din_to_din, Some(false));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_din_to_din, Some(false));
+    }
+
+    #[test]
+    fn test_roundtrip_midi_thru_usb_to_usb() {
+        let json = r#"{ "buttons": [], "midi_thru_usb_to_usb": true }"#;
+        let config: MidiCaptainConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.midi_thru_usb_to_usb, Some(true));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.midi_thru_usb_to_usb, Some(true));
     }
 
     /// Round-trip every shipped firmware config file: parse → serialize → parse,

--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -28,6 +28,26 @@ pub enum ButtonMode {
     Momentary,
     Flash,
     Select,
+    /// Multi-state cycle with short/long press timing (#48). Carries its message data
+    /// inside short[]/long[] KeytimesEntry arrays rather than at the button level.
+    Keytimes,
+}
+
+/// Color for a keytimes-mode cycle entry. Includes "off" explicitly (LED dark)
+/// in addition to the standard ButtonColor palette.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CycleEntryColor {
+    Red,
+    Green,
+    Blue,
+    Yellow,
+    Cyan,
+    Magenta,
+    Orange,
+    Purple,
+    White,
+    Off,
 }
 
 /// Behavior when re-pressing the already-active member of a select group.
@@ -82,6 +102,68 @@ pub enum HidModifier {
     Alt,
     Option,
     Windows,
+}
+
+/// One MIDI/HID message fired from a keytimes-mode cycle entry's down or up slot.
+/// Discriminated by the `type` field (serde tagged union).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum KeytimesMessage {
+    Cc {
+        cc: u8,
+        value: u8,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<u8>,
+    },
+    Note {
+        note: u8,
+        velocity: u8,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<u8>,
+    },
+    Pc {
+        program: u8,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<u8>,
+    },
+    PcInc {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        step: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<u8>,
+    },
+    PcDec {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        step: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<u8>,
+    },
+    Hid {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        action: Option<HidAction>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        modifier: Option<HidModifier>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        delay_ms: Option<u16>,
+    },
+}
+
+/// One entry in a keytimes-mode cycle (short or long). Optional down/up message
+/// arrays plus color/dim/label per entry.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KeytimesEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub down: Option<Vec<KeytimesMessage>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub up: Option<Vec<KeytimesMessage>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<CycleEntryColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dim: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// Per-state overrides for keytimes cycling
@@ -173,6 +255,13 @@ pub struct ButtonConfig {
     pub hid_modifier: Option<HidModifier>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hid_delay_ms: Option<u16>,
+    // Keytimes-mode fields (#48) — only meaningful when mode == "keytimes"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short: Option<Vec<KeytimesEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long: Option<Vec<KeytimesEntry>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long_press_threshold_ms: Option<u16>,
 }
 
 fn is_default_off_mode(mode: &OffMode) -> bool {
@@ -331,6 +420,10 @@ pub struct MidiCaptainConfig {
     pub expression: Option<ExpressionPedals>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<DisplayConfig>,
+    /// Global default long-press threshold in milliseconds for keytimes-mode buttons (#48).
+    /// Per-button overrides allowed via ButtonConfig.long_press_threshold_ms.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long_press_threshold_ms: Option<u16>,
 }
 
 impl MidiCaptainConfig {

--- a/config-editor/src-tauri/src/device.rs
+++ b/config-editor/src-tauri/src/device.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "windows"))]
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher, Event, EventKind};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Sender, Receiver};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -115,7 +115,7 @@ pub struct DetectedDevice {
 
 /// Get the volume name for a given path
 #[cfg(target_os = "windows")]
-fn get_volume_name(path: &PathBuf) -> Option<String> {
+fn get_volume_name(path: &Path) -> Option<String> {
     use std::os::windows::ffi::OsStrExt;
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
@@ -152,7 +152,7 @@ fn get_volume_name(path: &PathBuf) -> Option<String> {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn get_volume_name(path: &PathBuf) -> Option<String> {
+fn get_volume_name(path: &Path) -> Option<String> {
     path.file_name()?.to_str().map(|s| s.to_string())
 }
 
@@ -164,7 +164,7 @@ fn get_volume_name(path: &PathBuf) -> Option<String> {
 ///    (has a known `"device"` value: `"std10"`, `"mini6"`, `"nano4"`, `"duo2"`, or `"one1"`).
 ///    This covers user-renamed drives (e.g. renamed in Finder) where the
 ///    volume name no longer matches the default "MIDICAPTAIN".
-fn check_volume(path: &PathBuf) -> Option<DetectedDevice> {
+fn check_volume(path: &Path) -> Option<DetectedDevice> {
     let name = get_volume_name(path)?;
     let config_path = path.join("config.json");
     let has_config = config_path.exists();
@@ -174,7 +174,7 @@ fn check_volume(path: &PathBuf) -> Option<DetectedDevice> {
     if is_known_name || is_midi_captain_config(&config_path) {
         Some(DetectedDevice {
             name: name.to_string(),
-            path: path.clone(),
+            path: path.to_path_buf(),
             config_path,
             has_config,
         })

--- a/config-editor/src-tauri/src/device.rs
+++ b/config-editor/src-tauri/src/device.rs
@@ -531,7 +531,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = check_volume(&dir.path().to_path_buf());
+        let result = check_volume(dir.path());
         assert!(result.is_some(), "Custom-named volume should be detected when config name matches");
         let device = result.unwrap();
         assert!(device.has_config);
@@ -551,7 +551,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = check_volume(&dir.path().to_path_buf());
+        let result = check_volume(dir.path());
         assert!(result.is_some(), "Volume with valid MIDI Captain config should be accepted regardless of name");
     }
 
@@ -561,7 +561,7 @@ mod tests {
         // A volume with an unknown name AND no config.json should NOT be detected
         let dir = tempfile::TempDir::with_prefix("RANDOMDRIVE").unwrap();
         // No config.json written
-        let result = check_volume(&dir.path().to_path_buf());
+        let result = check_volume(dir.path());
         assert!(result.is_none(), "Unknown volume with no config should not be detected");
     }
 

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import ColorSelect from './ColorSelect.svelte';
+  import KeytimesEditor from './KeytimesEditor.svelte';
   import type { ButtonConfig, ButtonColor, ButtonMode, OffMode, MessageType } from '$lib/types';
-  import { MESSAGE_TYPE_LABELS } from '$lib/types';
+  import { MESSAGE_TYPE_LABELS, BUTTON_MODE_LABELS } from '$lib/types';
   import { validationErrors, syncButtonStates, selectGroupNames } from '$lib/formStore';
 
   interface Props {
@@ -31,6 +32,7 @@
   // Select mode (radio group) is valid only on plain PC and CC types.
   let canSelectMode = $derived(isPC || isCC);
   let isSelectMode = $derived(button.mode === 'select');
+  let isKeytimesMode = $derived(button.mode === 'keytimes');
   let datalistId = $derived(`${idPrefix}-select-groups`);
 
   function handleLabelChange(e: Event) {
@@ -281,6 +283,7 @@
     {/if}
   </div>
 
+  {#if !isKeytimesMode}
   {#if isCC}
     <div class="field">
       <label class="field-label" for={fieldId('cc')}>CC:</label>
@@ -419,6 +422,7 @@
     />
     {#if keytimesError}<span class="error-text">{keytimesError}</span>{/if}
   </div>
+  {/if}<!-- /!isKeytimesMode -->
 
   <div class="field">
     <span class="field-label">LED Color:</span>
@@ -428,21 +432,20 @@
     />
   </div>
 
-  {#if showMode}
-    <div class="field">
-      <label class="field-label" for={fieldId('mode')}>Mode:</label>
-      <select id={fieldId('mode')} class="select" value={button.mode || (isPCType ? 'flash' : 'toggle')} onchange={handleModeChange} disabled={disabled}>
-        {#if isPCType}
-          <option value="flash">Flash</option>
-        {/if}
-        <option value="toggle">Toggle</option>
-        <option value="momentary">Momentary</option>
-        {#if canSelectMode}
-          <option value="select">Select</option>
-        {/if}
-      </select>
-    </div>
-  {/if}
+  <div class="field">
+    <label class="field-label" for={fieldId('mode')}>Mode:</label>
+    <select id={fieldId('mode')} class="select" value={button.mode || (isPCType ? 'flash' : 'toggle')} onchange={handleModeChange} disabled={disabled}>
+      {#if isPCType}
+        <option value="flash">{BUTTON_MODE_LABELS.flash}</option>
+      {/if}
+      <option value="toggle">{BUTTON_MODE_LABELS.toggle}</option>
+      <option value="momentary">{BUTTON_MODE_LABELS.momentary}</option>
+      {#if canSelectMode}
+        <option value="select">{BUTTON_MODE_LABELS.select}</option>
+      {/if}
+      <option value="keytimes">{BUTTON_MODE_LABELS.keytimes}</option>
+    </select>
+  </div>
 
   {#if canSelectMode && isSelectMode}
     <div class="field">
@@ -483,6 +486,7 @@
     </div>
   {/if}
 
+  {#if !isKeytimesMode}
   <div class="field">
     <label class="field-label" for={fieldId('off-mode')}>LED Off Mode:</label>
     <select id={fieldId('off-mode')} class="select" value={button.off_mode || 'dim'} onchange={handleOffModeChange} disabled={disabled}>
@@ -490,8 +494,21 @@
       <option value="off">Off</option>
     </select>
   </div>
+  {/if}
 
-  {#if hasKeytimes && !disabled}
+  {#if isKeytimesMode && !disabled}
+    <KeytimesEditor button={button} index={index} globalChannel={globalChannel} />
+  {/if}
+
+  {#if hasKeytimes && !isKeytimesMode}
+    <div class="deprecation-notice" role="status">
+      <strong>Deprecated:</strong>
+      The <code>keytimes</code> field on non-keytimes modes is deprecated and will be removed in v3.0.
+      Switch this button to <strong>Mode: Keytimes (short/long)</strong> to use the new cycle model with full long-press support.
+    </div>
+  {/if}
+
+  {#if hasKeytimes && !isKeytimesMode && !disabled}
     <div class="states-section">
       <span class="states-label">States ({button.states?.length ?? 0}):</span>
       {#each (button.states ?? []) as state, si}
@@ -809,5 +826,23 @@
     font-size: 0.875rem;
     font-weight: 500;
     pointer-events: none;
+  }
+
+  .deprecation-notice {
+    flex-basis: 100%;
+    margin: 0.5rem 0;
+    padding: 0.5rem 0.75rem;
+    background: #fff8e1;
+    border: 1px solid #ffd54f;
+    border-radius: 4px;
+    color: #5a4a00;
+    font-size: 0.8125rem;
+  }
+
+  .deprecation-notice code {
+    background: rgba(0, 0, 0, 0.08);
+    padding: 0 0.25rem;
+    border-radius: 2px;
+    font-family: monospace;
   }
 </style>

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -407,21 +407,26 @@
     </div>
   {/if}
 
-  <div class="field">
-    <label class="field-label" for={fieldId('keytimes')}>Keytimes:</label>
-    <input
-      id={fieldId('keytimes')}
-      type="number"
-      class="input-cc"
-      class:error={!!keytimesError}
-      value={button.keytimes ?? 1}
-      onblur={handleKeytimesChange}
-      disabled={disabled}
-      min="1"
-      max="99"
-    />
-    {#if keytimesError}<span class="error-text">{keytimesError}</span>{/if}
-  </div>
+  {#if hasKeytimes}
+    <div class="field">
+      <label class="field-label" for={fieldId('keytimes')}>
+        Keytimes:
+        <span class="legacy-tag" title="Deprecated; will be removed in v3.0. Switch to Mode: Keytimes for the new cycle model.">legacy</span>
+      </label>
+      <input
+        id={fieldId('keytimes')}
+        type="number"
+        class="input-cc"
+        class:error={!!keytimesError}
+        value={button.keytimes ?? 1}
+        onblur={handleKeytimesChange}
+        disabled={disabled}
+        min="1"
+        max="99"
+      />
+      {#if keytimesError}<span class="error-text">{keytimesError}</span>{/if}
+    </div>
+  {/if}
   {/if}<!-- /!isKeytimesMode -->
 
   <div class="field">
@@ -844,5 +849,19 @@
     padding: 0 0.25rem;
     border-radius: 2px;
     font-family: monospace;
+  }
+
+  .legacy-tag {
+    display: inline-block;
+    margin-left: 0.25rem;
+    padding: 0 0.25rem;
+    background: #fff3cd;
+    border: 1px solid #d4a017;
+    border-radius: 3px;
+    color: #5a4a00;
+    font-size: 0.6875rem;
+    font-weight: normal;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
   }
 </style>

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -248,20 +248,22 @@
     {/if}
   </div>
 
-  <div class="field">
-    <label class="field-label" for={fieldId('type')}>Type:</label>
-    <select
-      id={fieldId('type')}
-      class="select"
-      value={button.type ?? 'cc'}
-      onchange={handleTypeChange}
-      disabled={disabled}
-    >
-      {#each Object.entries(MESSAGE_TYPE_LABELS) as [value, label]}
-        <option {value}>{label}</option>
-      {/each}
-    </select>
-  </div>
+  {#if !isKeytimesMode}
+    <div class="field">
+      <label class="field-label" for={fieldId('type')}>Type:</label>
+      <select
+        id={fieldId('type')}
+        class="select"
+        value={button.type ?? 'cc'}
+        onchange={handleTypeChange}
+        disabled={disabled}
+      >
+        {#each Object.entries(MESSAGE_TYPE_LABELS) as [value, label]}
+          <option {value}>{label}</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
 
   <div class="field">
     <label class="field-label" for={fieldId('channel')}>Channel:</label>

--- a/config-editor/src/lib/components/ButtonRow.svelte
+++ b/config-editor/src/lib/components/ButtonRow.svelte
@@ -493,15 +493,18 @@
     </div>
   {/if}
 
-  {#if !isKeytimesMode}
   <div class="field">
-    <label class="field-label" for={fieldId('off-mode')}>LED Off Mode:</label>
-    <select id={fieldId('off-mode')} class="select" value={button.off_mode || 'dim'} onchange={handleOffModeChange} disabled={disabled}>
+    <label class="field-label" for={fieldId('off-mode')}>
+      {isKeytimesMode ? 'LED Start Mode' : 'LED Off Mode'}:
+    </label>
+    <select id={fieldId('off-mode')} class="select" value={button.off_mode || 'dim'} onchange={handleOffModeChange} disabled={disabled}
+            title={isKeytimesMode
+              ? 'LED state at boot, before any cycle entry has rendered. After the first press, the cycle entry takes over.'
+              : 'LED state when the button is in its off/idle state.'}>
       <option value="dim">Dim</option>
       <option value="off">Off</option>
     </select>
   </div>
-  {/if}
 
   {#if isKeytimesMode && !disabled}
     <KeytimesEditor button={button} index={index} globalChannel={globalChannel} />

--- a/config-editor/src/lib/components/ConfigForm.svelte
+++ b/config-editor/src/lib/components/ConfigForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, type Snippet } from 'svelte';
-  import { isDirty, canUndo, canRedo, undo, redo, validationErrors, config } from '$lib/formStore';
+  import { isDirty, canUndo, canRedo, undo, redo, validationErrors, config, normalizeConfig } from '$lib/formStore';
   
   interface Props {
     onSave: () => void;
@@ -22,7 +22,9 @@
   }
 
   function handleViewJson() {
-    jsonText = JSON.stringify($config, null, 2);
+    // normalizeConfig strips type-irrelevant fields and ephemeral __uiId markers,
+    // so the preview matches what would actually be written to disk.
+    jsonText = JSON.stringify(normalizeConfig(structuredClone($config)), null, 2);
     showJsonModal = true;
   }
   

--- a/config-editor/src/lib/components/KeytimesEditor.svelte
+++ b/config-editor/src/lib/components/KeytimesEditor.svelte
@@ -85,7 +85,7 @@
         <p class="kt-empty">(no entries — button is silent for {cycle} press events)</p>
       {/if}
 
-      {#each entries as entry, ei (ei)}
+      {#each entries as entry, ei ((entry as { __uiId?: number }).__uiId ?? ei)}
         <div class="kt-entry">
           <div class="kt-entry-header">
             <span class="kt-entry-num">#{ei + 1}</span>
@@ -138,7 +138,7 @@
                   <span class="kt-slot-empty-hint">(empty — this event fires nothing)</span>
                 {/if}
               </div>
-              {#each messages as msg, mi (mi)}
+              {#each messages as msg, mi ((msg as { __uiId?: number }).__uiId ?? mi)}
                 <KeytimesMessageEditor
                   buttonIndex={index}
                   cycle={cycle as 'short' | 'long'}

--- a/config-editor/src/lib/components/KeytimesEditor.svelte
+++ b/config-editor/src/lib/components/KeytimesEditor.svelte
@@ -127,12 +127,16 @@
           {#each ['down', 'up'] as slot (slot)}
             {@const messages = (slot === 'down' ? entry.down : entry.up) ?? []}
             <div class="kt-slot">
-              <div class="kt-slot-header">
+              <div class="kt-slot-header"
+                   title="An empty slot does nothing on this event — no MIDI fires and the LED color/label/dim do not update. Add at least one message to make this event take effect.">
                 <span class="kt-slot-label">{cycle}_{slot}:</span>
                 <button type="button" class="kt-add-msg"
                         onclick={() => addKeytimesMessage(index, cycle as 'short' | 'long', ei, slot as 'down' | 'up')}>
                   + message
                 </button>
+                {#if messages.length === 0}
+                  <span class="kt-slot-empty-hint">(empty — this event fires nothing)</span>
+                {/if}
               </div>
               {#each messages as msg, mi (mi)}
                 <KeytimesMessageEditor
@@ -264,6 +268,12 @@
     font-family: monospace;
     font-size: 0.8125rem;
     color: #555;
+  }
+
+  .kt-slot-empty-hint {
+    font-size: 0.75rem;
+    color: #999;
+    font-style: italic;
   }
 
   .kt-add-msg {

--- a/config-editor/src/lib/components/KeytimesEditor.svelte
+++ b/config-editor/src/lib/components/KeytimesEditor.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+  import KeytimesMessageEditor from './KeytimesMessageEditor.svelte';
+  import type { ButtonConfig, KeytimesEntry, CycleEntryColor } from '$lib/types';
+  import { BUTTON_COLORS } from '$lib/types';
+  import {
+    addKeytimesEntry,
+    removeKeytimesEntry,
+    addKeytimesMessage,
+    updateField,
+    validationErrors,
+  } from '$lib/formStore';
+
+  interface Props {
+    button: ButtonConfig;
+    index: number;
+    globalChannel: number;
+  }
+
+  let { button, index, globalChannel }: Props = $props();
+
+  // Color palette for cycle entries: standard button colors plus "off".
+  const CYCLE_COLORS: CycleEntryColor[] = [
+    'red', 'green', 'blue', 'yellow', 'cyan', 'magenta', 'orange', 'purple', 'white', 'off',
+  ];
+
+  // Per-entry color picker: shows current value, swatch, and clear-to-inherit option.
+  function setEntryColor(cycle: 'short' | 'long', entryIndex: number, color: CycleEntryColor | undefined) {
+    updateField(`buttons[${index}].${cycle}[${entryIndex}].color`, color);
+  }
+
+  function setEntryDim(cycle: 'short' | 'long', entryIndex: number, dim: boolean) {
+    updateField(`buttons[${index}].${cycle}[${entryIndex}].dim`, dim ? true : undefined);
+  }
+
+  function setEntryLabel(cycle: 'short' | 'long', entryIndex: number, label: string) {
+    updateField(`buttons[${index}].${cycle}[${entryIndex}].label`, label === '' ? undefined : label);
+  }
+
+  function handleThresholdChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    if (target.value === '') {
+      updateField(`buttons[${index}].long_press_threshold_ms`, undefined);
+    } else {
+      updateField(`buttons[${index}].long_press_threshold_ms`, parseInt(target.value));
+    }
+  }
+
+  let thresholdError = $derived($validationErrors.get(`buttons[${index}].long_press_threshold_ms`));
+</script>
+
+<div class="keytimes-editor">
+  <div class="kt-threshold-row">
+    <label class="inline">
+      Long-press threshold (ms):
+      <input type="number" min="50" max="5000"
+             value={button.long_press_threshold_ms ?? ''}
+             placeholder="500 (global default)"
+             oninput={handleThresholdChange}
+             class:error={!!thresholdError}
+             title="Optional per-button override. Falls back to global long_press_threshold_ms (default 500ms)." />
+    </label>
+    {#if thresholdError}
+      <span class="kt-error">{thresholdError}</span>
+    {/if}
+  </div>
+
+  {#each ['short', 'long'] as cycle (cycle)}
+    {@const entries = (cycle === 'short' ? button.short : button.long) ?? []}
+    <section class="kt-cycle">
+      <header class="kt-cycle-header">
+        <h4>{cycle === 'short' ? 'Short Press Cycle' : 'Long Press Cycle'}</h4>
+        <span class="kt-cycle-hint">
+          {#if cycle === 'short'}
+            Cycles on every short tap. <code>short_down</code> fires on press, <code>short_up</code> fires on quick release (before threshold).
+          {:else}
+            Cycles on every long hold. <code>long_down</code> fires when threshold elapses; <code>long_up</code> fires on release after threshold.
+          {/if}
+        </span>
+        <button type="button" class="kt-add" onclick={() => addKeytimesEntry(index, cycle as 'short' | 'long')}>
+          + Add entry
+        </button>
+      </header>
+
+      {#if entries.length === 0}
+        <p class="kt-empty">(no entries — button is silent for {cycle} press events)</p>
+      {/if}
+
+      {#each entries as entry, ei (ei)}
+        <div class="kt-entry">
+          <div class="kt-entry-header">
+            <span class="kt-entry-num">#{ei + 1}</span>
+            <label class="inline">
+              Color:
+              <select value={entry.color ?? ''}
+                      onchange={(e) => setEntryColor(cycle as 'short' | 'long', ei, (e.target as HTMLSelectElement).value === '' ? undefined : (e.target as HTMLSelectElement).value as CycleEntryColor)}>
+                <option value="">(inherit)</option>
+                {#each CYCLE_COLORS as c}
+                  <option value={c}>{c}</option>
+                {/each}
+              </select>
+              {#if entry.color && entry.color !== 'off'}
+                <span class="color-swatch" style="background: {BUTTON_COLORS[entry.color as keyof typeof BUTTON_COLORS]}"></span>
+              {:else if entry.color === 'off'}
+                <span class="color-swatch off" title="LED dark">⌀</span>
+              {/if}
+            </label>
+            <label class="inline">
+              <input type="checkbox"
+                     checked={entry.dim ?? false}
+                     onchange={(e) => setEntryDim(cycle as 'short' | 'long', ei, (e.target as HTMLInputElement).checked)} />
+              dim
+            </label>
+            <label class="inline">
+              Label:
+              <input type="text" maxlength="6"
+                     value={entry.label ?? ''}
+                     placeholder="(inherit)"
+                     oninput={(e) => setEntryLabel(cycle as 'short' | 'long', ei, (e.target as HTMLInputElement).value)} />
+            </label>
+            <button type="button" class="kt-remove-entry"
+                    onclick={() => removeKeytimesEntry(index, cycle as 'short' | 'long', ei)}
+                    title="Remove this entry">
+              Remove entry
+            </button>
+          </div>
+
+          {#each ['down', 'up'] as slot (slot)}
+            {@const messages = (slot === 'down' ? entry.down : entry.up) ?? []}
+            <div class="kt-slot">
+              <div class="kt-slot-header">
+                <span class="kt-slot-label">{cycle}_{slot}:</span>
+                <button type="button" class="kt-add-msg"
+                        onclick={() => addKeytimesMessage(index, cycle as 'short' | 'long', ei, slot as 'down' | 'up')}>
+                  + message
+                </button>
+              </div>
+              {#each messages as msg, mi (mi)}
+                <KeytimesMessageEditor
+                  buttonIndex={index}
+                  cycle={cycle as 'short' | 'long'}
+                  entryIndex={ei}
+                  slot={slot as 'down' | 'up'}
+                  msgIndex={mi}
+                  message={msg}
+                  globalChannel={globalChannel}
+                />
+              {/each}
+            </div>
+          {/each}
+        </div>
+      {/each}
+    </section>
+  {/each}
+</div>
+
+<style>
+  .keytimes-editor {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    background: #f8f9fa;
+    border: 1px solid #ccd;
+    border-radius: 4px;
+  }
+
+  .kt-threshold-row {
+    margin-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .kt-cycle {
+    margin-top: 0.75rem;
+    padding: 0.5rem;
+    background: white;
+    border: 1px solid #d0d6e0;
+    border-radius: 4px;
+  }
+
+  .kt-cycle-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .kt-cycle-header h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #234;
+  }
+
+  .kt-cycle-hint {
+    font-size: 0.75rem;
+    color: #666;
+    flex: 1 1 auto;
+    min-width: 200px;
+  }
+
+  .kt-cycle-hint code {
+    background: #eee;
+    padding: 0 0.25rem;
+    border-radius: 2px;
+    font-family: monospace;
+  }
+
+  .kt-add {
+    padding: 0.25rem 0.5rem;
+    background: #e4f0ff;
+    border: 1px solid #6aa;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.8125rem;
+  }
+
+  .kt-add:hover {
+    background: #d4e8ff;
+  }
+
+  .kt-empty {
+    margin: 0.5rem 0;
+    color: #888;
+    font-style: italic;
+    font-size: 0.8125rem;
+  }
+
+  .kt-entry {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    background: #fafbfd;
+    border: 1px solid #d8dde5;
+    border-radius: 3px;
+  }
+
+  .kt-entry-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .kt-entry-num {
+    font-weight: bold;
+    color: #456;
+  }
+
+  .kt-slot {
+    margin: 0.25rem 0 0.25rem 0.5rem;
+    padding: 0.25rem;
+    border-left: 2px solid #cde;
+    padding-left: 0.5rem;
+  }
+
+  .kt-slot-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .kt-slot-label {
+    font-family: monospace;
+    font-size: 0.8125rem;
+    color: #555;
+  }
+
+  .kt-add-msg {
+    padding: 0.125rem 0.4rem;
+    background: #f0f0f0;
+    border: 1px solid #bbb;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.75rem;
+  }
+
+  .kt-add-msg:hover {
+    background: #e0e0e0;
+  }
+
+  .kt-remove-entry {
+    margin-left: auto;
+    padding: 0.125rem 0.5rem;
+    background: #fee;
+    border: 1px solid #d99;
+    color: #c00;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.75rem;
+  }
+
+  .kt-remove-entry:hover {
+    background: #fdd;
+  }
+
+  label.inline {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+  }
+
+  input[type="number"], input[type="text"], select {
+    padding: 0.125rem 0.25rem;
+    border: 1px solid #bbb;
+    border-radius: 3px;
+    font-size: 0.8125rem;
+  }
+
+  input[type="number"] { width: 5rem; }
+  input[type="text"] { width: 5rem; }
+
+  input.error {
+    border-color: #c00;
+    background: #fef0f0;
+  }
+
+  .kt-error {
+    color: #c00;
+    font-size: 0.75rem;
+  }
+
+  .color-swatch {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 1px solid #666;
+    vertical-align: middle;
+  }
+
+  .color-swatch.off {
+    background: #222;
+    color: #888;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+  }
+</style>

--- a/config-editor/src/lib/components/KeytimesMessageEditor.svelte
+++ b/config-editor/src/lib/components/KeytimesMessageEditor.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+  import type { KeytimesMessage, MessageType } from '$lib/types';
+  import { MESSAGE_TYPE_LABELS } from '$lib/types';
+  import {
+    removeKeytimesMessage,
+    setKeytimesMessageType,
+    updateField,
+    validationErrors,
+  } from '$lib/formStore';
+
+  interface Props {
+    buttonIndex: number;
+    cycle: 'short' | 'long';
+    entryIndex: number;
+    slot: 'down' | 'up';
+    msgIndex: number;
+    message: KeytimesMessage;
+    globalChannel: number;
+  }
+
+  let { buttonIndex, cycle, entryIndex, slot, msgIndex, message, globalChannel }: Props = $props();
+
+  // Path prefix used for both updateField() and validation error lookups.
+  let pathPrefix = $derived(`buttons[${buttonIndex}].${cycle}[${entryIndex}].${slot}[${msgIndex}]`);
+
+  // Display the configured channel as 1-16, fall back to global if undefined.
+  // HID messages have no channel field; the channel input is hidden for HID below.
+  let messageChannel = $derived(
+    message.type !== 'hid' ? (message as { channel?: number }).channel : undefined
+  );
+  let displayChannel = $derived(
+    messageChannel !== undefined ? messageChannel + 1 : undefined
+  );
+  let effectiveChannel = $derived(
+    messageChannel !== undefined ? messageChannel + 1 : globalChannel + 1
+  );
+
+  function handleTypeChange(e: Event) {
+    const newType = (e.target as HTMLSelectElement).value as MessageType;
+    setKeytimesMessageType(buttonIndex, cycle, entryIndex, slot, msgIndex, newType);
+  }
+
+  function handleChannelChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    if (target.value === '') {
+      updateField(`${pathPrefix}.channel`, undefined);
+    } else {
+      // Convert 1-16 display to 0-15 storage
+      updateField(`${pathPrefix}.channel`, parseInt(target.value) - 1);
+    }
+  }
+
+  function handleIntField(field: string, e: Event) {
+    const target = e.target as HTMLInputElement;
+    updateField(`${pathPrefix}.${field}`, parseInt(target.value));
+  }
+
+  function handleStringField(field: string, e: Event) {
+    const target = e.target as HTMLInputElement;
+    updateField(`${pathPrefix}.${field}`, target.value === '' ? undefined : target.value);
+  }
+
+  function handleRemove() {
+    removeKeytimesMessage(buttonIndex, cycle, entryIndex, slot, msgIndex);
+  }
+
+  // Field error lookups
+  function errFor(field: string): string | undefined {
+    return $validationErrors.get(`${pathPrefix}.${field}`);
+  }
+</script>
+
+<div class="kt-message">
+  <div class="kt-message-row">
+    <label class="inline">
+      Type:
+      <select value={message.type} onchange={handleTypeChange}>
+        {#each Object.entries(MESSAGE_TYPE_LABELS) as [val, label]}
+          <option value={val}>{label}</option>
+        {/each}
+      </select>
+    </label>
+
+    {#if message.type === 'cc'}
+      <label class="inline">
+        CC:
+        <input type="number" min="0" max="127"
+               value={message.cc}
+               oninput={(e) => handleIntField('cc', e)}
+               class:error={!!errFor('cc')} />
+      </label>
+      <label class="inline">
+        Value:
+        <input type="number" min="0" max="127"
+               value={message.value}
+               oninput={(e) => handleIntField('value', e)}
+               class:error={!!errFor('value')} />
+      </label>
+    {:else if message.type === 'note'}
+      <label class="inline">
+        Note:
+        <input type="number" min="0" max="127"
+               value={message.note}
+               oninput={(e) => handleIntField('note', e)}
+               class:error={!!errFor('note')} />
+      </label>
+      <label class="inline">
+        Velocity:
+        <input type="number" min="0" max="127"
+               value={message.velocity}
+               oninput={(e) => handleIntField('velocity', e)}
+               class:error={!!errFor('velocity')} />
+      </label>
+    {:else if message.type === 'pc'}
+      <label class="inline">
+        Program:
+        <input type="number" min="0" max="127"
+               value={message.program}
+               oninput={(e) => handleIntField('program', e)}
+               class:error={!!errFor('program')} />
+      </label>
+    {:else if message.type === 'pc_inc' || message.type === 'pc_dec'}
+      <label class="inline">
+        Step:
+        <input type="number" min="1" max="127"
+               value={message.step ?? 1}
+               oninput={(e) => handleIntField('step', e)}
+               class:error={!!errFor('step')} />
+      </label>
+    {:else if message.type === 'hid'}
+      <label class="inline">
+        Action:
+        <select value={message.action ?? 'send'} onchange={(e) => handleStringField('action', e)}>
+          <option value="send">send</option>
+          <option value="press">press</option>
+          <option value="release">release</option>
+          <option value="delay">delay</option>
+        </select>
+      </label>
+      {#if message.action !== 'delay'}
+        <label class="inline">
+          Key:
+          <input type="text" placeholder="A, F1, Space, ..."
+                 value={message.key ?? ''}
+                 oninput={(e) => handleStringField('key', e)} />
+        </label>
+        <label class="inline">
+          Modifier:
+          <select value={message.modifier ?? ''} onchange={(e) => handleStringField('modifier', e)}>
+            <option value="">(none)</option>
+            <option value="ctrl">ctrl</option>
+            <option value="shift">shift</option>
+            <option value="alt">alt</option>
+            <option value="option">option</option>
+            <option value="windows">windows</option>
+          </select>
+        </label>
+      {:else}
+        <label class="inline">
+          Delay ms:
+          <input type="number" min="1" max="5000"
+                 value={message.delay_ms ?? 50}
+                 oninput={(e) => handleIntField('delay_ms', e)} />
+        </label>
+      {/if}
+    {/if}
+
+    {#if message.type !== 'hid'}
+      <label class="inline">
+        Ch:
+        <input type="number" min="1" max="16"
+               value={displayChannel ?? ''}
+               placeholder={String(globalChannel + 1)}
+               oninput={handleChannelChange}
+               title="MIDI channel override (1-16). Default: {effectiveChannel}"
+               class:error={!!errFor('channel')} />
+      </label>
+    {/if}
+
+    <button type="button" class="kt-remove" onclick={handleRemove} title="Remove message">×</button>
+  </div>
+</div>
+
+<style>
+  .kt-message {
+    padding: 0.25rem 0.5rem;
+    margin: 0.25rem 0;
+    background: #fafafa;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+  }
+
+  .kt-message-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  label.inline {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+  }
+
+  input[type="number"], select, input[type="text"] {
+    padding: 0.125rem 0.25rem;
+    border: 1px solid #bbb;
+    border-radius: 3px;
+    font-size: 0.8125rem;
+  }
+
+  input[type="number"] { width: 4rem; }
+  input[type="text"] { width: 6rem; }
+  select { font-size: 0.8125rem; }
+
+  input.error {
+    border-color: #c00;
+    background: #fef0f0;
+  }
+
+  .kt-remove {
+    padding: 0 0.5rem;
+    background: #fee;
+    border: 1px solid #d88;
+    color: #c00;
+    border-radius: 3px;
+    cursor: pointer;
+    font-weight: bold;
+    margin-left: auto;
+  }
+
+  .kt-remove:hover {
+    background: #fdd;
+  }
+</style>

--- a/config-editor/src/lib/components/MidiThruSection.svelte
+++ b/config-editor/src/lib/components/MidiThruSection.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import Accordion from './Accordion.svelte';
+  import { config, updateField } from '$lib/formStore';
+
+  // Defaults: cross-thru on, DIN->DIN on (classic MIDI THRU), USB->USB off (loopback risk).
+  let usbToDin = $derived($config.midi_thru_usb_to_din ?? true);
+  let dinToUsb = $derived($config.midi_thru_din_to_usb ?? true);
+  let dinToDin = $derived($config.midi_thru_din_to_din ?? true);
+  let usbToUsb = $derived($config.midi_thru_usb_to_usb ?? false);
+
+  function onChange(field: string, e: Event) {
+    const target = e.target as HTMLInputElement;
+    updateField(field, target.checked);
+  }
+</script>
+
+<Accordion title="MIDI Thru">
+  <div class="midi-thru-section">
+    <p class="section-help">
+      Route incoming MIDI between USB and 5-pin DIN ports. Each cell of the matrix
+      controls one path from an input (row) to an output (column). Cross-thru and
+      DIN&nbsp;→&nbsp;DIN (classic MIDI THRU pass-through) are on by default.
+    </p>
+
+    <table class="thru-matrix" aria-label="MIDI Thru routing matrix">
+      <thead>
+        <tr>
+          <th scope="col" class="corner">From&nbsp;\&nbsp;To</th>
+          <th scope="col">USB</th>
+          <th scope="col">5-pin DIN</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">USB</th>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={usbToUsb}
+                onchange={(e) => onChange('midi_thru_usb_to_usb', e)}
+              />
+              <span>USB → USB</span>
+            </label>
+          </td>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={usbToDin}
+                onchange={(e) => onChange('midi_thru_usb_to_din', e)}
+              />
+              <span>USB → DIN</span>
+            </label>
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">5-pin DIN</th>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={dinToUsb}
+                onchange={(e) => onChange('midi_thru_din_to_usb', e)}
+              />
+              <span>DIN → USB</span>
+            </label>
+          </td>
+          <td>
+            <label class="cell">
+              <input
+                type="checkbox"
+                checked={dinToDin}
+                onchange={(e) => onChange('midi_thru_din_to_din', e)}
+              />
+              <span>DIN → DIN</span>
+            </label>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    {#if usbToUsb}
+      <div class="warning" role="alert">
+        <strong>⚠ USB loopback enabled.</strong>
+        Messages received on USB MIDI will be echoed back to the host. If your
+        DAW also has MIDI echo / through enabled on the same port, this will
+        cause duplicate notes or a feedback loop. Most users should leave this off.
+      </div>
+    {/if}
+
+    <details class="routing-help">
+      <summary>What does each route do?</summary>
+      <ul>
+        <li><strong>USB → DIN:</strong> forward MIDI from the computer to gear plugged into the 5-pin DIN output.</li>
+        <li><strong>DIN → USB:</strong> forward MIDI from a 5-pin source (e.g. another foot controller) to the computer.</li>
+        <li><strong>DIN → DIN:</strong> classic MIDI THRU. Forward incoming 5-pin MIDI to the 5-pin output for daisy-chaining controllers downstream.</li>
+        <li><strong>USB → USB:</strong> echo USB MIDI back to the host. Niche; off by default to avoid feedback with DAW MIDI echo.</li>
+      </ul>
+    </details>
+  </div>
+</Accordion>
+
+<style>
+  .midi-thru-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .section-help {
+    font-size: 0.875rem;
+    color: var(--text-secondary, #666);
+    margin: 0 0 0.25rem 0;
+  }
+
+  .thru-matrix {
+    border-collapse: collapse;
+    align-self: flex-start;
+    font-size: 0.9rem;
+  }
+
+  .thru-matrix th,
+  .thru-matrix td {
+    border: 1px solid var(--border, #d0d0d0);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  .thru-matrix thead th {
+    background: var(--surface-muted, #f3f3f3);
+    font-weight: 600;
+  }
+
+  .thru-matrix tbody th {
+    background: var(--surface-muted, #f8f8f8);
+    font-weight: 600;
+  }
+
+  .thru-matrix .corner {
+    background: transparent;
+    border: none;
+    font-weight: 500;
+    color: var(--text-secondary, #888);
+  }
+
+  .cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+  }
+
+  .cell input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+
+  .warning {
+    border: 1px solid #c89200;
+    background: #fff7e0;
+    color: #5a4400;
+    padding: 0.6rem 0.8rem;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    line-height: 1.4;
+  }
+
+  .routing-help {
+    font-size: 0.875rem;
+    color: var(--text-secondary, #555);
+  }
+
+  .routing-help summary {
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .routing-help ul {
+    margin: 0.5rem 0 0 1.25rem;
+    padding: 0;
+  }
+
+  .routing-help li {
+    margin-bottom: 0.25rem;
+  }
+</style>

--- a/config-editor/src/lib/formStore.ts
+++ b/config-editor/src/lib/formStore.ts
@@ -1,5 +1,5 @@
 import { writable, derived, get } from 'svelte/store';
-import type { MidiCaptainConfig, ButtonConfig, EncoderConfig, DeviceType } from './types';
+import type { MidiCaptainConfig, ButtonConfig, EncoderConfig, DeviceType, KeytimesEntry, KeytimesMessage, MessageType } from './types';
 import { validateConfig } from './validation';
 
 interface FormState {
@@ -203,6 +203,116 @@ export function updateField(path: string, value: any) {
   }, DEBOUNCE_MS);
 }
 
+// --- Keytimes-mode helpers (mode: "keytimes" cycle/message mutations) ---
+//
+// These wrap formState updates that change the *structure* of a keytimes-mode
+// button (adding/removing entries or messages). For leaf-value edits (color,
+// dim, label, individual message fields), use updateField() with a dotted path.
+
+function _defaultMessage(type: MessageType): KeytimesMessage {
+  switch (type) {
+    case 'cc':     return { type: 'cc', cc: 20, value: 127 };
+    case 'note':   return { type: 'note', note: 60, velocity: 127 };
+    case 'pc':     return { type: 'pc', program: 0 };
+    case 'pc_inc': return { type: 'pc_inc', step: 1 };
+    case 'pc_dec': return { type: 'pc_dec', step: 1 };
+    case 'hid':    return { type: 'hid', action: 'send' };
+  }
+}
+
+function _updateButton(buttonIndex: number, mutate: (btn: ButtonConfig) => void) {
+  formState.update(state => {
+    const newConfig = structuredClone(state.config);
+    const btn = newConfig.buttons[buttonIndex];
+    if (!btn) return state;
+    mutate(btn);
+    return { ...state, config: newConfig, isDirty: true };
+  });
+  validate();
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => formState.update(state => pushHistory(state)), DEBOUNCE_MS);
+}
+
+export function addKeytimesEntry(buttonIndex: number, cycle: 'short' | 'long') {
+  _updateButton(buttonIndex, btn => {
+    const arr = (btn[cycle] ?? []) as KeytimesEntry[];
+    arr.push({});
+    btn[cycle] = arr;
+  });
+}
+
+export function removeKeytimesEntry(buttonIndex: number, cycle: 'short' | 'long', entryIndex: number) {
+  _updateButton(buttonIndex, btn => {
+    const arr = btn[cycle];
+    if (!Array.isArray(arr)) return;
+    arr.splice(entryIndex, 1);
+    if (arr.length === 0) {
+      delete btn[cycle];
+    } else {
+      btn[cycle] = arr;
+    }
+  });
+}
+
+export function addKeytimesMessage(
+  buttonIndex: number,
+  cycle: 'short' | 'long',
+  entryIndex: number,
+  slot: 'down' | 'up',
+  msgType: MessageType = 'cc',
+) {
+  _updateButton(buttonIndex, btn => {
+    const arr = btn[cycle];
+    if (!Array.isArray(arr) || !arr[entryIndex]) return;
+    const entry = arr[entryIndex] as KeytimesEntry;
+    const messages = (entry[slot] ?? []) as KeytimesMessage[];
+    messages.push(_defaultMessage(msgType));
+    entry[slot] = messages;
+  });
+}
+
+export function removeKeytimesMessage(
+  buttonIndex: number,
+  cycle: 'short' | 'long',
+  entryIndex: number,
+  slot: 'down' | 'up',
+  msgIndex: number,
+) {
+  _updateButton(buttonIndex, btn => {
+    const arr = btn[cycle];
+    if (!Array.isArray(arr) || !arr[entryIndex]) return;
+    const entry = arr[entryIndex] as KeytimesEntry;
+    const messages = entry[slot];
+    if (!Array.isArray(messages)) return;
+    messages.splice(msgIndex, 1);
+    if (messages.length === 0) {
+      delete entry[slot];
+    } else {
+      entry[slot] = messages;
+    }
+  });
+}
+
+export function setKeytimesMessageType(
+  buttonIndex: number,
+  cycle: 'short' | 'long',
+  entryIndex: number,
+  slot: 'down' | 'up',
+  msgIndex: number,
+  newType: MessageType,
+) {
+  // Replace the whole message with a default of the new type, since type-specific
+  // fields don't overlap across types (cc/value vs note/velocity vs program vs step vs key).
+  _updateButton(buttonIndex, btn => {
+    const arr = btn[cycle];
+    if (!Array.isArray(arr) || !arr[entryIndex]) return;
+    const entry = arr[entryIndex] as KeytimesEntry;
+    const messages = entry[slot];
+    if (!Array.isArray(messages) || !messages[msgIndex]) return;
+    messages[msgIndex] = _defaultMessage(newType);
+  });
+}
+
 export function syncButtonStates(buttonIndex: number, keytimes: number) {
   if (debounceTimer) {
     clearTimeout(debounceTimer);
@@ -366,10 +476,29 @@ export function setDevice(deviceType: DeviceType) {
 // Prevents stale cc/note/program/etc. from accumulating in the saved JSON when
 // the user switches a button's type.
 function normalizeButton(btn: ButtonConfig): ButtonConfig {
-  const type = btn.type ?? 'cc';
+  // mode: "keytimes" carries its message data inside short[]/long[] entries,
+  // not at the top of the button. Strip all legacy per-type fields here so
+  // serialized JSON stays clean if the user toggled the button through other
+  // modes before settling on keytimes.
+  if (btn.mode === 'keytimes') {
+    const { cc, cc_on, cc_off, note, velocity_on, velocity_off, program, pc_step, flash_ms,
+            hid_action, hid_key, hid_modifier, hid_delay_ms,
+            select_group, select_repress, keytimes, states, type, ...common } = btn;
+    return {
+      ...common,
+      ...(btn.short !== undefined && { short: btn.short }),
+      ...(btn.long !== undefined && { long: btn.long }),
+      ...(btn.long_press_threshold_ms !== undefined && { long_press_threshold_ms: btn.long_press_threshold_ms }),
+    };
+  }
+
+  // Non-keytimes modes: keytimes/states are deprecated but still functional in v2.0.
+  // Strip the new-mode-only fields (short/long/long_press_threshold_ms) if they leaked in.
+  const { short: _short, long: _long, long_press_threshold_ms: _lpt, ...btnWithoutKeytimesFields } = btn;
+  const type = btnWithoutKeytimesFields.type ?? 'cc';
   const { cc, cc_on, cc_off, note, velocity_on, velocity_off, program, pc_step, flash_ms,
           hid_action, hid_key, hid_modifier, hid_delay_ms,
-          select_group, select_repress, ...common } = btn;
+          select_group, select_repress, ...common } = btnWithoutKeytimesFields;
 
   // Select mode (radio-group) is valid only on PC and CC. select_group/select_repress
   // are stripped on serialize when mode != 'select' so the JSON stays clean even if

--- a/config-editor/src/lib/formStore.ts
+++ b/config-editor/src/lib/formStore.ts
@@ -59,12 +59,43 @@ export const selectGroupNames = derived(formState, $state => {
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Ephemeral UI-only ids attached to KeytimesEntry/KeytimesMessage objects so
+// Svelte {#each} blocks can key by stable identity across structuredClone edits.
+// Stripped from any config written to disk (see normalizeConfig).
+let _uiIdCounter = 0;
+function _nextUiId(): number {
+  return ++_uiIdCounter;
+}
+
+// Walk a config and assign `__uiId` to any keytimes entry/message that lacks one.
+// Mutates in place; safe to call on a freshly structuredCloned config.
+function _attachUiIds(cfg: MidiCaptainConfig): void {
+  for (const btn of cfg.buttons) {
+    for (const cycle of ['short', 'long'] as const) {
+      const entries = (btn as unknown as Record<string, unknown>)[cycle];
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries as Array<Record<string, unknown>>) {
+        if (typeof entry.__uiId !== 'number') entry.__uiId = _nextUiId();
+        for (const slot of ['down', 'up'] as const) {
+          const messages = entry[slot];
+          if (!Array.isArray(messages)) continue;
+          for (const msg of messages as Array<Record<string, unknown>>) {
+            if (typeof msg.__uiId !== 'number') msg.__uiId = _nextUiId();
+          }
+        }
+      }
+    }
+  }
+}
+
 export function loadConfig(newConfig: MidiCaptainConfig) {
   // Ensure display always exists so DisplaySection can traverse into it
   const config = { ...newConfig, display: newConfig.display ?? {} };
+  const cloned = structuredClone(config);
+  _attachUiIds(cloned);
   formState.update(_state => ({
-    config: structuredClone(config),
-    history: [structuredClone(config)],
+    config: cloned,
+    history: [structuredClone(cloned)],
     historyIndex: 0,
     validationErrors: new Map(),
     isDirty: false,
@@ -236,7 +267,7 @@ function _updateButton(buttonIndex: number, mutate: (btn: ButtonConfig) => void)
 export function addKeytimesEntry(buttonIndex: number, cycle: 'short' | 'long') {
   _updateButton(buttonIndex, btn => {
     const arr = (btn[cycle] ?? []) as KeytimesEntry[];
-    arr.push({});
+    arr.push({ __uiId: _nextUiId() } as KeytimesEntry);
     btn[cycle] = arr;
   });
 }
@@ -266,7 +297,7 @@ export function addKeytimesMessage(
     if (!Array.isArray(arr) || !arr[entryIndex]) return;
     const entry = arr[entryIndex] as KeytimesEntry;
     const messages = (entry[slot] ?? []) as KeytimesMessage[];
-    messages.push(_defaultMessage(msgType));
+    messages.push({ ..._defaultMessage(msgType), __uiId: _nextUiId() } as KeytimesMessage);
     entry[slot] = messages;
   });
 }
@@ -556,12 +587,28 @@ function normalizeButton(btn: ButtonConfig): ButtonConfig {
   }
 }
 
+// Recursively strip ephemeral `__uiId` markers from a deep-cloned config so they
+// never reach the on-disk JSON. Operates on the input in place.
+function _stripUiIds(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const v of value) _stripUiIds(v);
+  } else if (value && typeof value === 'object') {
+    delete (value as Record<string, unknown>).__uiId;
+    for (const v of Object.values(value)) _stripUiIds(v);
+  }
+}
+
 export function normalizeConfig(cfg: MidiCaptainConfig): MidiCaptainConfig {
-  const normalized: MidiCaptainConfig = { ...cfg, buttons: cfg.buttons.map(normalizeButton) };
+  // Deep clone so the ephemeral `__uiId` strip below (and any other mutations)
+  // don't reach back into the live store.
+  const cloned = structuredClone(cfg);
+  const normalized: MidiCaptainConfig = { ...cloned, buttons: cloned.buttons.map(normalizeButton) };
   // Strip display if no fields were set (avoids writing `"display": {}` for untouched configs)
   if (normalized.display && Object.values(normalized.display).every(v => v === undefined)) {
     delete normalized.display;
   }
+  // Drop UI-only stable-key markers attached to keytimes entries/messages.
+  _stripUiIds(normalized);
   return normalized;
 }
 

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -176,11 +176,11 @@ export interface ButtonConfig {
    */
   flash_ms?: number;
   /**
-   * DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays for multi-state cycling. Validator now rejects this field on non-keytimes modes.
+   * DEPRECATED on toggle/momentary/flash/select modes (firmware accepts with a deprecation warning at boot; will be removed in v3.0). Forbidden on mode='keytimes' — use short[]/long[] arrays instead.
    */
   keytimes?: number;
   /**
-   * DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays. Validator now rejects this field on non-keytimes modes.
+   * DEPRECATED on toggle/momentary/flash/select modes (firmware accepts with a deprecation warning at boot; will be removed in v3.0). Forbidden on mode='keytimes' — use short[]/long[] arrays instead.
    */
   states?: StateOverride[];
   /**

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -17,6 +17,46 @@ export type HidAction = "send" | "press" | "release" | "delay";
  * Modifier key held during the HID action. 'option' is macOS Alt; 'windows' is the Windows/Meta key.
  */
 export type HidModifier = "ctrl" | "shift" | "alt" | "option" | "windows";
+/**
+ * One MIDI/HID message fired from a keytimes-mode cycle entry's down or up slot. Discriminated by 'type'.
+ */
+export type KeytimesMessage =
+  | {
+      type: "cc";
+      cc: MidiByte;
+      value: MidiByte;
+      channel?: MidiChannel;
+    }
+  | {
+      type: "note";
+      note: MidiByte;
+      velocity: MidiByte;
+      channel?: MidiChannel;
+    }
+  | {
+      type: "pc";
+      program: MidiByte;
+      channel?: MidiChannel;
+    }
+  | {
+      type: "pc_inc" | "pc_dec";
+      step?: number;
+      channel?: MidiChannel;
+    }
+  | {
+      type: "hid";
+      action?: HidAction;
+      /**
+       * HID key name (see hid_key field on ButtonConfig for valid values).
+       */
+      key?: string;
+      modifier?: HidModifier;
+      delay_ms?: number;
+    };
+/**
+ * MIDI channel. Stored as 0-15, displayed as 1-16 in UI.
+ */
+export type MidiChannel = number;
 
 /**
  * Configuration for Paint Audio MIDI Captain MAX custom firmware. This schema is the single source of truth for the config format — TypeScript types are generated from it, Rust structs are validated against it, and Python firmware uses it as reference. Note: the title field drives the generated TypeScript interface name, so keep it short and stable.
@@ -45,6 +85,10 @@ export interface MIDICaptainConfig {
   encoder?: EncoderConfig;
   expression?: ExpressionPedals;
   display?: DisplayConfig;
+  /**
+   * Global default long-press threshold in milliseconds for keytimes-mode buttons. Per-button overrides allowed via the button's long_press_threshold_ms field.
+   */
+  long_press_threshold_ms?: number;
 }
 export interface ButtonConfig {
   /**
@@ -62,7 +106,7 @@ export interface ButtonConfig {
   /**
    * Button behavior. 'toggle' = latching LED on/off, 'momentary' = LED on while held, 'flash' = brief LED flash on press (PC types only, default for PC types), 'select' = radio-group exclusivity (PC and CC only, requires select_group). Default for CC/Note/HID: 'toggle'.
    */
-  mode?: "toggle" | "momentary" | "flash" | "select";
+  mode?: "toggle" | "momentary" | "flash" | "select" | "keytimes";
   /**
    * Radio-group identifier. Required when mode='select'. Pressing a select-mode button activates it and deactivates all sibling buttons sharing the same select_group. PC and CC types only.
    */
@@ -116,13 +160,25 @@ export interface ButtonConfig {
    */
   flash_ms?: number;
   /**
-   * Number of states to cycle through on press. 1 = no cycling.
+   * DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays for multi-state cycling. Validator now rejects this field on non-keytimes modes.
    */
   keytimes?: number;
   /**
-   * Per-state overrides. Array length should match keytimes value.
+   * DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays. Validator now rejects this field on non-keytimes modes.
    */
   states?: StateOverride[];
+  /**
+   * Short-press cycle entries. Only valid when mode='keytimes'. Each entry can fire messages on down (short_down event), up (short_up event), and carries optional color/dim/label.
+   */
+  short?: KeytimesEntry[];
+  /**
+   * Long-press cycle entries. Only valid when mode='keytimes'. Independent counter from short. Each entry can fire messages on down (long_down event, when threshold reached) and up (long_up event, on release after threshold).
+   */
+  long?: KeytimesEntry[];
+  /**
+   * Per-button long-press threshold override in milliseconds. Only meaningful when mode='keytimes'. Falls back to top-level long_press_threshold_ms (default 500).
+   */
+  long_press_threshold_ms?: number;
   /**
    * 'send' = press+release, 'press' = hold key, 'release' = release key(s), 'delay' = pause execution.
    */
@@ -163,6 +219,31 @@ export interface StateOverride {
   hid_delay_ms?: number;
 }
 /**
+ * One entry in a keytimes-mode cycle (short or long). Optional down/up message arrays plus color/dim/label per entry.
+ */
+export interface KeytimesEntry {
+  /**
+   * Messages fired when this entry's down event triggers (short_down for short cycle, long_down for long cycle). Strict array; single-element today, multi-element supported when #47 lands.
+   */
+  down?: KeytimesMessage[];
+  /**
+   * Messages fired when this entry's up event triggers (short_up for short cycle, long_up for long cycle). Strict array; see down.
+   */
+  up?: KeytimesMessage[];
+  /**
+   * Color for this entry. Missing inherits the previous entry's color within this cycle. 'off' explicitly forces LED dark (kill-switch when on short layer).
+   */
+  color?: "red" | "green" | "blue" | "yellow" | "cyan" | "magenta" | "orange" | "purple" | "white" | "off";
+  /**
+   * When true, the resolved color is rendered at reduced brightness (15% of full via dim_color()).
+   */
+  dim?: boolean;
+  /**
+   * Optional display label override for this cycle position. Missing or empty inherits the button-level label.
+   */
+  label?: string;
+}
+/**
  * Rotary encoder configuration. Only supported on STD10.
  */
 export interface EncoderConfig {
@@ -195,7 +276,7 @@ export interface EncoderConfig {
    */
   steps?: number | null;
   /**
-   * Per-encoder MIDI channel override. Inherits global_channel if omitted.
+   * MIDI channel. Stored as 0-15, displayed as 1-16 in UI.
    */
   channel?: number;
   push?: EncoderPush;
@@ -219,9 +300,9 @@ export interface EncoderPush {
   /**
    * Button behavior. Default: 'momentary'.
    */
-  mode?: "toggle" | "momentary" | "flash" | "select";
+  mode?: "toggle" | "momentary" | "flash" | "select" | "keytimes";
   /**
-   * Per-push MIDI channel override. Inherits encoder channel or global_channel if omitted.
+   * MIDI channel. Stored as 0-15, displayed as 1-16 in UI.
    */
   channel?: number;
   /**
@@ -270,7 +351,7 @@ export interface ExpressionConfig {
    */
   threshold?: number;
   /**
-   * Per-pedal MIDI channel override. Inherits global_channel if omitted.
+   * MIDI channel. Stored as 0-15, displayed as 1-16 in UI.
    */
   channel?: number;
 }

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -89,6 +89,22 @@ export interface MIDICaptainConfig {
    * Global default long-press threshold in milliseconds for keytimes-mode buttons. Per-button overrides allowed via the button's long_press_threshold_ms field.
    */
   long_press_threshold_ms?: number;
+  /**
+   * MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output (cross-thru). Default true.
+   */
+  midi_thru_usb_to_din?: boolean;
+  /**
+   * MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output (cross-thru). Default true.
+   */
+  midi_thru_din_to_usb?: boolean;
+  /**
+   * MIDI Thru: forward messages received on the 5-pin DIN input to the 5-pin DIN output (classic MIDI THRU pass-through, for daisy-chaining controllers downstream). Default true.
+   */
+  midi_thru_din_to_din?: boolean;
+  /**
+   * MIDI Thru: echo messages received on USB MIDI back to the USB output (host loopback). Default false; enabling can cause duplicate notes or feedback when the DAW has MIDI echo enabled.
+   */
+  midi_thru_usb_to_usb?: boolean;
 }
 export interface ButtonConfig {
   /**

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -231,7 +231,7 @@ export interface KeytimesEntry {
    */
   up?: KeytimesMessage[];
   /**
-   * Color for this entry. Missing inherits the previous entry's color within this cycle. 'off' explicitly forces LED dark (kill-switch when on short layer).
+   * Color for this entry. Missing inherits the previous entry's color within this cycle, or falls back to the button-level 'color' field when no entry has set one. 'off' explicitly forces LED dark (kill-switch when on short layer).
    */
   color?: "red" | "green" | "blue" | "yellow" | "cyan" | "magenta" | "orange" | "purple" | "white" | "off";
   /**

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -231,7 +231,7 @@ export interface KeytimesEntry {
    */
   up?: KeytimesMessage[];
   /**
-   * Color for this entry. Missing inherits the previous entry's color within this cycle, or falls back to the button-level 'color' field when no entry has set one. 'off' explicitly forces LED dark (kill-switch when on short layer).
+   * Color for this entry. Missing ('(inherit)' in the editor) means no override — the LED falls back to the button-level 'color' field for this entry. 'off' explicitly forces LED dark (kill-switch when on short layer).
    */
   color?: "red" | "green" | "blue" | "yellow" | "cyan" | "magenta" | "orange" | "purple" | "white" | "off";
   /**

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -16,9 +16,13 @@ export type {
   ExpressionConfig,
   ExpressionPedals,
   DisplayConfig,
-  KeytimesEntry,
-  KeytimesMessage,
 } from './types.generated';
+
+// Keytimes entries/messages carry an optional ephemeral `__uiId` (UI-only, not persisted)
+// so {#each} blocks key by stable identity across structuredClone-on-edit. Stripped by
+// normalizeConfig before write — never reaches disk.
+export type KeytimesEntry = import('./types.generated').KeytimesEntry & { __uiId?: number };
+export type KeytimesMessage = import('./types.generated').KeytimesMessage & { __uiId?: number };
 
 // Derived from generated types — no manual sync needed
 export type ButtonMode = NonNullable<ButtonConfig['mode']>;

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -16,6 +16,8 @@ export type {
   ExpressionConfig,
   ExpressionPedals,
   DisplayConfig,
+  KeytimesEntry,
+  KeytimesMessage,
 } from './types.generated';
 
 // Derived from generated types — no manual sync needed
@@ -24,6 +26,9 @@ export type OffMode = NonNullable<ButtonConfig['off_mode']>;
 export type MessageType = NonNullable<ButtonConfig['type']>;
 export type Polarity = NonNullable<ExpressionConfig['polarity']>;
 export type DeviceType = NonNullable<MIDICaptainConfig['device']>;
+
+// CycleEntryColor includes "off" in addition to the named palette colors. Used by KeytimesEntry.color.
+export type CycleEntryColor = NonNullable<import('./types.generated').KeytimesEntry['color']>;
 
 // Human-readable labels for every message type.
 // `satisfies` ensures this map stays in sync with the MessageType union —
@@ -37,6 +42,16 @@ export const MESSAGE_TYPE_LABELS = {
   pc_dec: 'PC-',
   hid:    'HID',
 } as const satisfies Record<MessageType, string>;
+
+// Same pattern for button modes — fails to compile if a new mode is added to the schema
+// without updating this map.
+export const BUTTON_MODE_LABELS = {
+  toggle:    'Toggle',
+  momentary: 'Momentary',
+  flash:     'Flash',
+  select:    'Select',
+  keytimes:  'Keytimes (short/long)',
+} as const satisfies Record<ButtonMode, string>;
 
 export interface DetectedDevice {
   name: string;

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -223,6 +223,15 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
     if (btn.mode !== 'keytimes' && (btn.short || btn.long)) {
       errors.set(`buttons[${idx}].mode`, `short/long are only valid when mode is "keytimes"`);
     }
+    // Legacy keytimes/states are forbidden on the new mode='keytimes' (use short[]/long[] instead).
+    if (btn.mode === 'keytimes') {
+      if (btn.keytimes !== undefined) {
+        errors.set(`buttons[${idx}].keytimes`, `'keytimes' is not allowed on mode="keytimes" (use short[]/long[])`);
+      }
+      if (btn.states !== undefined) {
+        errors.set(`buttons[${idx}].states`, `'states' is not allowed on mode="keytimes" (use short[]/long[])`);
+      }
+    }
     if (btn.mode === 'keytimes' && btn.long_press_threshold_ms !== undefined) {
       const t = btn.long_press_threshold_ms;
       if (!Number.isInteger(t) || t < 50 || t > 5000) {

--- a/config-editor/src/lib/validation.ts
+++ b/config-editor/src/lib/validation.ts
@@ -218,6 +218,75 @@ export function validateConfig(config: MidiCaptainConfig): ValidationResult {
       errors.set(`buttons[${idx}].states`, 'states requires keytimes > 1');
     }
 
+    // mode: "keytimes" validation (#48): short/long entries + per-button threshold.
+    // short[]/long[] are only allowed when mode === 'keytimes'.
+    if (btn.mode !== 'keytimes' && (btn.short || btn.long)) {
+      errors.set(`buttons[${idx}].mode`, `short/long are only valid when mode is "keytimes"`);
+    }
+    if (btn.mode === 'keytimes' && btn.long_press_threshold_ms !== undefined) {
+      const t = btn.long_press_threshold_ms;
+      if (!Number.isInteger(t) || t < 50 || t > 5000) {
+        errors.set(`buttons[${idx}].long_press_threshold_ms`, 'Threshold must be between 50 and 5000 ms');
+      }
+    }
+    if (btn.mode === 'keytimes') {
+      // Validate Message objects nested inside short[i].down[j] / up[j] and same for long.
+      for (const cycle of ['short', 'long'] as const) {
+        const entries = btn[cycle];
+        if (!entries) continue;
+        entries.forEach((entry, ei) => {
+          for (const slot of ['down', 'up'] as const) {
+            const messages = entry[slot];
+            if (!messages) continue;
+            messages.forEach((msg, mi) => {
+              const mp = `buttons[${idx}].${cycle}[${ei}].${slot}[${mi}]`;
+              switch (msg.type) {
+                case 'cc': {
+                  const e = validators.cc(msg.cc);
+                  if (e) errors.set(`${mp}.cc`, e);
+                  const v = validators.withinRange(msg.value, 0, 127);
+                  if (v) errors.set(`${mp}.value`, v);
+                  break;
+                }
+                case 'note': {
+                  const e = validators.note(msg.note);
+                  if (e) errors.set(`${mp}.note`, e);
+                  const v = validators.velocity(msg.velocity);
+                  if (v) errors.set(`${mp}.velocity`, v);
+                  break;
+                }
+                case 'pc': {
+                  const e = validators.program(msg.program);
+                  if (e) errors.set(`${mp}.program`, e);
+                  break;
+                }
+                case 'pc_inc':
+                case 'pc_dec': {
+                  if (msg.step !== undefined) {
+                    const e = validators.pcStep(msg.step);
+                    if (e) errors.set(`${mp}.step`, e);
+                  }
+                  break;
+                }
+                case 'hid': {
+                  if (msg.delay_ms !== undefined) {
+                    if (!Number.isInteger(msg.delay_ms) || msg.delay_ms < 1 || msg.delay_ms > 5000) {
+                      errors.set(`${mp}.delay_ms`, 'Delay must be between 1 and 5000 ms');
+                    }
+                  }
+                  break;
+                }
+              }
+              if (msg.type !== 'hid' && (msg as { channel?: number }).channel !== undefined) {
+                const cherr = validators.channel((msg as { channel?: number }).channel!);
+                if (cherr) errors.set(`${mp}.channel`, cherr);
+              }
+            });
+          }
+        });
+      }
+    }
+
     if (btn.keytimes !== undefined) {
       const ktError = validators.keytimes(btn.keytimes);
       if (ktError) errors.set(`buttons[${idx}].keytimes`, ktError);

--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -18,6 +18,7 @@
   import EncoderSection from '$lib/components/EncoderSection.svelte';
   import ExpressionSection from '$lib/components/ExpressionSection.svelte';
   import DisplaySection from '$lib/components/DisplaySection.svelte';
+  import MidiThruSection from '$lib/components/MidiThruSection.svelte';
   import FirmwareInstaller from '$lib/components/FirmwareInstaller.svelte';
   import { loadConfig, validate, normalizeConfig, config } from '$lib/formStore';
 
@@ -335,6 +336,7 @@
         <EncoderSection />
         <ExpressionSection />
         <DisplaySection />
+        <MidiThruSection />
         <FirmwareInstaller
           device={$selectedDevice}
           hasUnsavedChanges={$hasUnsavedChanges}

--- a/config.schema.json
+++ b/config.schema.json
@@ -47,6 +47,13 @@
     "display": {
       "$ref": "#/definitions/DisplayConfig",
       "description": "Display and text rendering settings."
+    },
+    "long_press_threshold_ms": {
+      "type": "integer",
+      "minimum": 50,
+      "maximum": 5000,
+      "default": 500,
+      "description": "Global default long-press threshold in milliseconds for keytimes-mode buttons. Per-button overrides allowed via the button's long_press_threshold_ms field."
     }
   },
   "additionalProperties": false,
@@ -57,7 +64,8 @@
     },
     "ButtonMode": {
       "type": "string",
-      "enum": ["toggle", "momentary", "flash", "select"]
+      "enum": ["toggle", "momentary", "flash", "select", "keytimes"],
+      "description": "Button behavior. 'toggle' = latching, 'momentary' = LED on while held, 'flash' = brief LED flash (PC types), 'select' = radio-group exclusivity, 'keytimes' = multi-state cycle with short/long press timing (see short/long/long_press_threshold_ms fields)."
     },
     "SelectRepress": {
       "type": "string",
@@ -109,6 +117,99 @@
       "minimum": 0,
       "maximum": 15,
       "description": "MIDI channel. Stored as 0-15, displayed as 1-16 in UI."
+    },
+    "CycleEntryColor": {
+      "type": "string",
+      "enum": ["red", "green", "blue", "yellow", "cyan", "magenta", "orange", "purple", "white", "off"],
+      "description": "Color for a keytimes cycle entry. 'off' explicitly means LED dark; missing means inherit the previous entry's color in the same cycle."
+    },
+    "KeytimesMessage": {
+      "type": "object",
+      "description": "One MIDI/HID message fired from a keytimes-mode cycle entry's down or up slot. Discriminated by 'type'.",
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties": {
+            "type": { "const": "cc" },
+            "cc": { "$ref": "#/definitions/MidiByte" },
+            "value": { "$ref": "#/definitions/MidiByte" },
+            "channel": { "$ref": "#/definitions/MidiChannel" }
+          },
+          "required": ["type", "cc", "value"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "type": { "const": "note" },
+            "note": { "$ref": "#/definitions/MidiByte" },
+            "velocity": { "$ref": "#/definitions/MidiByte" },
+            "channel": { "$ref": "#/definitions/MidiChannel" }
+          },
+          "required": ["type", "note", "velocity"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "type": { "const": "pc" },
+            "program": { "$ref": "#/definitions/MidiByte" },
+            "channel": { "$ref": "#/definitions/MidiChannel" }
+          },
+          "required": ["type", "program"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "type": { "enum": ["pc_inc", "pc_dec"] },
+            "step": { "type": "integer", "minimum": 1, "maximum": 127, "default": 1 },
+            "channel": { "$ref": "#/definitions/MidiChannel" }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "type": { "const": "hid" },
+            "action": { "$ref": "#/definitions/HidAction" },
+            "key": { "type": "string", "description": "HID key name (see hid_key field on ButtonConfig for valid values)." },
+            "modifier": { "$ref": "#/definitions/HidModifier" },
+            "delay_ms": { "type": "integer", "minimum": 1, "maximum": 5000 }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "KeytimesEntry": {
+      "type": "object",
+      "description": "One entry in a keytimes-mode cycle (short or long). Optional down/up message arrays plus color/dim/label per entry.",
+      "properties": {
+        "down": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/KeytimesMessage" },
+          "description": "Messages fired when this entry's down event triggers (short_down for short cycle, long_down for long cycle). Strict array; single-element today, multi-element supported when #47 lands."
+        },
+        "up": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/KeytimesMessage" },
+          "description": "Messages fired when this entry's up event triggers (short_up for short cycle, long_up for long cycle). Strict array; see down."
+        },
+        "color": {
+          "$ref": "#/definitions/CycleEntryColor",
+          "description": "Color for this entry. Missing inherits the previous entry's color within this cycle. 'off' explicitly forces LED dark (kill-switch when on short layer)."
+        },
+        "dim": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, the resolved color is rendered at reduced brightness (15% of full via dim_color())."
+        },
+        "label": {
+          "type": "string",
+          "maxLength": 6,
+          "pattern": "^[\\w \\-]+$",
+          "description": "Optional display label override for this cycle position. Missing or empty inherits the button-level label."
+        }
+      },
+      "additionalProperties": false
     },
     "StateOverride": {
       "type": "object",
@@ -232,12 +333,28 @@
           "minimum": 1,
           "maximum": 99,
           "default": 1,
-          "description": "Number of states to cycle through on press. 1 = no cycling."
+          "description": "DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays for multi-state cycling. Validator now rejects this field on non-keytimes modes."
         },
         "states": {
           "type": "array",
           "items": { "$ref": "#/definitions/StateOverride" },
-          "description": "Per-state overrides. Array length should match keytimes value."
+          "description": "DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays. Validator now rejects this field on non-keytimes modes."
+        },
+        "short": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/KeytimesEntry" },
+          "description": "Short-press cycle entries. Only valid when mode='keytimes'. Each entry can fire messages on down (short_down event), up (short_up event), and carries optional color/dim/label."
+        },
+        "long": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/KeytimesEntry" },
+          "description": "Long-press cycle entries. Only valid when mode='keytimes'. Independent counter from short. Each entry can fire messages on down (long_down event, when threshold reached) and up (long_up event, on release after threshold)."
+        },
+        "long_press_threshold_ms": {
+          "type": "integer",
+          "minimum": 50,
+          "maximum": 5000,
+          "description": "Per-button long-press threshold override in milliseconds. Only meaningful when mode='keytimes'. Falls back to top-level long_press_threshold_ms (default 500)."
         },
         "hid_action": {
           "$ref": "#/definitions/HidAction",

--- a/config.schema.json
+++ b/config.schema.json
@@ -54,6 +54,26 @@
       "maximum": 5000,
       "default": 500,
       "description": "Global default long-press threshold in milliseconds for keytimes-mode buttons. Per-button overrides allowed via the button's long_press_threshold_ms field."
+    },
+    "midi_thru_usb_to_din": {
+      "type": "boolean",
+      "default": true,
+      "description": "MIDI Thru: forward messages received on USB MIDI to the 5-pin DIN output (cross-thru). Default true."
+    },
+    "midi_thru_din_to_usb": {
+      "type": "boolean",
+      "default": true,
+      "description": "MIDI Thru: forward messages received on the 5-pin DIN MIDI input to the USB MIDI output (cross-thru). Default true."
+    },
+    "midi_thru_din_to_din": {
+      "type": "boolean",
+      "default": true,
+      "description": "MIDI Thru: forward messages received on the 5-pin DIN input to the 5-pin DIN output (classic MIDI THRU pass-through, for daisy-chaining controllers downstream). Default true."
+    },
+    "midi_thru_usb_to_usb": {
+      "type": "boolean",
+      "default": false,
+      "description": "MIDI Thru: echo messages received on USB MIDI back to the USB output (host loopback). Default false; enabling can cause duplicate notes or feedback when the DAW has MIDI echo enabled."
     }
   },
   "additionalProperties": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -353,12 +353,12 @@
           "minimum": 1,
           "maximum": 99,
           "default": 1,
-          "description": "DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays for multi-state cycling. Validator now rejects this field on non-keytimes modes."
+          "description": "DEPRECATED on toggle/momentary/flash/select modes (firmware accepts with a deprecation warning at boot; will be removed in v3.0). Forbidden on mode='keytimes' — use short[]/long[] arrays instead."
         },
         "states": {
           "type": "array",
           "items": { "$ref": "#/definitions/StateOverride" },
-          "description": "DEPRECATED on toggle/momentary/flash/select modes. Use mode='keytimes' with short[]/long[] arrays. Validator now rejects this field on non-keytimes modes."
+          "description": "DEPRECATED on toggle/momentary/flash/select modes (firmware accepts with a deprecation warning at boot; will be removed in v3.0). Forbidden on mode='keytimes' — use short[]/long[] arrays instead."
         },
         "short": {
           "type": "array",

--- a/config.schema.json
+++ b/config.schema.json
@@ -121,7 +121,7 @@
     "CycleEntryColor": {
       "type": "string",
       "enum": ["red", "green", "blue", "yellow", "cyan", "magenta", "orange", "purple", "white", "off"],
-      "description": "Color for a keytimes cycle entry. 'off' explicitly means LED dark; missing means inherit the previous entry's color in the same cycle."
+      "description": "Color for a keytimes cycle entry. 'off' explicitly means LED dark; missing means inherit the previous entry's color in the same cycle, falling back to the button-level 'color' field when no entry has set one."
     },
     "KeytimesMessage": {
       "type": "object",
@@ -195,7 +195,7 @@
         },
         "color": {
           "$ref": "#/definitions/CycleEntryColor",
-          "description": "Color for this entry. Missing inherits the previous entry's color within this cycle. 'off' explicitly forces LED dark (kill-switch when on short layer)."
+          "description": "Color for this entry. Missing inherits the previous entry's color within this cycle, or falls back to the button-level 'color' field when no entry has set one. 'off' explicitly forces LED dark (kill-switch when on short layer)."
         },
         "dim": {
           "type": "boolean",

--- a/config.schema.json
+++ b/config.schema.json
@@ -121,7 +121,7 @@
     "CycleEntryColor": {
       "type": "string",
       "enum": ["red", "green", "blue", "yellow", "cyan", "magenta", "orange", "purple", "white", "off"],
-      "description": "Color for a keytimes cycle entry. 'off' explicitly means LED dark; missing means inherit the previous entry's color in the same cycle, falling back to the button-level 'color' field when no entry has set one."
+      "description": "Color for a keytimes cycle entry. 'off' explicitly means LED dark; missing ('(inherit)' in the editor) means no override — the LED falls back to the button-level 'color' field for this entry."
     },
     "KeytimesMessage": {
       "type": "object",
@@ -195,7 +195,7 @@
         },
         "color": {
           "$ref": "#/definitions/CycleEntryColor",
-          "description": "Color for this entry. Missing inherits the previous entry's color within this cycle, or falls back to the button-level 'color' field when no entry has set one. 'off' explicitly forces LED dark (kill-switch when on short layer)."
+          "description": "Color for this entry. Missing ('(inherit)' in the editor) means no override — the LED falls back to the button-level 'color' field for this entry. 'off' explicitly forces LED dark (kill-switch when on short layer)."
         },
         "dim": {
           "type": "boolean",

--- a/docs/plans/2026-05-12-save-and-apply-hot-reload.md
+++ b/docs/plans/2026-05-12-save-and-apply-hot-reload.md
@@ -1,0 +1,812 @@
+# Save & Apply — Hot Reload on Save
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the "Save to Device" button with a split button whose primary action is **Save & Apply** — write `config.json` to device, then automatically hot-reload (REPL `reload_runtime_config()` via `sys.modules['__main__']`) for runtime fields, or hard-reset (`microcontroller.reset()`) when boot-level fields changed. Secondary actions: **Save** (local file) and **Save to Device, No Reload** (dev-mode only).
+
+**Architecture:**
+- Editor diffs old vs new config JSON before save via Rust command `classify_reload`. Boot-level field change → hard reset path. Otherwise → hot reload path.
+- Firmware adds `reload_runtime_config()` to `code.py`. Reached over REPL via `sys.modules['__main__'].reload_runtime_config()` — NOT `import code` (would re-execute the whole file as a new module).
+- Hard reset uses `import microcontroller; microcontroller.reset()` over serial — full re-enumeration, picks up USB descriptor / drive-name / HID toggle changes without physical power cycle.
+- File-flush race already handled by `write_sync` in `commands.rs:232` (calls `file.sync_all()`).
+- Existing `restart_device` (Ctrl-C + Ctrl-D soft reboot) is preserved as a manual fallback button but no longer the auto-save path.
+
+**Tech Stack:** Svelte 5 (runes), TypeScript, Tauri 2 (Rust), CircuitPython 7.x, `serialport` crate.
+
+---
+
+## Boot-Level Field List (forces hard reset)
+
+A change to any of these forces `microcontroller.reset()`:
+
+- `usb_drive_name` — set in `boot.py` via `storage.remount(label=...)`; host needs re-enumeration to see new label
+- `dev_mode` — `boot.py` decides whether to call `storage.disable_usb_drive()`
+- `device` — pin maps and module imports decided at top of `code.py`; safer to fully reset than hot-swap
+- HID descriptor toggle — `boot.py` enables HID only if any button has `type:"hid"`. Detection: `any button.type == "hid"` OR `any button.states[*].type == "hid"`. If either side's "has HID" boolean flips, descriptor must rebuild → hard reset. Note: changing a HID button's `hid_key` or `hid_modifier` is **hot**, only the on/off toggle is hard.
+
+Everything else (CC numbers, colors, labels, flash_ms, encoder maps, expression maps, page count, display text) is hot-reloadable.
+
+---
+
+## Task 1: Firmware — `reload_runtime_config()`
+
+**Files:**
+- Modify: `firmware/dev/code.py`
+- Test: manual on-device — no pytest mock covers full code.py runtime
+
+**Step 1: Locate the globals and the LED/display paint logic**
+
+Run:
+```bash
+grep -n "^config = load_config\|^buttons = \|^pc_values = \|^pc_flash_timers = " firmware/dev/code.py
+grep -n "pixels\[\|pixels.fill\|set_status_text\|display.show\|main_group" firmware/dev/code.py | head -30
+```
+
+Note line numbers. Identify:
+- The lines that paint each button's idle LED color from `buttons[i]["color"]`
+- The lines that paint the display banner from `config`
+
+**Step 2: Extract paint helpers (carefully — leave hardware init alone)**
+
+Create two module-level functions in `code.py`. Move **only the paint lines** that consume `buttons` / `config`. Leave NeoPixel object creation, display object creation, font loading, and any one-time hardware init at the top of the file untouched.
+
+```python
+def _refresh_idle_leds():
+    """Repaint each button's idle LED color from current `buttons` config."""
+    # Move existing per-button idle-color loop here.
+    # Reference globals: buttons, pixels, switch_to_led
+    ...
+
+def _refresh_display():
+    """Repaint display banner from current `config`."""
+    # Move existing display banner paint lines here.
+    ...
+```
+
+Update the original startup sites to call these helpers instead of inlining the logic — single source of truth, exercises the path before reload ever runs.
+
+**Step 3: Add `reload_runtime_config()`**
+
+Place after the helpers, before `while True:`:
+
+```python
+def reload_runtime_config():
+    """Re-read /config.json and rebuild runtime state without rebooting.
+
+    Called over REPL by the editor's Save & Apply flow when only
+    runtime fields changed. Boot-level changes (usb_drive_name, dev_mode,
+    device, HID toggle) require microcontroller.reset() instead.
+    """
+    global config, buttons
+    try:
+        config = load_config()
+        buttons = config["buttons"]
+        # Clear in-flight LED flashes — they reference button indices in
+        # the old config and would paint stale colors. Keep pc_values
+        # intact so users mid-performance don't lose pc_inc/dec state
+        # on a color/label edit.
+        for i in range(len(pc_flash_timers)):
+            pc_flash_timers[i] = 0.0
+        _refresh_idle_leds()
+        _refresh_display()
+        print("Config hot-reloaded")
+        return True
+    except Exception as e:
+        print("Hot reload failed:", e)
+        return False
+```
+
+**Step 4: Manual on-device smoke test**
+
+1. Deploy: `bash tools/deploy.sh`
+2. Open serial: `screen $(ls /dev/cu.usbmodem*) 115200`
+3. Ctrl-C to halt, send a sacrificial CRLF, then run:
+   `import sys; sys.modules['__main__'].reload_runtime_config()`
+   Expected: `Config hot-reloaded` printed, no crash, no reboot.
+4. Edit a button color in `config.json` on the mounted drive, save.
+5. Re-run the REPL line. Expected: LED color updates, serial stays up, no reboot.
+
+**Step 5: Commit**
+
+```bash
+git add firmware/dev/code.py
+git commit -m "feat(firmware): add reload_runtime_config() for hot config reload"
+```
+
+---
+
+## Task 2: Rust — boot-level diff logic
+
+**Files:**
+- Create: `config-editor/src-tauri/src/reload_diff.rs`
+- Modify: `config-editor/src-tauri/src/lib.rs` (add `mod reload_diff;`)
+
+**Step 1: Write failing tests + impl**
+
+Create `config-editor/src-tauri/src/reload_diff.rs`:
+
+```rust
+use serde_json::Value;
+
+/// Decision returned by `classify_change`.
+#[derive(Debug, PartialEq)]
+pub enum ReloadKind {
+    /// No change detected — caller can skip serial work entirely.
+    None,
+    /// Runtime-only change — REPL `reload_runtime_config()` is sufficient.
+    Hot,
+    /// Boot-level change — `microcontroller.reset()` required.
+    Hard,
+}
+
+/// Returns `Hard` if any boot-level field differs between `old` and `new`,
+/// `Hot` if other fields differ, `None` if equal.
+pub fn classify_change(old: &Value, new: &Value) -> ReloadKind {
+    if old == new {
+        return ReloadKind::None;
+    }
+    if boot_level_differs(old, new) {
+        return ReloadKind::Hard;
+    }
+    ReloadKind::Hot
+}
+
+fn boot_level_differs(old: &Value, new: &Value) -> bool {
+    for field in ["usb_drive_name", "dev_mode", "device"] {
+        if old.get(field) != new.get(field) {
+            return true;
+        }
+    }
+    has_hid(old) != has_hid(new)
+}
+
+fn has_hid(cfg: &Value) -> bool {
+    let Some(buttons) = cfg.get("buttons").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    buttons.iter().any(button_has_hid)
+}
+
+fn button_has_hid(btn: &Value) -> bool {
+    if btn.get("type").and_then(|v| v.as_str()) == Some("hid") {
+        return true;
+    }
+    let Some(states) = btn.get("states").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    states.iter().any(|s| s.get("type").and_then(|v| v.as_str()) == Some("hid"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn identical_configs_yield_none() {
+        let cfg = json!({"device": "STD10", "buttons": []});
+        assert_eq!(classify_change(&cfg, &cfg), ReloadKind::None);
+    }
+
+    #[test]
+    fn button_color_change_is_hot() {
+        let old = json!({"device": "STD10", "buttons": [{"label":"1","cc":20,"color":"red"}]});
+        let new = json!({"device": "STD10", "buttons": [{"label":"1","cc":20,"color":"blue"}]});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hot);
+    }
+
+    #[test]
+    fn usb_drive_name_change_is_hard() {
+        let old = json!({"usb_drive_name": "MIDICAPTAIN", "buttons": []});
+        let new = json!({"usb_drive_name": "MYCAPTAIN", "buttons": []});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hard);
+    }
+
+    #[test]
+    fn dev_mode_change_is_hard() {
+        let old = json!({"dev_mode": false, "buttons": []});
+        let new = json!({"dev_mode": true, "buttons": []});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hard);
+    }
+
+    #[test]
+    fn device_change_is_hard() {
+        let old = json!({"device": "STD10", "buttons": []});
+        let new = json!({"device": "NANO4", "buttons": []});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hard);
+    }
+
+    #[test]
+    fn adding_hid_button_is_hard() {
+        let old = json!({"buttons": [{"type":"cc","cc":20}]});
+        let new = json!({"buttons": [{"type":"cc","cc":20},{"type":"hid","hid_key":"A"}]});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hard);
+    }
+
+    #[test]
+    fn removing_last_hid_button_is_hard() {
+        let old = json!({"buttons": [{"type":"hid","hid_key":"A"}]});
+        let new = json!({"buttons": [{"type":"cc","cc":20}]});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hard);
+    }
+
+    #[test]
+    fn hid_in_state_override_counts() {
+        let old = json!({"buttons": [{"type":"cc","cc":20}]});
+        let new = json!({"buttons": [{"type":"cc","cc":20,"states":[{"type":"hid","hid_key":"A"}]}]});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hard);
+    }
+
+    #[test]
+    fn changing_hid_key_while_descriptor_unchanged_is_hot() {
+        let old = json!({"buttons": [{"type":"hid","hid_key":"A"}]});
+        let new = json!({"buttons": [{"type":"hid","hid_key":"B"}]});
+        assert_eq!(classify_change(&old, &new), ReloadKind::Hot);
+    }
+}
+```
+
+**Step 2: Wire module into `lib.rs`**
+
+Add `mod reload_diff;` near other `mod` declarations.
+
+**Step 3: Run tests**
+
+Run: `cd config-editor/src-tauri && cargo test --lib reload_diff`
+Expected: 9 tests pass.
+
+**Step 4: Commit**
+
+```bash
+git add config-editor/src-tauri/src/reload_diff.rs config-editor/src-tauri/src/lib.rs
+git commit -m "feat(editor): add boot-level config diff classifier"
+```
+
+---
+
+## Task 3: Rust — `hot_reload_device`, `hard_reset_device`, `classify_reload`
+
+**Files:**
+- Modify: `config-editor/src-tauri/src/commands.rs` (add three commands near `restart_device`)
+- Modify: `config-editor/src-tauri/src/lib.rs` (register all three in `tauri::generate_handler!`)
+
+**Step 1: Add serial helpers and commands in `commands.rs`**
+
+After `soft_reboot_via_serial`:
+
+```rust
+/// Trigger firmware hot reload over REPL — calls `reload_runtime_config()`
+/// in the already-running __main__ (code.py). Does NOT re-run boot.py.
+/// `code.py` runs as __main__; `import code` would re-execute the whole
+/// file as a separate module, so we reach the live function via
+/// `sys.modules['__main__']` instead.
+pub(crate) fn hot_reload_via_serial(path: &Path) -> Result<(), ConfigError> {
+    let mut port = open_device_serial(path)?;
+
+    // Ctrl-C: drop to REPL. CP consumes next byte as the "press any key" prompt.
+    port.write_all(&[0x03]).map_err(|e| ConfigError {
+        message: format!("Failed to send interrupt: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Sacrificial CRLF — consumed as the prompt keypress.
+    port.write_all(b"\r\n").map_err(|e| ConfigError {
+        message: format!("Failed to enter REPL: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Reach into the running __main__ and call the reload function.
+    let cmd = b"import sys; sys.modules['__main__'].reload_runtime_config()\r\n";
+    port.write_all(cmd).map_err(|e| ConfigError {
+        message: format!("Failed to send reload command: {}", e),
+        details: None,
+    })?;
+    port.flush().map_err(|e| ConfigError {
+        message: format!("Failed to flush: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(300));
+
+    Ok(())
+}
+
+/// Hard-reset the MCU via `microcontroller.reset()`. Forces full
+/// USB re-enumeration — required for usb_drive_name, dev_mode, device,
+/// and HID descriptor changes. ~2s before device reappears on host.
+pub(crate) fn hard_reset_via_serial(path: &Path) -> Result<(), ConfigError> {
+    let mut port = open_device_serial(path)?;
+
+    port.write_all(&[0x03]).map_err(|e| ConfigError {
+        message: format!("Failed to send interrupt: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(500));
+
+    port.write_all(b"\r\n").map_err(|e| ConfigError {
+        message: format!("Failed to enter REPL: {}", e),
+        details: None,
+    })?;
+    std::thread::sleep(Duration::from_millis(200));
+
+    let cmd = b"import microcontroller; microcontroller.reset()\r\n";
+    port.write_all(cmd).map_err(|e| ConfigError {
+        message: format!("Failed to send reset command: {}", e),
+        details: None,
+    })?;
+    port.flush().map_err(|e| ConfigError {
+        message: format!("Failed to flush: {}", e),
+        details: None,
+    })?;
+    // Don't sleep long — port will drop on reset. Port handle drops on
+    // function return; serialport crate handles the disconnect.
+    std::thread::sleep(Duration::from_millis(50));
+
+    Ok(())
+}
+
+#[command]
+pub fn hot_reload_device(path: String) -> Result<(), ConfigError> {
+    validate_device_path(&path)?;
+    let p = Path::new(&path);
+    verify_device_connected(p)?;
+    hot_reload_via_serial(p)
+}
+
+#[command]
+pub fn hard_reset_device(path: String) -> Result<(), ConfigError> {
+    validate_device_path(&path)?;
+    let p = Path::new(&path);
+    verify_device_connected(p)?;
+    hard_reset_via_serial(p)
+}
+
+/// Classify a config change as None / Hot / Hard. Used by the editor
+/// to pick reload strategy after writing config.json to the device.
+#[command]
+pub fn classify_reload(old: serde_json::Value, new: serde_json::Value) -> &'static str {
+    use crate::reload_diff::{classify_change, ReloadKind};
+    match classify_change(&old, &new) {
+        ReloadKind::None => "None",
+        ReloadKind::Hot => "Hot",
+        ReloadKind::Hard => "Hard",
+    }
+}
+```
+
+**Step 2: Register all three commands in `lib.rs`**
+
+Find `tauri::generate_handler!` and add: `commands::hot_reload_device, commands::hard_reset_device, commands::classify_reload`.
+
+**Step 3: Build**
+
+Run: `cd config-editor/src-tauri && cargo build`
+Expected: clean build.
+
+**Step 4: Commit**
+
+```bash
+git add config-editor/src-tauri/src/commands.rs config-editor/src-tauri/src/lib.rs
+git commit -m "feat(editor): add hot_reload, hard_reset, classify_reload tauri commands"
+```
+
+---
+
+## Task 4: TypeScript API wrappers
+
+**Files:**
+- Modify: `config-editor/src/lib/api.ts`
+
+**Step 1: Add wrappers next to existing `restartDevice`**
+
+```typescript
+export async function hotReloadDevice(path: string): Promise<void> {
+  return invoke('hot_reload_device', { path });
+}
+
+export async function hardResetDevice(path: string): Promise<void> {
+  return invoke('hard_reset_device', { path });
+}
+
+export async function classifyReload(
+  oldConfig: unknown,
+  newConfig: unknown,
+): Promise<'None' | 'Hot' | 'Hard'> {
+  return invoke('classify_reload', { old: oldConfig, new: newConfig });
+}
+```
+
+**Step 2: Type-check**
+
+Run: `cd config-editor && npm run check`
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add config-editor/src/lib/api.ts
+git commit -m "feat(editor): add hotReloadDevice, hardResetDevice, classifyReload api wrappers"
+```
+
+---
+
+## Task 5: SplitButton component
+
+**Files:**
+- Create: `config-editor/src/lib/components/SplitButton.svelte`
+
+**Step 1: Create the component**
+
+Key fix vs first draft: outside-click handler uses `pointerdown` AND checks whether the target lies inside the menu — otherwise menu items are clicked away before their `click` fires.
+
+```svelte
+<script lang="ts">
+  interface MenuItem {
+    label: string;
+    onclick: () => void;
+    disabled?: boolean;
+    hidden?: boolean;
+  }
+
+  interface Props {
+    primaryLabel: string;
+    primaryOnClick: () => void;
+    primaryDisabled?: boolean;
+    primaryTitle?: string;
+    menu: MenuItem[];
+    variant?: 'primary' | 'secondary';
+  }
+
+  let {
+    primaryLabel,
+    primaryOnClick,
+    primaryDisabled = false,
+    primaryTitle = '',
+    menu,
+    variant = 'primary',
+  }: Props = $props();
+
+  let open = $state(false);
+  let rootEl: HTMLDivElement | undefined = $state();
+  let menuEl: HTMLUListElement | undefined = $state();
+
+  function toggle() { open = !open; }
+  function close() { open = false; }
+
+  // pointerdown so the close fires before the menuitem click; check that
+  // the pointer landed outside both the menu and the toggle, otherwise
+  // the menuitem click would land on nothing.
+  function handlePointerDown(e: PointerEvent) {
+    const t = e.target as Node;
+    if (rootEl && rootEl.contains(t)) return;
+    close();
+  }
+
+  function handleKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') close();
+    if (e.altKey && e.key === 'ArrowDown') { e.preventDefault(); open = true; }
+  }
+
+  $effect(() => {
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown);
+      return () => document.removeEventListener('pointerdown', handlePointerDown);
+    }
+  });
+
+  const visibleMenu = $derived(menu.filter(m => !m.hidden));
+</script>
+
+<div class="split" bind:this={rootEl} onkeydown={handleKey} role="group">
+  <button
+    class="primary {variant}"
+    onclick={primaryOnClick}
+    disabled={primaryDisabled}
+    title={primaryTitle}
+  >
+    {primaryLabel}
+  </button>
+  <button
+    class="caret {variant}"
+    onclick={toggle}
+    aria-haspopup="menu"
+    aria-expanded={open}
+    aria-label="More save options"
+    disabled={visibleMenu.length === 0}
+  >
+    ▾
+  </button>
+  {#if open && visibleMenu.length > 0}
+    <ul class="menu" role="menu" bind:this={menuEl}>
+      {#each visibleMenu as item}
+        <li role="none">
+          <button
+            role="menuitem"
+            disabled={item.disabled}
+            onclick={() => { item.onclick(); close(); }}
+          >
+            {item.label}
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .split { position: relative; display: inline-flex; }
+  .primary { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+  .caret {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 1px solid rgba(0,0,0,0.15);
+    padding: 0 0.5rem;
+  }
+  .menu {
+    position: absolute; top: 100%; right: 0; margin: 0.25rem 0 0;
+    padding: 0.25rem 0; list-style: none;
+    background: var(--bg, #fff); color: var(--fg, #000);
+    border: 1px solid #888; border-radius: 4px;
+    min-width: 220px; z-index: 100;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  }
+  .menu button {
+    display: block; width: 100%; text-align: left;
+    background: none; border: 0; padding: 0.5rem 0.75rem;
+    font: inherit; cursor: pointer;
+  }
+  .menu button:hover:not(:disabled) { background: rgba(0,0,0,0.08); }
+  .menu button:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>
+```
+
+**Step 2: Type-check**
+
+Run: `cd config-editor && npm run check`
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add config-editor/src/lib/components/SplitButton.svelte
+git commit -m "feat(editor): add SplitButton component"
+```
+
+---
+
+## Task 6: Wire Save & Apply into +page.svelte
+
+**Files:**
+- Modify: `config-editor/src/routes/+page.svelte`
+- Modify: `config-editor/src/lib/components/ConfigForm.svelte`
+
+**Step 1: Read existing save flow**
+
+Existing flow (verified):
+- `saveToDevice()` at `+page.svelte:174` calls `normalizeConfig(get(config))` → `JSON.stringify(_, null, 2)` → `writeConfigRaw($selectedDevice.config_path, configJson)` → sets `$currentConfigRaw = configJson` and `$hasUnsavedChanges = false` → prompts to restart.
+- `$currentConfigRaw` is the post-save "last known on-device" raw JSON — perfect "old" side for the diff.
+- `config` is the form store (Svelte store); `dev_mode` is on the same shape.
+
+**Step 2: Replace `saveToDevice` with three actions in `+page.svelte`**
+
+```typescript
+import {
+  hotReloadDevice, hardResetDevice, classifyReload, writeConfigRaw,
+} from '$lib/api';
+import { save as saveFileDialog } from '@tauri-apps/plugin-dialog';
+
+async function saveAndApply() {
+  if (!$selectedDevice) return;
+  if (!validate()) {
+    await message('Please fix validation errors before saving', { title: 'Validation Error', kind: 'error' });
+    return;
+  }
+  $isLoading = true;
+  try {
+    const oldRaw = $currentConfigRaw;
+    const configObj = normalizeConfig(get(config));
+    const newJson = JSON.stringify(configObj, null, 2);
+
+    await writeConfigRaw($selectedDevice.config_path, newJson);
+    $currentConfigRaw = newJson;
+    $hasUnsavedChanges = false;
+
+    let oldObj: unknown = {};
+    let newObj: unknown = configObj;
+    try { oldObj = JSON.parse(oldRaw); } catch {}
+
+    const kind = await classifyReload(oldObj, newObj);
+    if (kind === 'None') {
+      $statusMessage = 'Saved — no changes';
+    } else if (kind === 'Hard') {
+      $statusMessage = 'Saved. Rebooting…';
+      await hardResetDevice($selectedDevice.config_path);
+      $statusMessage = 'Saved & rebooted';
+    } else {
+      $statusMessage = 'Saved. Reloading…';
+      await hotReloadDevice($selectedDevice.config_path);
+      $statusMessage = 'Saved & applied';
+    }
+  } catch (e: any) {
+    $statusMessage = `Error: ${e.message || e}`;
+    await message($statusMessage, { title: 'Error', kind: 'error' });
+  } finally {
+    $isLoading = false;
+  }
+}
+
+async function saveLocalOnly() {
+  if (!validate()) {
+    await message('Please fix validation errors before saving', { title: 'Validation Error', kind: 'error' });
+    return;
+  }
+  const path = await saveFileDialog({
+    defaultPath: 'config.json',
+    filters: [{ name: 'JSON', extensions: ['json'] }],
+  });
+  if (!path) return;
+  $isLoading = true;
+  try {
+    const configObj = normalizeConfig(get(config));
+    const json = JSON.stringify(configObj, null, 2);
+    await writeConfigRaw(path, json);
+    $statusMessage = `Saved to ${path}`;
+  } catch (e: any) {
+    $statusMessage = `Error: ${e.message || e}`;
+    await message($statusMessage, { title: 'Error', kind: 'error' });
+  } finally {
+    $isLoading = false;
+  }
+}
+
+async function saveToDeviceNoReload() {
+  if (!$selectedDevice) return;
+  if (!validate()) return;
+  $isLoading = true;
+  try {
+    const configObj = normalizeConfig(get(config));
+    const newJson = JSON.stringify(configObj, null, 2);
+    await writeConfigRaw($selectedDevice.config_path, newJson);
+    $currentConfigRaw = newJson;
+    $hasUnsavedChanges = false;
+    $statusMessage = 'Saved to device — reload skipped';
+  } catch (e: any) {
+    $statusMessage = `Error: ${e.message || e}`;
+  } finally {
+    $isLoading = false;
+  }
+}
+
+// Derived dev-mode flag from the form store. Adjust property access to
+// match the actual store shape verified during Step 1.
+const devMode = $derived($config?.dev_mode === true);
+```
+
+**Step 3: Replace the existing save button**
+
+Current button is in `ConfigForm.svelte:102-109`. Two options — pick whichever fits the codebase style:
+
+**Option A (recommended):** Remove the save button from `ConfigForm.svelte` entirely. Render `SplitButton` directly in the toolbar area of `+page.svelte` where `ConfigForm` sits. Cleaner separation: form owns validation, page owns persistence.
+
+**Option B:** Keep button inside `ConfigForm.svelte`, change its `Props` to:
+```typescript
+interface Props {
+  onSaveAndApply: () => void;
+  onSaveLocal: () => void;
+  onSaveNoReload: () => void;
+  devMode: boolean;
+  hasErrors: boolean;
+  isDirty: boolean;
+  hasDeviceConnected: boolean;
+  children?: Snippet;
+}
+```
+and render:
+```svelte
+<SplitButton
+  primaryLabel={hasErrors ? 'Fix errors to save' : isDirty ? 'Save & Apply *' : 'Save & Apply'}
+  primaryOnClick={onSaveAndApply}
+  primaryDisabled={hasErrors || !hasDeviceConnected}
+  primaryTitle="Save & Apply (⌘S)"
+  variant="primary"
+  menu={[
+    { label: 'Save (local file only)', onclick: onSaveLocal },
+    { label: 'Save to Device, No Reload', onclick: onSaveNoReload, hidden: !devMode, disabled: !hasDeviceConnected },
+  ]}
+/>
+```
+
+**Step 4: Update ⌘S keyboard handler**
+
+`+page.svelte:113` currently calls `saveToDevice()`. Change to `saveAndApply()`.
+
+**Step 5: Type-check**
+
+Run: `cd config-editor && npm run check`
+Expected: 0 errors.
+
+**Step 6: Manual UI test**
+
+1. `cd config-editor && npm run tauri dev`
+2. Connect a device, load its config.
+3. Change a button color → **Save & Apply** → expect "Saved & applied", LED color updates on device, no reboot, serial stays connected.
+4. Caret → **Save (local file only)** → expect Tauri save dialog, no device write.
+5. Change `usb_drive_name` → **Save & Apply** → expect "Saved & rebooted", drive remounts with new name, host re-enumerates (~2s).
+6. Toggle a button to `type:"hid"` → **Save & Apply** → expect hard reset (HID descriptor change).
+7. Enable `dev_mode` in config (via Save & Apply, which triggers hard reset), reconnect, then caret menu shows **Save to Device, No Reload**. Click → file written, no reload. Manually click existing Reload button → works.
+8. Disconnect device → primary button disabled, **Save (local)** still works.
+9. Confirm SplitButton: click outside menu closes it; click on menu item still fires (regression test for click-outside ordering).
+
+**Step 7: Commit**
+
+```bash
+git add config-editor/src/routes/+page.svelte config-editor/src/lib/components/ConfigForm.svelte
+git commit -m "feat(editor): Save & Apply split button with auto hot-reload / hard-reset"
+```
+
+---
+
+## Task 7: AGENTS.md updates
+
+**Files:**
+- Modify: `firmware/AGENTS.md`
+- Modify: `config-editor/AGENTS.md` (if present) or root `AGENTS.md`
+
+**Step 1: Document hot-reload contract in `firmware/AGENTS.md`**
+
+Add under "Firmware Patterns":
+
+```markdown
+### Hot Config Reload
+
+`reload_runtime_config()` in `code.py` re-reads `/config.json` and rebuilds
+runtime state (buttons, LEDs, display, MIDI maps) without re-running
+`boot.py`. Called over REPL by the config-editor's Save & Apply flow as
+`sys.modules['__main__'].reload_runtime_config()` — NOT `import code`,
+which would re-execute the whole file as a separate module.
+
+**Cannot hot-reload** — these require `microcontroller.reset()`:
+- `usb_drive_name` — set by `storage.remount(label=...)` in `boot.py`
+- `dev_mode` — controls `storage.disable_usb_drive()` in `boot.py`
+- `device` — pin maps and module imports decided at top of `code.py`
+- HID descriptor toggle — `boot.py` enables HID conditionally on any
+  `type:"hid"` button; descriptor rebuild needs USB re-enumeration.
+  Changing `hid_key` / `hid_modifier` on an existing HID button is hot;
+  only the on/off toggle is hard.
+
+The editor diffs old vs new config in `reload_diff.rs` and picks
+hot-reload vs hard-reset automatically.
+```
+
+**Step 2: Commit**
+
+```bash
+git add firmware/AGENTS.md config-editor/AGENTS.md
+git commit -m "docs: document hot config reload contract"
+```
+
+---
+
+## Out of Scope (V1)
+
+- mtime-based auto-watch in firmware (extra loop overhead, race conditions)
+- Partial reloads (LED-only, display-only)
+- Rollback on reload failure — surface error to user, they re-save
+- Remembering "last used" secondary as new primary
+- Arrow-key navigation inside the SplitButton dropdown
+- Touch UI / mobile breakpoints for the SplitButton menu
+- Vitest setup for the SplitButton + diff logic on the TS side (Rust side already has unit tests)
+
+---
+
+## Review Patches Applied (vs first draft)
+
+- **Bug 1:** REPL command changed from `from code import reload_runtime_config` to `import sys; sys.modules['__main__'].reload_runtime_config()` (code.py runs as `__main__`, `import code` would re-execute it).
+- **Bug 2:** SplitButton outside-click uses `pointerdown` and checks `rootEl.contains(target)` so menu items still receive clicks.
+- **Bug 3:** `pc_values` no longer reset on hot reload — preserves mid-performance pc_inc/dec state.
+- **Bug 4:** `classify_reload` Tauri command explicit in Task 3 Step 1 + registered in `lib.rs` Step 2.
+- **Gap 1 (file flush race):** retracted — `write_sync` (`commands.rs:232`) already `sync_all()`s before returning. No extra sleep needed.
+- **Gap 2 (currentConfigJson, devMode):** resolved — uses `$currentConfigRaw` store and `normalizeConfig(get(config))` consistent with existing `saveToDevice`. `devMode` from `$config?.dev_mode`.
+- **Gap 3 (saveLocalOnly stub):** concrete impl using `@tauri-apps/plugin-dialog` `save()`.
+- **Nit 3 (extract helpers):** Task 1 Step 2 now explicit: move only paint lines, leave hardware init alone, and update startup sites to call the helpers (single source of truth).

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -12,7 +12,7 @@
 **Closes:** #14 (already closed as duplicate of #73).
 **Forward-links:** #15 (pages), #47 (multi-message per slot), #123 (CC ramp), #125 (select-mode + keytimes compatibility).
 
-**Breaking change:** The `keytimes: N` + `states[]` fields on existing `mode: "toggle"`/`"momentary"` buttons are **removed**. They were the multi-state cycling mechanism we're replacing — anyone using them upgrades by switching the button to `mode: "keytimes"` and re-expressing the cycle in the new shape. No automatic migration; the user base is small and the new mode is a strict superset of what `keytimes` + `states[]` could do. Validator rejects `keytimes`/`states` on non-keytimes-mode buttons.
+**Breaking change (lands in Phase 3):** The `keytimes: N` + `states[]` fields on existing `mode: "toggle"`/`"momentary"` buttons are **removed** in v2.0. They were the multi-state cycling mechanism we're replacing — anyone using them upgrades by switching the button to `mode: "keytimes"` and re-expressing the cycle in the new shape. No automatic migration; the user base is small and the new mode is a strict superset of what `keytimes` + `states[]` could do. To keep phases incrementally shippable, the validator continues to *accept* legacy `keytimes`/`states` through Phase 1 and Phase 2 (existing behavior preserved); Phase 3 flips that to strict rejection alongside example-config cleanup and the v2.0 release notes.
 
 ---
 

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -1,0 +1,697 @@
+# Press Timings & Long-Press Implementation Plan (#48)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add OEM-parity press-timing support to footswitches — short/long press detection with independent message cycles, replacing the current `keytimes`/`states[]` shape with a cleaner two-cycle model.
+
+**Architecture:** Two independent cycles per button (`short`, `long`), each an array of entries with optional `down`/`up`/`color` sub-fields. A polling-loop threshold timer in the firmware detects when a held button transitions from "short" to "long" classification. Cycle state lives in a per-page table in RAM (per-page model is forward-compatible with #15). The schema reserves array-of-messages per slot (single-element today, multi-element later per #47).
+
+**Tech Stack:** CircuitPython firmware (Python), pytest for firmware tests, JSON schema for config validation.
+
+**Resolves:** #48 (this issue), #73 (external-contributor parity request), partially feeds #15 (pages) and #47 (multi-message).
+**Closes:** #14 (already closed as duplicate of #73).
+**Forward-links:** #15 (pages), #47 (multi-message per slot), #123 (CC ramp).
+
+---
+
+## Design Summary
+
+### The Four Trigger Timings
+
+| Slot | Fires when |
+|---|---|
+| `short_down` | Button physically goes down, *before* the long-press threshold elapses. Always fires on every press (short or long) if defined. |
+| `short_up` | Button is released *before* the threshold elapses (i.e. a "tap-and-release"). Does NOT fire if the press became long. |
+| `long_down` | Threshold elapsed while still held. The press has been classified as long. |
+| `long_up` | Button is released *after* the threshold elapsed (i.e. release of a long press). |
+
+`short_up` is the only slot that doesn't fire under all conditions — this is deliberate and matches OEM. Doc this as a "tap" semantic.
+
+To fire a message regardless of duration:
+- On the press → bind `short_down`. It fires on every physical press.
+- On the release → bind the same message to both `short_up` AND `long_up`.
+
+### Cycles
+
+Each button has **two independent cycles**: `short` and `long`. Each is an array of entries. Each entry has optional `down`, `up`, and `color` sub-fields. The down/up of the same entry are paired by physical press (same as OEM's `short_dwN`/`short_upN` pairing by N).
+
+**Advancement rule:** Per cycle, per physical press — advance by 1 if ≥1 of that cycle's events fired during the press; else don't advance.
+
+So a short tap with both `short_down` and `short_up` defined → both fire, short cycle advances **by 1** (not 2). A long press with both `short_down` and `long_down` defined → both fire (different cycles), each advances by 1.
+
+### Threshold
+
+- `long_press_threshold_ms` is a top-level config field. Default **500ms**.
+- Each button may set its own `long_press_threshold_ms` override.
+- Resolution: button override if set, else global, else 500.
+
+### Color Render Rule
+
+Each cycle's current entry carries an optional `color`. The two layers combine as:
+
+```
+if short.color == "off":     LED = off       (kill switch — short "off" overrides all)
+elif long.color is set:      LED = long      (decoration over primary)
+elif short.color is set:     LED = short
+else:                        LED = off
+```
+
+Within a cycle, an entry with no `color` field **inherits** the previous entry's color. An explicit `"off"` is distinct from unset.
+
+The asymmetry (`"off"` on short kills the LED but `"off"` on long is just "no decoration") matches the physical pedalboard metaphor: short is the primary indicator, long is a decoration painted over it; with no primary, there's nothing to decorate.
+
+### Cycle State Lifecycle
+
+| Event | Cycles reset? |
+|---|---|
+| Power cycle / boot | Yes (RAM is volatile) |
+| Config push from editor | Yes (triggers reboot) |
+| Page change away & back (after #15 lands) | No (sticky per page) |
+| In-flight press when page changes | Press cancelled; no events fire |
+
+In-flight cancellation is the chosen behavior. Alternatives **(b)** "press continues against original page" and **(c)** "press rebinds to new page" are documented in this plan and the user-facing docs as considered-but-rejected, in case a future use case justifies them.
+
+### Reserved Slots (Future)
+
+- `hold` — continuous repeating action while held (re-send the same message every N ms). Tracked separately from `long`. Initially unimplemented; schema reserves the key.
+- CC ramp (#123) — interpolate a CC value while held. Out of scope for #48.
+
+### Schema Shape
+
+```json
+{
+  "label": "VERB",
+  "color": "blue",
+  "long_press_threshold_ms": 500,
+  "short": [
+    { "down": [{ "type": "cc", "cc": 20, "value": 127 }], "color": "white" },
+    { "down": [{ "type": "cc", "cc": 20, "value": 0   }], "color": "off"   }
+  ],
+  "long": [
+    { "down": [{ "type": "cc", "cc": 21, "value": 127 }], "color": "blue"  },
+    { "down": [{ "type": "cc", "cc": 21, "value": 0   }], "color": "white" }
+  ]
+}
+```
+
+Each sub-action (`down`, `up`) is an **array** of message objects, even when there's only one. This reserves the shape for #47 (multi-message per slot) without future migration. Initial firmware reads index `[0]` only; later firmware iterates the full list.
+
+Message objects use the existing `type`-discriminated shape (`{type: "cc", cc, value}`, `{type: "pc", program}`, `{type: "note", note, velocity}`, `{type: "hid", action, key, modifier, delay_ms}`). This converges with the unified-message-types plan (`docs/plans/2026-03-01-unified-message-types.md`).
+
+---
+
+## Design Rationale & Alternatives Considered
+
+This section preserves the *why* behind the choices so future contributors don't re-litigate them.
+
+### Why two independent cycles instead of one shared
+
+A user's real OEM config: short-press 1 = reverb on, short-press 2 = reverb off, long-press 1 = shimmer on, long-press 2 = shimmer off. This only works if short and long maintain independent counters — otherwise a hold in the middle of a sequence would scramble the short cycle.
+
+OEM does the same: `short_upX` and `longX` increment their X separately.
+
+**Rejected:** one shared cycle index across both short and long. It collapses the two-effect-per-button pattern into a single sequence, which is strictly less expressive than OEM and breaks the reverb+shimmer scenario.
+
+### Why pair `down`/`up` within an entry instead of independent timing sequences
+
+OEM pairs `short_dwN` and `short_upN` by N — both reference "the Nth short press." Within a single physical press, the down and up events are bookends of the same event, so they must use the same cycle index.
+
+**Rejected:** separate `short_down: [...]`, `short_up: [...]` arrays with independent counters. This would mean down and up could desynchronize, which isn't physically possible (every down has a matching up). Pairing inside one entry object is correct.
+
+**Rejected:** wrapper renames `short_press_cycle`/`long_press_cycle`, nested `cycles.short`/`cycles.long`, per-entry `n` field for explicit indexing. The schema as proposed already matches OEM's pairing-by-index semantics; further naming changes added clutter without clarity. The doc and examples carry the burden of teaching the pairing.
+
+### Why "long modifies short" for color, with `"off"`-on-short as kill switch
+
+Pedalboard mental model: the short cycle is the *primary* effect indicator. The long cycle is a *decoration* (secondary effect) painted on top. When the primary is off, the LED is dark — there's nothing for the decoration to attach to.
+
+Concretely, this preserves the user's traced expectation: with reverb (short=white) + shimmer (long=blue), the LED is blue while both are on. Hit short again to turn reverb off (short=`off`); LED goes dark even though shimmer is still on, because there's no primary effect to color.
+
+**Rejected:** symmetric override ("long always wins when set"). Loses the kill-switch semantic and surprises users who turn off the primary effect.
+
+**Rejected:** RGB blending of short + long colors. Cute but unpredictable and impossible to reason about during a gig.
+
+**Deferred:** opt-in inversion flag `color_priority: "short" | "long"`. YAGNI — no concrete use case. If one surfaces, easy to add as a button-level flag without migration.
+
+### Why `hold` is reserved for the repeating flavor only
+
+"Continuous on/off while held" (CC-on at threshold, CC-off at release) is already expressible via `long_down` (on) + `long_up` (off). No new slot needed. Reserving `hold` exclusively for the repeating-while-held flavor avoids overloading the term.
+
+CC ramp (continuous interpolation while held) is filed separately as #123 — different enough to merit its own field, not just a `hold` variant.
+
+### Why `states[]` and `keytimes` count are removed
+
+The current shape locks each button to one `cc` channel and message type (`cc_on`/`cc_off` values vary per state). Adding long-press would force each state to carry multiple message variants and possibly different message types — the flat shape doesn't compose.
+
+**Replaced with:** cycle arrays where length *is* the count, each entry can carry any message type, and `down`/`up`/`color` are first-class per-entry fields.
+
+### Why arrays for `down`/`up` even when single-message
+
+Forward compatibility with #47 (multi-message per slot). Strict array form means no schema migration when #47 lands — only firmware logic changes (read all elements instead of index 0).
+
+**Rejected:** polymorphic `Message | Message[]` shape. Easier for hand-authors, harder for the config editor and the schema validator. Strict arrays are the right trade for a mostly-tool-edited config.
+
+### Why page-change cancels in-flight press
+
+Alternatives:
+- **(b)** Continue press; fire long/up events against the *original* page's bindings even though that page isn't displayed. Creates ghost events.
+- **(c)** Rebind in-flight press to the new page's button at the same position. Incoherent — there's no guarantee the new page's button has the same press class defined.
+
+**(a)** cancellation is the only sane default. (b) and (c) are documented in user-facing docs as "considered alternatives" so contributors with a concrete use case can advocate without re-discovering the trade-off.
+
+---
+
+## Phasing
+
+This is too large for a single PR. The plan phases the work so each phase is independently shippable and reviewable.
+
+| Phase | What | Status |
+|---|---|---|
+| 1 | Switch timing infrastructure: timer/threshold detection in `Switch` class. Pure-test, no config changes. | Detailed below |
+| 2 | Schema + validator: parse new `short`/`long`/`long_press_threshold_ms` fields. New code doesn't yet *use* them. | Outline only |
+| 3 | New dispatch core: `handle_switches()` consumes the new schema for buttons that declare `short`/`long`. Old buttons keep working via the existing dispatch path. | Outline only |
+| 4 | Color render rule + cycle state table (forward-compatible with per-page). | Outline only |
+| 5 | Migrate all example configs to the new shape. Deprecate old shape via validator warning. | Outline only |
+| 6 | Remove old shape entirely (post-#47, post-#15). | Future plan |
+
+**Phase 1 is fully detailed below.** Phases 2–5 are outlined; each becomes its own plan when it gets picked up. This keeps the plan document focused on actionable work without ballooning to thousands of lines.
+
+---
+
+## Phase 1: Switch Timing Infrastructure
+
+**Goal:** Extend the `Switch` class so it produces timing-classified events (`short_down`, `short_up`, `long_down`, `long_up`) based on observed press lifecycle, with no impact on existing dispatch.
+
+**Files:**
+- Modify: `firmware/dev/core/button.py` (add `PressTracker` class — separate from `Switch` for testability)
+- Test: `tests/test_press_tracker.py` (new file)
+- Reference: `tests/conftest.py` for time-mocking patterns
+
+**Why a separate class instead of bolting onto `Switch`:** `Switch` is a thin wrapper around `digitalio.DigitalInOut` and pull-up state. Timing logic is pure and best tested without any hardware mock. `PressTracker` consumes `(pressed: bool, now: float)` inputs and emits events. Compose: `Switch` produces edge-detected pressed/released, `PressTracker` adds timing classification.
+
+### Task 1: PressTracker contract + failing test
+
+**Files:**
+- Create: `tests/test_press_tracker.py`
+
+**Step 1: Write failing tests for the PressTracker contract**
+
+Drop this into `tests/test_press_tracker.py`:
+
+```python
+"""Tests for press-timing classification."""
+import pytest
+from core.button import PressTracker
+
+
+class TestPressTrackerIdle:
+    def test_idle_no_events(self):
+        tracker = PressTracker(threshold_ms=500)
+        events = tracker.update(pressed=False, now=0.0)
+        assert events == []
+
+
+class TestPressTrackerShortPress:
+    def test_press_emits_short_down(self):
+        tracker = PressTracker(threshold_ms=500)
+        events = tracker.update(pressed=True, now=0.0)
+        assert events == ["short_down"]
+
+    def test_release_before_threshold_emits_short_up(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=False, now=0.2)
+        assert events == ["short_up"]
+
+    def test_hold_steady_no_events(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=True, now=0.1)
+        assert events == []
+
+
+class TestPressTrackerLongPress:
+    def test_threshold_emits_long_down(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=True, now=0.5)
+        assert events == ["long_down"]
+
+    def test_long_down_fires_once(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        events = tracker.update(pressed=True, now=1.0)
+        assert events == []
+
+    def test_release_after_threshold_emits_long_up(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        events = tracker.update(pressed=False, now=0.7)
+        assert events == ["long_up"]
+
+    def test_release_after_threshold_does_not_emit_short_up(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        events = tracker.update(pressed=False, now=0.7)
+        assert "short_up" not in events
+
+
+class TestPressTrackerSubsequentPresses:
+    def test_two_short_presses_independent(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=False, now=0.1)
+        events = tracker.update(pressed=True, now=0.5)
+        assert events == ["short_down"]
+
+    def test_long_then_short(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        tracker.update(pressed=False, now=0.7)
+        events = tracker.update(pressed=True, now=1.0)
+        assert events == ["short_down"]
+
+
+class TestPressTrackerEdgeCases:
+    def test_threshold_exactly(self):
+        """Crossing the threshold exactly counts as long."""
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=True, now=0.5)
+        assert events == ["long_down"]
+
+    def test_immediate_long_press_from_initial_state(self):
+        """First update with pressed=True at t=0 fires short_down; later update past threshold fires long_down."""
+        tracker = PressTracker(threshold_ms=500)
+        events_t0 = tracker.update(pressed=True, now=0.0)
+        events_t1 = tracker.update(pressed=True, now=0.6)
+        assert events_t0 == ["short_down"]
+        assert events_t1 == ["long_down"]
+
+    def test_release_with_no_prior_press(self):
+        """Defensive: spurious release without preceding press emits nothing."""
+        tracker = PressTracker(threshold_ms=500)
+        events = tracker.update(pressed=False, now=0.0)
+        assert events == []
+```
+
+**Step 2: Run tests, verify they all fail**
+
+```bash
+cd firmware/dev && python -m pytest ../../tests/test_press_tracker.py -v
+```
+
+Expected: ImportError or "PressTracker not defined" for every test.
+
+**Step 3: Commit failing tests**
+
+```bash
+git add tests/test_press_tracker.py
+git commit -m "Add failing tests for PressTracker timing classification (#48)"
+```
+
+---
+
+### Task 2: Minimal PressTracker implementation
+
+**Files:**
+- Modify: `firmware/dev/core/button.py` (append `PressTracker` class)
+
+**Step 1: Write the minimal implementation**
+
+Append to `firmware/dev/core/button.py`:
+
+```python
+class PressTracker:
+    """Classifies button press events into short/long timing slots.
+
+    Consumes (pressed, now) on every poll and returns a list of timing events
+    that fired during the transition. Designed to compose with Switch — the
+    caller passes Switch.pressed and time.monotonic() each loop.
+
+    Threshold defines the boundary between short and long presses. A release
+    before threshold emits short_up; a release after emits long_up. The
+    short_down event fires immediately on every physical press; long_down
+    fires once when threshold is reached while still held.
+    """
+
+    def __init__(self, threshold_ms):
+        self.threshold_s = threshold_ms / 1000.0
+        self._pressed = False
+        self._down_at = None
+        self._long_fired = False
+
+    def update(self, pressed, now):
+        """Process one poll. Returns a list of event names that fired.
+
+        Event names: "short_down", "short_up", "long_down", "long_up".
+        Multiple events can fire in one update (e.g. long_down arriving during
+        a steady hold). Returned list preserves firing order.
+        """
+        events = []
+
+        if pressed and not self._pressed:
+            self._pressed = True
+            self._down_at = now
+            self._long_fired = False
+            events.append("short_down")
+        elif pressed and self._pressed:
+            if not self._long_fired and (now - self._down_at) >= self.threshold_s:
+                self._long_fired = True
+                events.append("long_down")
+        elif not pressed and self._pressed:
+            self._pressed = False
+            if self._long_fired:
+                events.append("long_up")
+            else:
+                events.append("short_up")
+            self._down_at = None
+            self._long_fired = False
+
+        return events
+```
+
+**Step 2: Run tests, verify they pass**
+
+```bash
+cd firmware/dev && python -m pytest ../../tests/test_press_tracker.py -v
+```
+
+Expected: all tests pass.
+
+**Step 3: Commit the implementation**
+
+```bash
+git add firmware/dev/core/button.py
+git commit -m "Implement PressTracker class for short/long press classification (#48)"
+```
+
+---
+
+### Task 3: Add per-press-class state for multi-press cycle support
+
+PressTracker only classifies a single press. The cycle-state (which entry to fire from) is separate concern — a `PressCycle` class.
+
+**Files:**
+- Create: tests in `tests/test_press_cycle.py`
+- Modify: `firmware/dev/core/button.py` (add `PressCycle` class)
+
+**Step 1: Write failing tests**
+
+```python
+"""Tests for press-cycle state (independent counters per short/long class)."""
+from core.button import PressCycle
+
+
+class TestPressCycleAdvancement:
+    def test_initial_index_zero(self):
+        cycle = PressCycle(length=3)
+        assert cycle.index == 0
+
+    def test_advance_increments(self):
+        cycle = PressCycle(length=3)
+        cycle.advance()
+        assert cycle.index == 1
+
+    def test_advance_wraps(self):
+        cycle = PressCycle(length=3)
+        cycle.advance()
+        cycle.advance()
+        cycle.advance()
+        assert cycle.index == 0
+
+    def test_length_one_advance_stays_at_zero(self):
+        cycle = PressCycle(length=1)
+        cycle.advance()
+        assert cycle.index == 0
+
+    def test_length_zero_no_advance(self):
+        """Zero-length cycle (no events defined) doesn't change index."""
+        cycle = PressCycle(length=0)
+        cycle.advance()
+        assert cycle.index == 0
+
+    def test_reset(self):
+        cycle = PressCycle(length=3)
+        cycle.advance()
+        cycle.advance()
+        cycle.reset()
+        assert cycle.index == 0
+```
+
+**Step 2: Run tests, verify they fail**
+
+```bash
+cd firmware/dev && python -m pytest ../../tests/test_press_cycle.py -v
+```
+
+Expected: ImportError or "PressCycle not defined."
+
+**Step 3: Commit failing tests**
+
+```bash
+git add tests/test_press_cycle.py
+git commit -m "Add failing tests for PressCycle state (#48)"
+```
+
+**Step 4: Implement PressCycle**
+
+Append to `firmware/dev/core/button.py`:
+
+```python
+class PressCycle:
+    """Tracks the current entry index for one timing class (short or long).
+
+    Independent of PressTracker — a button has two PressCycles (short, long)
+    each managing its own index. Advanced once per physical press in which
+    at least one event from this class fired.
+    """
+
+    def __init__(self, length):
+        self.length = length
+        self.index = 0
+
+    def advance(self):
+        """Advance index by 1, wrapping at length. No-op when length <= 0."""
+        if self.length > 0:
+            self.index = (self.index + 1) % self.length
+
+    def reset(self):
+        """Reset index to 0 (e.g. on power cycle or config reload)."""
+        self.index = 0
+```
+
+**Step 5: Run tests, verify they pass**
+
+```bash
+cd firmware/dev && python -m pytest ../../tests/test_press_cycle.py -v
+```
+
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add firmware/dev/core/button.py
+git commit -m "Implement PressCycle for per-class cycle state (#48)"
+```
+
+---
+
+### Task 4: Composition test — PressTracker + PressCycle end-to-end
+
+Verify the two classes compose as the design intends: feed timing events from PressTracker into the correct PressCycle's advancement, and trace the user's real-world reverb+shimmer scenario.
+
+**Files:**
+- Create: `tests/test_press_tracker_cycle_integration.py`
+
+**Step 1: Write failing test for the scenario**
+
+```python
+"""Integration: PressTracker + PressCycle traces the reverb+shimmer scenario.
+
+Replicates the user's OEM config:
+- short_up_1: reverb on
+- long_down_1: shimmer on
+- short_up_2: reverb off
+- long_down_2: shimmer off
+"""
+from core.button import PressTracker, PressCycle
+
+
+def _advance_cycles(events, short_cycle, long_cycle):
+    """Advance the relevant cycle at most once per call, per design rule."""
+    fired_short = any(e in ("short_down", "short_up") for e in events)
+    fired_long = any(e in ("long_down", "long_up") for e in events)
+    if fired_short:
+        short_cycle.advance()
+    if fired_long:
+        long_cycle.advance()
+
+
+def test_reverb_shimmer_sequence():
+    tracker = PressTracker(threshold_ms=500)
+    short = PressCycle(length=2)
+    long_ = PressCycle(length=2)
+
+    # Initial state
+    assert short.index == 0
+    assert long_.index == 0
+
+    # 1. Short tap — reverb on
+    tracker.update(pressed=True, now=0.0)
+    events = tracker.update(pressed=False, now=0.1)
+    assert "short_up" in events
+    _advance_cycles(events, short, long_)
+    assert short.index == 1
+    assert long_.index == 0
+
+    # 2. Long hold — shimmer on
+    tracker.update(pressed=True, now=1.0)
+    events_threshold = tracker.update(pressed=True, now=1.5)
+    events_release = tracker.update(pressed=False, now=1.7)
+    assert "long_down" in events_threshold
+    assert "long_up" in events_release
+    _advance_cycles(events_threshold + events_release, short, long_)
+    assert short.index == 1   # unchanged — no short event fired
+    assert long_.index == 1   # advanced
+
+    # 3. Long hold — shimmer off
+    tracker.update(pressed=True, now=2.0)
+    events_threshold = tracker.update(pressed=True, now=2.5)
+    events_release = tracker.update(pressed=False, now=2.7)
+    _advance_cycles(events_threshold + events_release, short, long_)
+    assert short.index == 1
+    assert long_.index == 0   # wrapped
+
+    # 4. Short tap — reverb off
+    tracker.update(pressed=True, now=3.0)
+    events = tracker.update(pressed=False, now=3.1)
+    _advance_cycles(events, short, long_)
+    assert short.index == 0   # wrapped
+    assert long_.index == 0
+```
+
+**Step 2: Run, verify it passes**
+
+```bash
+cd firmware/dev && python -m pytest ../../tests/test_press_tracker_cycle_integration.py -v
+```
+
+Expected: passes (both classes are now implemented).
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_press_tracker_cycle_integration.py
+git commit -m "Add integration test for PressTracker + PressCycle (#48)"
+```
+
+---
+
+### Task 5: Phase 1 verification & PR
+
+**Step 1: Run full test suite to verify no regressions**
+
+```bash
+cd firmware/dev && python -m pytest ../../tests/ -v
+```
+
+Expected: all existing tests still pass; three new test files pass.
+
+**Step 2: Push branch and open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat(#48): add PressTracker and PressCycle primitives (phase 1 of 5)" --body "$(cat <<'EOF'
+First phase of #48 (press timings). Adds timing-classification primitives in `core/button.py` with no impact on existing dispatch — these are building blocks for phases 2–5.
+
+## What's added
+- `PressTracker` — classifies a physical press into `short_down`/`short_up`/`long_down`/`long_up` events based on a configurable threshold
+- `PressCycle` — independent index counter for one timing class, with wrap-around and reset
+- Unit tests for each + integration test tracing the reverb+shimmer scenario
+
+## What's not changed
+- Schema (`config.schema.json`) — phase 2
+- Dispatch (`code.py`) — phase 3
+- Color rendering — phase 4
+- Example configs — phase 5
+
+See `docs/plans/2026-05-13-issue-48-press-timings.md` for the full design and phasing.
+
+## Test plan
+- [x] `pytest tests/test_press_tracker.py` passes
+- [x] `pytest tests/test_press_cycle.py` passes
+- [x] `pytest tests/test_press_tracker_cycle_integration.py` passes
+- [x] Existing test suite unaffected
+EOF
+)"
+```
+
+---
+
+## Phase 2 (Outline): Schema & Validator
+
+Goal: parse new fields without consuming them yet. Lays groundwork for phase 3.
+
+- **Schema:** Extend `config.schema.json` with the new top-level field `long_press_threshold_ms` (number, default 500) and per-button `short`, `long`, `hold` fields. Reserve `hold` as schema-only (no validator support yet).
+- **Validator:** `validate_button` in `firmware/dev/core/config.py` learns to parse `short[]` and `long[]` as lists of entries, each with optional `down: Message[]`, `up: Message[]`, `color: string`. Each `Message` validated by type (`cc`, `pc`, `note`, `hid`, `pc_inc`, `pc_dec`). `long_press_threshold_ms` accepted at both top level and per-button.
+- **Mutual exclusion:** A button cannot have BOTH the new shape (`short`/`long`) AND the legacy shape (`cc` + `cc_on`/`cc_off`/`keytimes`/`states`). Validator rejects, falling back to legacy with a warning.
+- **Tests:** schema parses, defaults applied, threshold resolution (button override > global > 500), invalid shapes rejected gracefully.
+
+Estimated effort: ~12 tasks of TDD-pace.
+
+## Phase 3 (Outline): Dispatch Core
+
+Goal: firmware actually *uses* the new schema for buttons that opt in. Legacy buttons unchanged.
+
+- **Loop hook:** `code.py`'s `handle_switches()` polls each switch's `pressed` + `time.monotonic()` and feeds them through one `PressTracker` per button (allocated at startup). Events drive a per-button dispatcher.
+- **Per-button dispatch:** For each event in the returned list, look up the matching slot in the new schema (e.g. `short[short_idx].down`) and dispatch its `Message[]` (initially just `[0]`, full iteration deferred to #47). After dispatch, advance the relevant cycle at most once per press.
+- **Co-existence:** Buttons with legacy fields (`cc`, `keytimes`, etc.) skip the new dispatcher and use existing logic. Decision deferred to phase 5.
+- **Tests:** dispatch table for each (event, message-type) combo; integration test for the reverb+shimmer scenario at the firmware level (mocked MIDI bus).
+
+## Phase 4 (Outline): Color Rendering & Cycle State Table
+
+Goal: per-button cycle state lives in a structure designed to extend to per-page for #15. LED renders per the two-layer rule.
+
+- **State table:** `cycle_state[button_idx] = {short_idx, long_idx, short_color, long_color}`. When pages land (#15), key on `(page_id, button_idx)`.
+- **Color inherit:** When an entry has no `color` field, the layer's stored color persists. `"off"` explicitly clears it.
+- **Render function:** `compute_led_color(short_color, long_color) → rgb` per the kill-switch rule.
+- **Tests:** color trace for the reverb+shimmer example (`[white, blue, off, blue, white]`); inherit semantics; `"off"` asymmetry.
+
+## Phase 5 (Outline): Example Config Migration & Deprecation
+
+Goal: convert in-tree example configs to the new shape; warn on legacy shape.
+
+- **Migrate:** `config-example-keytimes.json`, `config-example-mini6-keytimes.json`, `config-example-all-types.json`, plus the device-default configs if they use keytimes/states.
+- **Migration script:** one-shot Python script in `firmware/dev/scripts/migrate_legacy_keytimes.py` that converts a legacy config to the new shape. Run once, commit results, archive the script under `docs/migrations/`.
+- **Deprecation warning:** validator prints a warning when legacy `keytimes`/`states` is detected. Schema can also flag deprecated.
+- **Docs:** update `AGENTS.md` and any user-facing config docs.
+
+Final removal of legacy shape: separate plan, deferred until #47 and #15 are landed (since both interact with cycle state).
+
+---
+
+## Open Items for Future Plans
+
+These were identified during design but deferred:
+
+- **#15 (pages):** when pages land, cycle state must key on `(page_id, button_idx)`. The phase 4 table is designed for this — adding the page dimension is a refactor of one key access, not a re-architecture.
+- **#47 (multi-message):** phase 3's dispatcher reads `Message[]` but only processes index 0. When #47 lands, replace the index-0 read with iteration. No schema migration needed.
+- **#123 (CC ramp):** independent feature. Lives outside the short/long cycle model; consumes the long-press threshold to start the ramp.
+- **`hold` slot (repeating-while-held):** schema reserved, no implementation. Add when a concrete use case arises.
+- **Page-change-mid-press alternatives (b) and (c):** documented as rejected; revisit if a user-reported use case justifies one.
+- **Color priority inversion:** YAGNI; one-line opt-in flag if requested.
+
+---
+
+## Concerns & Risks
+
+- **CircuitPython performance:** the polling loop must call `time.monotonic()` for every switch every iteration. On the std10 (10 switches) this is 10 timestamp reads per poll — negligible, but worth verifying the loop's overall frequency doesn't degrade. Bench on hardware after phase 3 lands.
+- **`time.monotonic()` precision on CircuitPython:** documented as second-precision on some boards. Verify on RP2040 — if precision is too coarse for 500ms thresholds, consider `time.monotonic_ns()` instead.
+- **Per-button PressTracker allocation:** STD10 has up to 10 footswitches → 10 PressTracker instances. Memory is trivial but should be confirmed within CircuitPython heap limits on the smallest target (DUO2, ONE1).
+- **CircuitPython 7.x missing `str` methods:** existing project gotcha. None of the new code uses `isalnum()`/`isalpha()`/`isdigit()` — it deals only in numbers and booleans. No exposure.
+- **Test-time mocking of `time.monotonic`:** existing `tests/conftest.py` may have helpers; if not, the tests pass an explicit `now` argument so no mock is needed.

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -12,7 +12,9 @@
 **Closes:** #14 (already closed as duplicate of #73).
 **Forward-links:** #15 (pages), #47 (multi-message per slot), #123 (CC ramp), #125 (select-mode + keytimes compatibility).
 
-**Breaking change (lands in Phase 3):** The `keytimes: N` + `states[]` fields on existing `mode: "toggle"`/`"momentary"` buttons are **removed** in v2.0. They were the multi-state cycling mechanism we're replacing — anyone using them upgrades by switching the button to `mode: "keytimes"` and re-expressing the cycle in the new shape. No automatic migration; the user base is small and the new mode is a strict superset of what `keytimes` + `states[]` could do. To keep phases incrementally shippable, the validator continues to *accept* legacy `keytimes`/`states` through Phase 1 and Phase 2 (existing behavior preserved); Phase 3 flips that to strict rejection alongside example-config cleanup and the v2.0 release notes.
+**Deprecation (v2.0) + Breaking change (v3.0):** The `keytimes: N` + `states[]` fields on `mode: "toggle"`/`"momentary"` buttons are **deprecated** in v2.0 and will be **removed** in v3.0. v2.0's validator continues to process them (legacy behavior preserved — users' existing buttons keep working) but prints a loud boot-time warning per affected button pointing to `mode: "keytimes"`. v3.0 will drop the field handling entirely. The user base is small and the new mode is a strict superset of what `keytimes` + `states[]` could do, so migration is mechanical; the soft-deprecation period exists only to avoid silently breaking buttons during upgrade.
+
+The strict-rejection alternative was considered and rejected: dropping the legacy fields silently in v2.0 would turn cycling buttons into single-state buttons with no visible explanation, which is worse UX than a warning-plus-functional. v3.0 can do the hard cut once users have had time to migrate (and once the warning has been visible for a release).
 
 ---
 
@@ -229,7 +231,7 @@ This is too large for a single PR. The plan phases the work so each phase is ind
 |---|---|---|
 | 1: Foundation | `PressTracker` + `PressCycle` primitives + schema/validator for `mode: "keytimes"`. Pure-logic, fully unit-tested, no firmware integration. Ships nothing user-visible but lays the groundwork. | Detailed below |
 | 2: Integration | `handle_switches()` adds a `mode == "keytimes"` branch consuming the new schema; color render rule + cycle state table wired in. v2.0 actually does the thing. | Outline only |
-| 3: Polish | New example configs for keytimes mode; remove or convert in-tree configs that used `keytimes`/`states` on non-keytimes modes; release notes and docs. | Outline only |
+| 3: Polish | New example configs for keytimes mode; convert in-tree configs that used `keytimes`/`states` on non-keytimes modes; deprecation warning in validator (full removal deferred to v3.0); release notes and docs. | Outline only |
 
 **Phase 1 is fully detailed below.** Phases 2 and 3 are outlined; each becomes its own plan when picked up.
 

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -61,13 +61,27 @@ Each cycle's current entry carries an optional `color`. The two layers combine a
 if short.color == "off":     LED = off          (kill switch — short "off" overrides all)
 elif long.color is set:      LED = long         (decoration over primary)
 elif short.color is set:     LED = short
-elif button.color is set:    LED = button.color (fallback — every entry inherits)
+elif button.color is set:    LED = button.color (fallback for "(inherit)" entries)
 else:                        LED = off
 ```
 
-Within a cycle, an entry with no `color` field **inherits** the previous entry's color in the same cycle. If no entry in either cycle has ever set a color (every entry is "(inherit)"), the LED falls back to the button-level `color` field — the same value used for the boot-time dim glow and for the label rendering precedence (`long_label or short_label or button.label`). An explicit `"off"` is distinct from unset.
+An entry with no `color` field — "(inherit)" in the editor — means **no override**: the layer's color clears on that entry and the LED falls back to the button-level `color` field. This mirrors the label rendering precedence (`long_label or short_label or button.label`) and matches the boot-time dim glow. An explicit `"off"` is distinct from unset: `"off"` overrides; `(inherit)` does not.
+
+Note: this is *not* "inherit the previous entry's color". An earlier draft of #48 carried the previous entry's color forward, but that caused a wrap-around surprise — a kill-switch `"off"` entry would persist through subsequent inherit entries because the inherit didn't clear the layer. The current rule is per-entry: each press resets the layer to exactly what the entry specifies, or to the button-level fallback if the entry specifies nothing.
 
 The asymmetry (`"off"` on short kills the LED but `"off"` on long is just "no decoration") matches the physical pedalboard metaphor: short is the primary indicator, long is a decoration painted over it; with no primary, there's nothing to decorate.
+
+### Render-Update Trigger
+
+Render state for an entry (`color`/`dim`/`label`) is updated **only on events whose slot has messages**. An event with an empty slot fires no MIDI and does not change the LED — the slot is silent on every axis.
+
+Consequences:
+- A config with only `short_up` populated → LED changes on tap-release, nothing on press. No "flash" of the short entry's color during a long press, because `short_down` has no slot content for that entry.
+- A config with `long_down` populated → LED changes at the threshold (when the long press is confirmed).
+- A config with `long_up` populated → LED changes at release of a long press.
+- If you want LED feedback at the threshold, configure something on `long_down`. If you want it at release, configure something on `long_up`. The slot you populate is the slot where stuff happens.
+
+Cycle *advancement* is unrelated to slot content — per-press, "≥1 of that cycle's events fired" still advances the cycle (Advancement rule above). This means a long press can still advance the short cycle even though no short-slot messages fired, because `short_down` itself is an event.
 
 ### Cycle State Lifecycle
 

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -58,13 +58,14 @@ So a short tap with both `short_down` and `short_up` defined → both fire, shor
 Each cycle's current entry carries an optional `color`. The two layers combine as:
 
 ```
-if short.color == "off":     LED = off       (kill switch — short "off" overrides all)
-elif long.color is set:      LED = long      (decoration over primary)
+if short.color == "off":     LED = off          (kill switch — short "off" overrides all)
+elif long.color is set:      LED = long         (decoration over primary)
 elif short.color is set:     LED = short
+elif button.color is set:    LED = button.color (fallback — every entry inherits)
 else:                        LED = off
 ```
 
-Within a cycle, an entry with no `color` field **inherits** the previous entry's color. An explicit `"off"` is distinct from unset.
+Within a cycle, an entry with no `color` field **inherits** the previous entry's color in the same cycle. If no entry in either cycle has ever set a color (every entry is "(inherit)"), the LED falls back to the button-level `color` field — the same value used for the boot-time dim glow and for the label rendering precedence (`long_label or short_label or button.label`). An explicit `"off"` is distinct from unset.
 
 The asymmetry (`"off"` on short kills the LED but `"off"` on long is just "no decoration") matches the physical pedalboard metaphor: short is the primary indicator, long is a decoration painted over it; with no primary, there's nothing to decorate.
 

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -43,9 +43,9 @@ Each button has **two independent cycles**: `short` and `long`. Each is an array
 - `dim` — boolean. When true, the resolved color is rendered through `dim_color()` (15% brightness, reusing existing `core/colors.py:34`). Lets a cycle entry represent a "muted" state without introducing new color names.
 - `label` — optional text override for the TFT display. Missing or empty string means inherit from the button-level `label`. Same inherit rule across the cycle as `color`.
 
-**Advancement rule:** Per cycle, per physical press — advance by 1 if ≥1 of that cycle's events fired during the press; else don't advance.
+**Advancement rule:** Per cycle, per physical press — advance by 1 if ≥1 of that cycle's events fired **with slot content** during the press; else don't advance. An event whose slot is empty does not advance the cycle (same rule as MIDI dispatch and LED render — see Render-Update Trigger below).
 
-So a short tap with both `short_down` and `short_up` defined → both fire, short cycle advances **by 1** (not 2). A long press with both `short_down` and `long_down` defined → both fire (different cycles), each advances by 1.
+So a short tap with both `short_down` and `short_up` populated → both fire, short cycle advances **by 1** (not 2). A long press with `long_down` populated but `short_down` empty → only the long cycle advances. The short cycle stays put, which is what you want for the reverb+shimmer scenario: holding to toggle shimmer must not silently shift your reverb cycle.
 
 ### Threshold
 
@@ -71,17 +71,17 @@ Note: this is *not* "inherit the previous entry's color". An earlier draft of #4
 
 The asymmetry (`"off"` on short kills the LED but `"off"` on long is just "no decoration") matches the physical pedalboard metaphor: short is the primary indicator, long is a decoration painted over it; with no primary, there's nothing to decorate.
 
-### Render-Update Trigger
+### Slot-Has-Content Rule (MIDI + LED + Cycle Advancement)
 
-Render state for an entry (`color`/`dim`/`label`) is updated **only on events whose slot has messages**. An event with an empty slot fires no MIDI and does not change the LED — the slot is silent on every axis.
+A single rule governs all three axes: **an event whose slot has no messages does nothing.** No MIDI fires, the LED render state doesn't update, and the cycle doesn't advance.
 
-Consequences:
-- A config with only `short_up` populated → LED changes on tap-release, nothing on press. No "flash" of the short entry's color during a long press, because `short_down` has no slot content for that entry.
-- A config with `long_down` populated → LED changes at the threshold (when the long press is confirmed).
-- A config with `long_up` populated → LED changes at release of a long press.
-- If you want LED feedback at the threshold, configure something on `long_down`. If you want it at release, configure something on `long_up`. The slot you populate is the slot where stuff happens.
+The slot the user populates is the slot where stuff happens. Concretely:
+- A config with only `short_up` populated → LED changes on tap-release. No flash on press. Long press does not advance the short cycle (no short MIDI fired).
+- A config with `long_down` populated → LED changes (and MIDI fires) at the threshold.
+- A config with `long_up` populated → LED changes (and MIDI fires) at release of a long press.
+- An entry with no messages on either slot (color-only) does nothing — no render, no advance. If you want a colored cycle position, give it at least one message.
 
-Cycle *advancement* is unrelated to slot content — per-press, "≥1 of that cycle's events fired" still advances the cycle (Advancement rule above). This means a long press can still advance the short cycle even though no short-slot messages fired, because `short_down` itself is an event.
+This is intentional. An earlier draft had cycle advancement triggered by any event firing (including empty `short_down` during a long press), which silently shifted the short cycle every time you held the button. That's now fixed.
 
 ### Cycle State Lifecycle
 

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -2,15 +2,17 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Add OEM-parity press-timing support to footswitches — short/long press detection with independent message cycles, replacing the current `keytimes`/`states[]` shape with a cleaner two-cycle model.
+**Goal:** Add OEM-parity press-timing support to footswitches as a **new mode** (`mode: "keytimes"`) — short/long press detection with independent message cycles per button. Existing modes (`toggle`, `momentary`, `flash`, `select`) are unchanged.
 
-**Architecture:** Two independent cycles per button (`short`, `long`), each an array of entries with optional `down`/`up`/`color` sub-fields. A polling-loop threshold timer in the firmware detects when a held button transitions from "short" to "long" classification. Cycle state lives in a per-page table in RAM (per-page model is forward-compatible with #15). The schema reserves array-of-messages per slot (single-element today, multi-element later per #47).
+**Architecture:** A new button mode `keytimes` opts into a rich press-timing + multi-state cycle model: two independent cycles per button (`short`, `long`), each an array of entries with optional `down`/`up`/`color`/`dim`/`label` sub-fields. A polling-loop threshold timer in the firmware detects when a held button transitions from "short" to "long" classification. Cycle state lives in a per-page table in RAM (per-page model is forward-compatible with #15). The schema reserves array-of-messages per slot (single-element today, multi-element later per #47). Buttons in any other mode use their existing dispatch path and config shape, completely untouched.
 
 **Tech Stack:** CircuitPython firmware (Python), pytest for firmware tests, JSON schema for config validation.
 
 **Resolves:** #48 (this issue), #73 (external-contributor parity request), partially feeds #15 (pages) and #47 (multi-message).
 **Closes:** #14 (already closed as duplicate of #73).
-**Forward-links:** #15 (pages), #47 (multi-message per slot), #123 (CC ramp).
+**Forward-links:** #15 (pages), #47 (multi-message per slot), #123 (CC ramp), #125 (select-mode + keytimes compatibility).
+
+**Breaking change:** The `keytimes: N` + `states[]` fields on existing `mode: "toggle"`/`"momentary"` buttons are **removed**. They were the multi-state cycling mechanism we're replacing — anyone using them upgrades by switching the button to `mode: "keytimes"` and re-expressing the cycle in the new shape. No automatic migration; the user base is small and the new mode is a strict superset of what `keytimes` + `states[]` could do. Validator rejects `keytimes`/`states` on non-keytimes-mode buttons.
 
 ---
 
@@ -33,7 +35,11 @@ To fire a message regardless of duration:
 
 ### Cycles
 
-Each button has **two independent cycles**: `short` and `long`. Each is an array of entries. Each entry has optional `down`, `up`, and `color` sub-fields. The down/up of the same entry are paired by physical press (same as OEM's `short_dwN`/`short_upN` pairing by N).
+Each button has **two independent cycles**: `short` and `long`. Each is an array of entries. Each entry has optional `down`, `up`, `color`, `dim`, and `label` sub-fields. The down/up of the same entry are paired by physical press (same as OEM's `short_dwN`/`short_upN` pairing by N).
+
+- `color` — named color from the existing palette. `"off"` means LED dark. Missing means inherit the previous entry's value within this cycle.
+- `dim` — boolean. When true, the resolved color is rendered through `dim_color()` (15% brightness, reusing existing `core/colors.py:34`). Lets a cycle entry represent a "muted" state without introducing new color names.
+- `label` — optional text override for the TFT display. Missing or empty string means inherit from the button-level `label`. Same inherit rule across the cycle as `color`.
 
 **Advancement rule:** Per cycle, per physical press — advance by 1 if ≥1 of that cycle's events fired during the press; else don't advance.
 
@@ -78,14 +84,17 @@ In-flight cancellation is the chosen behavior. Alternatives **(b)** "press conti
 
 ### Schema Shape
 
+A button opts into the new cycle/timing model by setting `mode: "keytimes"`. The `short` and `long` arrays are valid **only** on keytimes-mode buttons; the validator rejects them elsewhere. Existing modes (`toggle`, `momentary`, `flash`, `select`) keep their current configuration shape unchanged.
+
 ```json
 {
   "label": "VERB",
+  "mode": "keytimes",
   "color": "blue",
   "long_press_threshold_ms": 500,
   "short": [
-    { "down": [{ "type": "cc", "cc": 20, "value": 127 }], "color": "white" },
-    { "down": [{ "type": "cc", "cc": 20, "value": 0   }], "color": "off"   }
+    { "down": [{ "type": "cc", "cc": 20, "value": 127 }], "color": "white", "label": "VERB+" },
+    { "down": [{ "type": "cc", "cc": 20, "value": 0   }], "color": "white", "dim": true }
   ],
   "long": [
     { "down": [{ "type": "cc", "cc": 21, "value": 127 }], "color": "blue"  },
@@ -97,6 +106,12 @@ In-flight cancellation is the chosen behavior. Alternatives **(b)** "press conti
 Each sub-action (`down`, `up`) is an **array** of message objects, even when there's only one. This reserves the shape for #47 (multi-message per slot) without future migration. Initial firmware reads index `[0]` only; later firmware iterates the full list.
 
 Message objects use the existing `type`-discriminated shape (`{type: "cc", cc, value}`, `{type: "pc", program}`, `{type: "note", note, velocity}`, `{type: "hid", action, key, modifier, delay_ms}`). This converges with the unified-message-types plan (`docs/plans/2026-03-01-unified-message-types.md`).
+
+### Other Modes (unchanged)
+
+`mode: "toggle"`, `"momentary"`, `"flash"`, and `"select"` retain their current schemas verbatim — button-level `cc`/`cc_on`/`cc_off`, `note`/`velocity_on`/`velocity_off`, `program`, `pc_step`, `hid_*` fields, `color`, `off_mode`, `channel`, `flash_ms`, `select_group`, `select_repress`. A user who just wants a stomp picks `momentary`; a latching effect uses `toggle`; rich multi-state/long-press behavior uses `keytimes`. Nothing in the new mode disturbs the simple cases.
+
+The one schema change for non-keytimes modes: the legacy `keytimes: N` + `states[]` fields are **removed** from `toggle`/`momentary` (they previously enabled multi-state cycling on those modes). That role is now exclusively `mode: "keytimes"`'s job. Validator emits a clear error on configs that try to use them outside keytimes mode.
 
 ---
 
@@ -111,6 +126,43 @@ A user's real OEM config: short-press 1 = reverb on, short-press 2 = reverb off,
 OEM does the same: `short_upX` and `longX` increment their X separately.
 
 **Rejected:** one shared cycle index across both short and long. It collapses the two-effect-per-button pattern into a single sequence, which is strictly less expressive than OEM and breaks the reverb+shimmer scenario.
+
+### Why cycle lengths are independent
+
+OEM uses a single `keytimes` count covering all four timing slots on a button (so `short_dwN`, `short_upN`, `longN`, `long_upN` all share the same N — though the short and long *counters* advance independently). The new model decouples the lengths too: `short` and `long` are independent arrays with independent lengths.
+
+The reverb+shimmer scenario above happens to use length 2 for both cycles. But a button can legitimately have `short.length == 3` and `long.length == 2` — e.g., a "Lead" footswitch where:
+
+- Tap cycles through three gain stages: Clean → Crunch → Lead → (back to Clean)
+- Hold cycles through two ambient modes: Hall reverb → Plate reverb → (back to Hall)
+
+**In the new model**, that's five entries total — three in `short`, two in `long`:
+
+```json
+"short": [
+  { "down": [...Clean ...], "label": "CLEAN"  },
+  { "down": [...Crunch...], "label": "CRUNCH" },
+  { "down": [...Lead  ...], "label": "LEAD"   }
+],
+"long": [
+  { "down": [...Hall ...], "label": "HALL"  },
+  { "down": [...Plate...], "label": "PLATE" }
+]
+```
+
+**Under OEM**, the shared `keytimes` count forces you to the lowest-common-multiple of the two cycle periods — here `LCM(3, 2) = 6`. That's *twelve* slot definitions (six short, six long), with values repeated to keep both cycles aligned:
+
+```
+keytimes = 6
+short_up_1 = Clean,  long_1 = Hall
+short_up_2 = Crunch, long_2 = Plate
+short_up_3 = Lead,   long_3 = Hall
+short_up_4 = Clean,  long_4 = Plate
+short_up_5 = Crunch, long_5 = Hall
+short_up_6 = Lead,   long_6 = Plate
+```
+
+This works because OEM advances the short and long counters independently — but the user pays for it with redundant entries and a DRY violation: change Clean's CC value and you must update slots 1 and 4 in lockstep; same for every other repeated state. The new model expresses the user's actual intent (three taps, two holds) without forcing them through the LCM-padding ceremony. A future contributor tempted to "fix" this by collapsing back to a single count should know it's intentional — the asymmetric case is what makes the model strictly more expressive than OEM.
 
 ### Why pair `down`/`up` within an entry instead of independent timing sequences
 
@@ -138,11 +190,20 @@ Concretely, this preserves the user's traced expectation: with reverb (short=whi
 
 CC ramp (continuous interpolation while held) is filed separately as #123 — different enough to merit its own field, not just a `hold` variant.
 
-### Why `states[]` and `keytimes` count are removed
+### Why keytimes is a dedicated mode instead of a universal replacement
 
-The current shape locks each button to one `cc` channel and message type (`cc_on`/`cc_off` values vary per state). Adding long-press would force each state to carry multiple message variants and possibly different message types — the flat shape doesn't compose.
+The first version of this design replaced toggle and momentary altogether — every button moved to the new shape, with a 2-entry cycle for "old toggle" and a single-entry-with-down+up for "old momentary." That approach buckled under its own ambition:
 
-**Replaced with:** cycle arrays where length *is* the count, each entry can carry any message type, and `down`/`up`/`color` are first-class per-entry fields.
+- It forced a migration on every existing button regardless of need
+- It required render-side heuristics ("when entry has both down and up, treat as momentary") to recover behavior the old modes expressed directly
+- It removed `off_mode` (a button-level field) and tried to express the same intent via per-entry `color`/`dim`, which got tangled
+- It generated extended discussion of "Option A vs Option C" migration strategies that don't apply if no migration is required
+
+The right framing: **toggle and momentary are intuitive, universal stomp-pedal concepts**. They're not legacy to be deprecated — they're the right shape for ~95% of button configs. The new cycle/timing model is a genuinely different *kind* of button (multi-state, press-duration-aware) and deserves its own mode rather than masquerading as a generalization of the simple cases.
+
+**Replaced with:** `mode: "keytimes"` as a third primary mode alongside `toggle` and `momentary`. Toggle/momentary buttons keep their existing shape and dispatch path; only buttons that need cycling or long-press detection opt into the new mode and the new schema fields.
+
+**Why the legacy `keytimes` + `states[]` fields on toggle/momentary are removed:** they were a half-baked version of what `mode: "keytimes"` now does properly. Keeping both would be two cycling mechanisms in the codebase, which smells. The user base is small enough that asking the handful of `keytimes`-using configs to be re-expressed in the new mode is reasonable — and the new mode is a strict superset of what the old fields could do, so nothing is lost.
 
 ### Why arrays for `down`/`up` even when single-message
 
@@ -166,27 +227,31 @@ This is too large for a single PR. The plan phases the work so each phase is ind
 
 | Phase | What | Status |
 |---|---|---|
-| 1 | Switch timing infrastructure: timer/threshold detection in `Switch` class. Pure-test, no config changes. | Detailed below |
-| 2 | Schema + validator: parse new `short`/`long`/`long_press_threshold_ms` fields. New code doesn't yet *use* them. | Outline only |
-| 3 | New dispatch core: `handle_switches()` consumes the new schema for buttons that declare `short`/`long`. Old buttons keep working via the existing dispatch path. | Outline only |
-| 4 | Color render rule + cycle state table (forward-compatible with per-page). | Outline only |
-| 5 | Migrate all example configs to the new shape. Deprecate old shape via validator warning. | Outline only |
-| 6 | Remove old shape entirely (post-#47, post-#15). | Future plan |
+| 1: Foundation | `PressTracker` + `PressCycle` primitives + schema/validator for `mode: "keytimes"`. Pure-logic, fully unit-tested, no firmware integration. Ships nothing user-visible but lays the groundwork. | Detailed below |
+| 2: Integration | `handle_switches()` adds a `mode == "keytimes"` branch consuming the new schema; color render rule + cycle state table wired in. v2.0 actually does the thing. | Outline only |
+| 3: Polish | New example configs for keytimes mode; remove or convert in-tree configs that used `keytimes`/`states` on non-keytimes modes; release notes and docs. | Outline only |
 
-**Phase 1 is fully detailed below.** Phases 2–5 are outlined; each becomes its own plan when it gets picked up. This keeps the plan document focused on actionable work without ballooning to thousands of lines.
+**Phase 1 is fully detailed below.** Phases 2 and 3 are outlined; each becomes its own plan when picked up.
+
+There is no legacy-coexistence phase. Toggle, momentary, flash, and select keep their existing dispatch and schema; the `keytimes` mode is purely additive. The only removal is the legacy `keytimes`/`states` fields when used on non-keytimes-mode buttons — that's a hard rejection in the validator with a clear error message pointing users to the new mode.
 
 ---
 
-## Phase 1: Switch Timing Infrastructure
+## Phase 1: Foundation
 
-**Goal:** Extend the `Switch` class so it produces timing-classified events (`short_down`, `short_up`, `long_down`, `long_up`) based on observed press lifecycle, with no impact on existing dispatch.
+**Goal:** Land the data-and-logic foundation for keytimes mode: `PressTracker` and `PressCycle` primitives (timing classification + cycle state), and the schema + validator changes so configs using `mode: "keytimes"` are parseable. No firmware integration yet — that's Phase 2.
 
 **Files:**
-- Modify: `firmware/dev/core/button.py` (add `PressTracker` class — separate from `Switch` for testability)
-- Test: `tests/test_press_tracker.py` (new file)
-- Reference: `tests/conftest.py` for time-mocking patterns
+- Modify: `firmware/dev/core/button.py` (add `PressTracker` and `PressCycle` classes — separate from `Switch` for testability)
+- Modify: `firmware/dev/core/config.py` (validate `mode: "keytimes"` buttons; reject `keytimes`/`states` on other modes)
+- Modify: `config.schema.json` (add `mode: "keytimes"` and the new fields; gate by mode)
+- Test: `tests/test_press_tracker.py` (new)
+- Test: `tests/test_press_cycle.py` (new)
+- Test: `tests/test_press_tracker_cycle_integration.py` (new)
+- Test: extend `tests/test_config.py` with keytimes-mode validation tests
+- Reference: `tests/conftest.py` for any helpers
 
-**Why a separate class instead of bolting onto `Switch`:** `Switch` is a thin wrapper around `digitalio.DigitalInOut` and pull-up state. Timing logic is pure and best tested without any hardware mock. `PressTracker` consumes `(pressed: bool, now: float)` inputs and emits events. Compose: `Switch` produces edge-detected pressed/released, `PressTracker` adds timing classification.
+**Why separate classes from `Switch`:** `Switch` is a thin wrapper around `digitalio.DigitalInOut` and pull-up state. Timing logic is pure and best tested without any hardware mock. `PressTracker` consumes `(pressed: bool, now: float)` inputs and emits events. Compose: `Switch` produces edge-detected pressed/released, `PressTracker` adds timing classification, `PressCycle` tracks per-class cycle index.
 
 ### Task 1: PressTracker contract + failing test
 
@@ -606,19 +671,20 @@ Expected: all existing tests still pass; three new test files pass.
 
 ```bash
 git push -u origin <branch-name>
-gh pr create --title "feat(#48): add PressTracker and PressCycle primitives (phase 1 of 5)" --body "$(cat <<'EOF'
-First phase of #48 (press timings). Adds timing-classification primitives in `core/button.py` with no impact on existing dispatch — these are building blocks for phases 2–5.
+gh pr create --title "feat(#48): foundation — PressTracker, PressCycle, keytimes-mode validator (phase 1 of 3)" --body "$(cat <<'EOF'
+First phase of #48 (press timings). Lands the data-and-logic foundation for `mode: "keytimes"` — primitives, schema, validator. No firmware integration yet.
 
 ## What's added
 - `PressTracker` — classifies a physical press into `short_down`/`short_up`/`long_down`/`long_up` events based on a configurable threshold
 - `PressCycle` — independent index counter for one timing class, with wrap-around and reset
-- Unit tests for each + integration test tracing the reverb+shimmer scenario
+- `mode: "keytimes"` recognized by validator; `short[]`/`long[]`/`long_press_threshold_ms` parsed and validated on keytimes-mode buttons
+- Validator rejects legacy `keytimes`/`states` on non-keytimes-mode buttons with a helpful error pointing to the new mode
+- Unit tests for primitives + integration test tracing the reverb+shimmer scenario + validator tests
 
-## What's not changed
-- Schema (`config.schema.json`) — phase 2
-- Dispatch (`code.py`) — phase 3
-- Color rendering — phase 4
-- Example configs — phase 5
+## What's not changed yet
+- Dispatch (`code.py`) — phase 2 wires the new schema into `handle_switches()`
+- Color rendering and cycle state table — phase 2
+- Example configs — phase 3
 
 See `docs/plans/2026-05-13-issue-48-press-timings.md` for the full design and phasing.
 
@@ -626,6 +692,7 @@ See `docs/plans/2026-05-13-issue-48-press-timings.md` for the full design and ph
 - [x] `pytest tests/test_press_tracker.py` passes
 - [x] `pytest tests/test_press_cycle.py` passes
 - [x] `pytest tests/test_press_tracker_cycle_integration.py` passes
+- [x] `pytest tests/test_config.py` passes including new keytimes-mode tests
 - [x] Existing test suite unaffected
 EOF
 )"
@@ -633,45 +700,58 @@ EOF
 
 ---
 
-## Phase 2 (Outline): Schema & Validator
+## Phase 2 (Outline): Integration
 
-Goal: parse new fields without consuming them yet. Lays groundwork for phase 3.
+Goal: firmware actually *uses* the new schema for `mode: "keytimes"` buttons. Other modes' dispatch paths are completely untouched.
 
-- **Schema:** Extend `config.schema.json` with the new top-level field `long_press_threshold_ms` (number, default 500) and per-button `short`, `long`, `hold` fields. Reserve `hold` as schema-only (no validator support yet).
-- **Validator:** `validate_button` in `firmware/dev/core/config.py` learns to parse `short[]` and `long[]` as lists of entries, each with optional `down: Message[]`, `up: Message[]`, `color: string`. Each `Message` validated by type (`cc`, `pc`, `note`, `hid`, `pc_inc`, `pc_dec`). `long_press_threshold_ms` accepted at both top level and per-button.
-- **Mutual exclusion:** A button cannot have BOTH the new shape (`short`/`long`) AND the legacy shape (`cc` + `cc_on`/`cc_off`/`keytimes`/`states`). Validator rejects, falling back to legacy with a warning.
-- **Tests:** schema parses, defaults applied, threshold resolution (button override > global > 500), invalid shapes rejected gracefully.
-
-Estimated effort: ~12 tasks of TDD-pace.
-
-## Phase 3 (Outline): Dispatch Core
-
-Goal: firmware actually *uses* the new schema for buttons that opt in. Legacy buttons unchanged.
-
-- **Loop hook:** `code.py`'s `handle_switches()` polls each switch's `pressed` + `time.monotonic()` and feeds them through one `PressTracker` per button (allocated at startup). Events drive a per-button dispatcher.
+- **Loop hook:** `code.py`'s `handle_switches()` adds a new branch when `mode == "keytimes"`. For those buttons, the loop polls `pressed` + `time.monotonic()` and feeds them through one `PressTracker` per keytimes button (allocated at startup, only for keytimes-mode buttons — others don't need timing classification).
 - **Per-button dispatch:** For each event in the returned list, look up the matching slot in the new schema (e.g. `short[short_idx].down`) and dispatch its `Message[]` (initially just `[0]`, full iteration deferred to #47). After dispatch, advance the relevant cycle at most once per press.
-- **Co-existence:** Buttons with legacy fields (`cc`, `keytimes`, etc.) skip the new dispatcher and use existing logic. Decision deferred to phase 5.
-- **Tests:** dispatch table for each (event, message-type) combo; integration test for the reverb+shimmer scenario at the firmware level (mocked MIDI bus).
+- **No legacy fallback path:** the existing dispatch branches for `cc`/`pc`/`note`/`hid` × `toggle`/`momentary`/`flash`/`select` are unchanged. The keytimes branch is purely additive.
+- **Tests:** dispatch table for each (event, message-type) combo; integration test for the reverb+shimmer scenario at the firmware level (mocked MIDI bus); verification that non-keytimes-mode buttons are completely unaffected by the new code path.
 
-## Phase 4 (Outline): Color Rendering & Cycle State Table
+### Color Rendering & Cycle State Table (within Phase 2)
 
-Goal: per-button cycle state lives in a structure designed to extend to per-page for #15. LED renders per the two-layer rule.
+Per-button cycle state lives in a structure designed to extend to per-page for #15. LED renders per the two-layer rule.
 
 - **State table:** `cycle_state[button_idx] = {short_idx, long_idx, short_color, long_color}`. When pages land (#15), key on `(page_id, button_idx)`.
 - **Color inherit:** When an entry has no `color` field, the layer's stored color persists. `"off"` explicitly clears it.
 - **Render function:** `compute_led_color(short_color, long_color) → rgb` per the kill-switch rule.
 - **Tests:** color trace for the reverb+shimmer example (`[white, blue, off, blue, white]`); inherit semantics; `"off"` asymmetry.
 
-## Phase 5 (Outline): Example Config Migration & Deprecation
+## Phase 3 (Outline): Example Configs & Legacy Cleanup
 
-Goal: convert in-tree example configs to the new shape; warn on legacy shape.
+Goal: ship example configs for `mode: "keytimes"`; remove the legacy `keytimes`/`states` fields from non-keytimes example configs (cleaning up in-tree configs that the validator now rejects).
 
-- **Migrate:** `config-example-keytimes.json`, `config-example-mini6-keytimes.json`, `config-example-all-types.json`, plus the device-default configs if they use keytimes/states.
-- **Migration script:** one-shot Python script in `firmware/dev/scripts/migrate_legacy_keytimes.py` that converts a legacy config to the new shape. Run once, commit results, archive the script under `docs/migrations/`.
-- **Deprecation warning:** validator prints a warning when legacy `keytimes`/`states` is detected. Schema can also flag deprecated.
-- **Docs:** update `AGENTS.md` and any user-facing config docs.
+### New example configs
 
-Final removal of legacy shape: separate plan, deferred until #47 and #15 are landed (since both interact with cycle state).
+- Add `config-example-keytimes-mode.json` showcasing `mode: "keytimes"`: a reverb+shimmer pattern, a multi-state cycle (3 short × 2 long Lead button from the asymmetry rationale), and a long-press-only button. Include `long_press_threshold_ms` override examples.
+- Update `config-example-all-types.json` to demonstrate `mode: "keytimes"` alongside existing modes — showing the three primary modes side-by-side.
+
+### Cleanup of legacy in-tree configs
+
+The existing `config-example-keytimes.json` and `config-example-mini6-keytimes.json` files use the old `keytimes: N` + `states[]` shape on `mode: "toggle"` buttons. Once Phase 2's validator rejects that combination, those configs won't load. Two options:
+
+- **Rewrite them as `mode: "keytimes"` examples** — preferred. Preserves the demo value and shows the new shape.
+- **Delete them entirely** — acceptable if the new `config-example-keytimes-mode.json` covers the same ground.
+
+Check device-default configs (`config-mini6.json`, `config-nano4.json`, etc.) for any `keytimes`/`states` usage and clear them; default configs shouldn't depend on the deprecated combination.
+
+### User-facing release notes
+
+For v2.0 release notes / changelog (these are for users, not contributors):
+
+- **New:** `mode: "keytimes"` adds long-press detection and rich multi-state cycling. See `config-example-keytimes-mode.json` for usage.
+- **Breaking:** the `keytimes: N` and `states[]` fields no longer work on `mode: "toggle"` or `mode: "momentary"` buttons. If you used them, switch the button to `mode: "keytimes"` and re-express the cycle in the new shape. The new mode is a strict superset and can do everything the old fields could, plus long-press.
+- Toggle, momentary, flash, and select modes are otherwise unchanged. Plain stomp configs continue to work without modification.
+
+### Tasks
+
+- Write new keytimes-mode example configs.
+- Rewrite or delete legacy in-tree configs that use `keytimes`/`states` on non-keytimes modes.
+- Update `AGENTS.md` and any user-facing config docs with the three-mode framing and a "which mode should I use?" decision guide.
+- Add v2.0 release notes to the project README or changelog.
+
+No automatic migration code is shipped. The user base is small enough (and the affected subset — anyone using `keytimes` + `states` — even smaller) that a clean break with clear release notes is the right trade.
 
 ---
 
@@ -679,6 +759,7 @@ Final removal of legacy shape: separate plan, deferred until #47 and #15 are lan
 
 These were identified during design but deferred:
 
+- **#125 (select-mode + keytimes compatibility):** select mode (#43) and keytimes mode are mutually exclusive in v2.0 — they're separate `mode` values, so a button is one or the other. Some users may want both behaviors (group-radio selection AND long-press), so #125 tracks a future design for combining them. Not blocking #48.
 - **#15 (pages):** when pages land, cycle state must key on `(page_id, button_idx)`. The phase 4 table is designed for this — adding the page dimension is a refactor of one key access, not a re-architecture.
 - **#47 (multi-message):** phase 3's dispatcher reads `Message[]` but only processes index 0. When #47 lands, replace the index-0 read with iteration. No schema migration needed.
 - **#123 (CC ramp):** independent feature. Lives outside the short/long cycle model; consumes the long-press threshold to start the ramp.

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -190,7 +190,21 @@ All outgoing MIDI goes through `midi_send(msg)` which writes to both USB and 5-p
 
 `pc_values` is a 16-element array (one per MIDI channel), shared across all pc_inc/dec buttons.
 
-Keytimes: `btn_state.advance_keytime()` is called before reading `state_cfg`, so per-state overrides are applied from `btn_config["states"][keytime_index]` via `get_button_state_config()`.
+Keytimes (legacy, deprecated): `btn_state.advance_keytime()` is called before reading `state_cfg`, so per-state overrides are applied from `btn_config["states"][keytime_index]` via `get_button_state_config()`. **Deprecated in v2.0 (warning at boot); removed in v3.0** — see `mode: "keytimes"` below for the replacement.
+
+### Mode `"keytimes"` (#48, v2.0)
+
+The `mode: "keytimes"` dispatch path is a parallel branch in `handle_switches()` separate from the legacy `dispatch_button` logic. It owns its own per-button state in `keytimes_states[]` (parallel array to `button_states[]`, holds `KeytimesButtonState` or `None`).
+
+Per-loop flow for a keytimes-mode button:
+1. `state.tracker.update(sw.pressed, time.monotonic())` returns timing events (`short_down`/`short_up`/`long_down`/`long_up`)
+2. `dispatch_keytimes_events(events, state, btn_config, callback)` — pure function in `core/button.py`, calls callback for each Message to dispatch, updates state's inherited color/dim/label, advances cycles on press-end
+3. `_dispatch_keytimes_message(msg, default_channel, btn_num)` routes by `msg["type"]` to ControlChange/ProgramChange/NoteOn/NoteOff/dispatch_hid
+4. `_render_keytimes_led(btn_num, state, btn_config)` uses `compute_keytimes_led_color()` for the two-layer render rule (short.color == "off" kills; else long.color if set; else short.color; else off)
+
+Cycle state lives in RAM only — resets on power cycle / config reload. Per-page persistence (when #15 lands) keys the state table on `(page_id, button_idx)`.
+
+See [docs/plans/2026-05-13-issue-48-press-timings.md](../docs/plans/2026-05-13-issue-48-press-timings.md) for the full design and rationale.
 
 ### PC Button LED Modes
 

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -43,6 +43,7 @@ These pass `py_compile` and `pytest` on desktop Python but **crash on device boo
 | Dict unpacking in literals | `{**cfg, "key": val}` | Manual loop: `for k,v in d.items(): r[k] = v` |
 | Walrus operator | `if (n := len(x)) > 0:` | Separate assignment |
 | `match`/`case` | `match x: case 1:` | `if`/`elif` |
+| f-string conversion specifiers | `f"{x!r}"`, `f"{x!s}"`, `f"{x!a}"` | Plain string concat with explicit `str(x)` or pre-quoted text |
 
 **CI enforces this** via the "CircuitPython 7.x compatibility guard" step in `ci.yml`.
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -1060,10 +1060,14 @@ def handle_switches():
             events = kt_state.tracker.update(sw.pressed, now)
             if events:
                 default_channel = btn_config.get("channel", 0)
+                # Trace before dispatch so the indices logged are the ones we read from
+                # for THIS event's message dispatch (not post-advance).
+                print(f"[KT btn{btn_num}] events={events} pre: short_idx={kt_state.short_cycle.index}/{kt_state.short_cycle.length} long_idx={kt_state.long_cycle.index}/{kt_state.long_cycle.length} fired_s={kt_state._fired_short} fired_l={kt_state._fired_long}")
                 dispatch_keytimes_events(
                     events, kt_state, btn_config,
                     lambda msg: _dispatch_keytimes_message(msg, default_channel, btn_num)
                 )
+                print(f"[KT btn{btn_num}] post: short_idx={kt_state.short_cycle.index} long_idx={kt_state.long_cycle.index} short_color={kt_state.short_color} long_color={kt_state.long_color}")
                 _render_keytimes_led(btn_num, kt_state, btn_config)
             continue
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -1060,14 +1060,10 @@ def handle_switches():
             events = kt_state.tracker.update(sw.pressed, now)
             if events:
                 default_channel = btn_config.get("channel", 0)
-                # Trace before dispatch so the indices logged are the ones we read from
-                # for THIS event's message dispatch (not post-advance).
-                print(f"[KT btn{btn_num}] events={events} pre: short_idx={kt_state.short_cycle.index}/{kt_state.short_cycle.length} long_idx={kt_state.long_cycle.index}/{kt_state.long_cycle.length} fired_s={kt_state._fired_short} fired_l={kt_state._fired_long}")
                 dispatch_keytimes_events(
                     events, kt_state, btn_config,
                     lambda msg: _dispatch_keytimes_message(msg, default_channel, btn_num)
                 )
-                print(f"[KT btn{btn_num}] post: short_idx={kt_state.short_cycle.index} long_idx={kt_state.long_cycle.index} short_color={kt_state.short_color} long_color={kt_state.long_color}")
                 _render_keytimes_led(btn_num, kt_state, btn_config)
             continue
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -1019,7 +1019,8 @@ def _render_keytimes_led(btn_num, state, btn_config):
         return
 
     rgb = compute_keytimes_led_color(state.short_color, state.short_dim,
-                                     state.long_color, state.long_dim)
+                                     state.long_color, state.long_dim,
+                                     btn_config.get("color"))
 
     led_idx = switch_to_led(btn_num)
     if led_idx is not None:

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -1086,6 +1086,10 @@ def handle_switches():
         # Keytimes mode (#48): poll-driven dispatch via PressTracker. Runs every loop iteration
         # so the long-press threshold timer fires even when the switch state is steady.
         if btn_config.get("mode") == "keytimes":
+            # Defensive: keytimes_states is sized to BUTTON_COUNT; idx should already be < BUTTON_COUNT
+            # given the switches loop above, but guard explicitly to mirror the buttons[] fallback at L1084.
+            if idx >= len(keytimes_states):
+                continue
             kt_state = keytimes_states[idx]
             if kt_state is None:
                 continue

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -38,9 +38,9 @@ from adafruit_midi.note_on import NoteOn
 from adafruit_midi.note_off import NoteOff
 
 # Import core modules (testable logic)
-from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display
-from core.config import load_config as _load_config_from_file, validate_config, get_display_config, get_button_state_config
-from core.button import Switch, ButtonState
+from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display, compute_keytimes_led_color
+from core.config import load_config as _load_config_from_file, validate_config, get_display_config, get_button_state_config, get_long_press_threshold_ms
+from core.button import Switch, ButtonState, KeytimesButtonState, dispatch_keytimes_events
 from core.hid import dispatch_hid
 
 # =============================================================================
@@ -480,6 +480,19 @@ for i in range(BUTTON_COUNT):
     mode = btn_config.get("mode", "toggle")
     keytimes = btn_config.get("keytimes", 1)
     button_states.append(ButtonState(cc=cc, mode=mode, keytimes=keytimes))
+
+# Per-button KeytimesButtonState for buttons in mode: "keytimes" (#48). None for other modes.
+# Each holds a PressTracker (timing classifier), two PressCycles (short/long), and inherited
+# color/dim/label state for LED rendering.
+keytimes_states = [None] * BUTTON_COUNT
+for i in range(BUTTON_COUNT):
+    _kt_cfg = buttons[i] if i < len(buttons) else {}
+    if _kt_cfg.get("mode") == "keytimes":
+        _kt_threshold = get_long_press_threshold_ms(config, _kt_cfg)
+        _kt_short_len = len(_kt_cfg.get("short", []))
+        _kt_long_len = len(_kt_cfg.get("long", []))
+        keytimes_states[i] = KeytimesButtonState(_kt_threshold, _kt_short_len, _kt_long_len)
+        print(f"Button {i+1}: mode=keytimes, threshold={_kt_threshold}ms, short_len={_kt_short_len}, long_len={_kt_long_len}")
 
 pc_values = [0] * 16                 # Current PC value per MIDI channel (0-15), shared across all pc_inc/pc_dec buttons
 pc_flash_timers = [0.0] * BUTTON_COUNT  # Expiry time (monotonic) for PC button flash; 0 = inactive
@@ -946,21 +959,119 @@ def handle_midi():
                 pass
 
 
+def _dispatch_keytimes_message(msg, default_channel, btn_num):
+    """Send a single Message dict (from a keytimes-mode entry) to MIDI or HID.
+
+    Routes by msg["type"]. Falls back to default_channel for the button when the
+    message itself doesn't specify a channel. Used by handle_switches() via the
+    callback passed to dispatch_keytimes_events().
+    """
+    channel = msg.get("channel", default_channel)
+    mtype = msg.get("type", "cc")
+    if mtype == "cc":
+        cc = msg.get("cc", 0)
+        val = msg.get("value", 0)
+        midi_send(ControlChange(cc, val), channel=channel)
+        print(f"[MIDI TX] Ch{channel+1} CC{cc}={val} (switch {btn_num}, keytimes)")
+        update_status(f"TX CC{cc}={val}")
+    elif mtype == "note":
+        note = msg.get("note", 60)
+        vel = msg.get("velocity", 127)
+        if vel > 0:
+            midi_send(NoteOn(note, vel), channel=channel)
+            print(f"[MIDI TX] Ch{channel+1} NoteOn{note} vel{vel} (switch {btn_num}, keytimes)")
+        else:
+            midi_send(NoteOff(note, 0), channel=channel)
+            print(f"[MIDI TX] Ch{channel+1} NoteOff{note} (switch {btn_num}, keytimes)")
+        update_status(f"TX Note{note}")
+    elif mtype == "pc":
+        program = msg.get("program", 0)
+        midi_send(ProgramChange(program), channel=channel)
+        pc_values[channel] = program
+        print(f"[MIDI TX] Ch{channel+1} PC{program} (switch {btn_num}, keytimes)")
+        update_status(f"TX PC{program}")
+    elif mtype in ("pc_inc", "pc_dec"):
+        step = msg.get("step", 1)
+        delta = step if mtype == "pc_inc" else -step
+        pc_values[channel] = clamp_pc_value(pc_values[channel] + delta)
+        midi_send(ProgramChange(pc_values[channel]), channel=channel)
+        print(f"[MIDI TX] Ch{channel+1} PC{pc_values[channel]} (switch {btn_num}, keytimes {mtype})")
+        update_status(f"TX PC{pc_values[channel]}")
+    elif mtype == "hid":
+        action = msg.get("action", "send")
+        key = msg.get("key")
+        modifier = msg.get("modifier")
+        delay_ms = msg.get("delay_ms", 50)
+        dispatch_hid(hid_keyboard, hid_mouse, action, key, modifier, delay_ms)
+        key_label = key if key else "?"
+        print(f"[HID TX] {action} {key_label} (switch {btn_num}, keytimes)")
+        update_status(f"HID {action}")
+
+
+def _render_keytimes_led(btn_num, state, btn_config):
+    """Update LED + display for a mode: "keytimes" button based on its current state.
+
+    Uses compute_keytimes_led_color() to apply the two-layer render rule. Label
+    precedence: long_label > short_label > button-level label.
+    """
+    idx = btn_num - 1
+    if idx < 0 or idx >= BUTTON_COUNT:
+        return
+
+    rgb = compute_keytimes_led_color(state.short_color, state.short_dim,
+                                     state.long_color, state.long_dim)
+
+    led_idx = switch_to_led(btn_num)
+    if led_idx is not None:
+        base = led_idx * 3
+        for j in range(3):
+            if base + j < LED_COUNT:
+                pixels[base + j] = rgb
+        pixels.show()
+
+    if HAS_TFT and idx < len(button_labels):
+        # Label precedence: long override (if non-empty) > short override > button-level label.
+        effective_label = (state.long_label or state.short_label or btn_config.get("label", ""))[:6]
+        button_labels[idx].text = effective_label
+        button_labels[idx].color = rgb_to_hex(rgb)
+        if idx < len(button_boxes):
+            _, box_palette = button_boxes[idx]
+            box_palette[1] = rgb_to_hex(rgb)
+
+
 def handle_switches():
     """Handle footswitch presses with keytimes support."""
     # STD10: index 0 is encoder push, 1-10 are footswitches
     # Mini6: indices 0-5 are footswitches (no encoder)
     start_idx = 1 if HAS_ENCODER else 0
+    now = time.monotonic()
     for i in range(start_idx, len(switches)):
         sw = switches[i]
+        btn_num = i if HAS_ENCODER else i + 1
+        idx = btn_num - 1
+        btn_config = buttons[idx] if idx < len(buttons) else {"cc": 20 + idx}
+
+        # Keytimes mode (#48): poll-driven dispatch via PressTracker. Runs every loop iteration
+        # so the long-press threshold timer fires even when the switch state is steady.
+        if btn_config.get("mode") == "keytimes":
+            kt_state = keytimes_states[idx]
+            if kt_state is None:
+                continue
+            events = kt_state.tracker.update(sw.pressed, now)
+            if events:
+                default_channel = btn_config.get("channel", 0)
+                dispatch_keytimes_events(
+                    events, kt_state, btn_config,
+                    lambda msg: _dispatch_keytimes_message(msg, default_channel, btn_num)
+                )
+                _render_keytimes_led(btn_num, kt_state, btn_config)
+            continue
+
+        # Legacy modes (toggle/momentary/flash/select): edge-triggered dispatch.
         changed, pressed = sw.changed()
 
         if changed:
-            # Convert to 1-indexed button number
-            btn_num = i if HAS_ENCODER else i + 1
-            idx = btn_num - 1
             btn_state = button_states[idx]
-            btn_config = buttons[idx] if idx < len(buttons) else {"cc": 20 + idx}
 
             message_type = btn_config.get("type", "cc")
             mode = btn_config.get("mode", "toggle")

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -39,7 +39,17 @@ from adafruit_midi.note_off import NoteOff
 
 # Import core modules (testable logic)
 from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display, compute_keytimes_led_color
-from core.config import load_config as _load_config_from_file, validate_config, get_display_config, get_button_state_config, get_long_press_threshold_ms
+from core.config import (
+    load_config as _load_config_from_file,
+    validate_config,
+    get_display_config,
+    get_button_state_config,
+    get_long_press_threshold_ms,
+    get_midi_thru_usb_to_din,
+    get_midi_thru_din_to_usb,
+    get_midi_thru_din_to_din,
+    get_midi_thru_usb_to_usb,
+)
 from core.button import Switch, ButtonState, KeytimesButtonState, dispatch_keytimes_events
 from core.hid import dispatch_hid
 
@@ -264,6 +274,17 @@ def load_config():
 config = load_config()
 buttons = config.get("buttons", [])
 print(f"Loaded {len(buttons)} button configs")
+
+# MIDI Thru routing matrix (read once at boot).
+# Cross routes default True; USB->USB defaults False (host loopback risk).
+MIDI_THRU_USB_TO_DIN = get_midi_thru_usb_to_din(config)
+MIDI_THRU_DIN_TO_USB = get_midi_thru_din_to_usb(config)
+MIDI_THRU_DIN_TO_DIN = get_midi_thru_din_to_din(config)
+MIDI_THRU_USB_TO_USB = get_midi_thru_usb_to_usb(config)
+print(
+    f"MIDI thru: USB->DIN={MIDI_THRU_USB_TO_DIN}, DIN->USB={MIDI_THRU_DIN_TO_USB}, "
+    f"DIN->DIN={MIDI_THRU_DIN_TO_DIN}, USB->USB={MIDI_THRU_USB_TO_USB}"
+)
 
 # =============================================================================
 # Fonts
@@ -935,15 +956,21 @@ def _process_midi_msg(msg, source="USB"):
 
 
 def handle_midi():
-    """Handle incoming MIDI messages and MIDI thru."""
+    """Handle incoming MIDI messages and MIDI thru (4-route matrix)."""
     # --- USB MIDI in ---
     usb_msg = midi.receive()
     if usb_msg:
         _process_midi_msg(usb_msg, source="USB")
-        # Thru: forward USB → 5-pin
-        if midi_serial is not None:
+        # USB -> DIN (cross)
+        if MIDI_THRU_USB_TO_DIN and midi_serial is not None:
             try:
                 midi_serial.send(usb_msg)
+            except Exception:
+                pass
+        # USB -> USB (loopback to host; opt-in)
+        if MIDI_THRU_USB_TO_USB:
+            try:
+                midi.send(usb_msg)
             except Exception:
                 pass
 
@@ -952,11 +979,18 @@ def handle_midi():
         din_msg = midi_serial.receive()
         if din_msg:
             _process_midi_msg(din_msg, source="DIN")
-            # Thru: forward 5-pin → USB
-            try:
-                midi.send(din_msg)
-            except Exception:
-                pass
+            # DIN -> USB (cross)
+            if MIDI_THRU_DIN_TO_USB:
+                try:
+                    midi.send(din_msg)
+                except Exception:
+                    pass
+            # DIN -> DIN (classic MIDI THRU pass-through)
+            if MIDI_THRU_DIN_TO_DIN:
+                try:
+                    midi_serial.send(din_msg)
+                except Exception:
+                    pass
 
 
 def _dispatch_keytimes_message(msg, default_channel, btn_num):

--- a/firmware/dev/config-example-hid.json
+++ b/firmware/dev/config-example-hid.json
@@ -69,14 +69,11 @@
     {
       "label": "Cycle",
       "color": "yellow",
-      "type": "hid",
-      "hid_action": "send",
-      "hid_key": "F1",
-      "keytimes": 3,
-      "states": [
-        { "hid_key": "F1", "color": "yellow" },
-        { "hid_key": "F2", "color": "cyan" },
-        { "hid_key": "F3", "color": "green" }
+      "mode": "keytimes",
+      "short": [
+        {"down": [{"type": "hid", "action": "send", "key": "F1"}], "color": "yellow"},
+        {"down": [{"type": "hid", "action": "send", "key": "F2"}], "color": "cyan"},
+        {"down": [{"type": "hid", "action": "send", "key": "F3"}], "color": "green"}
       ]
     }
   ]

--- a/firmware/dev/config-example-keytimes-mode.json
+++ b/firmware/dev/config-example-keytimes-mode.json
@@ -1,0 +1,111 @@
+{
+  "device": "std10",
+  "display": {
+    "button_text_size": "medium",
+    "status_text_size": "medium",
+    "expression_text_size": "medium"
+  },
+  "long_press_threshold_ms": 500,
+  "buttons": [
+    {
+      "label": "VERB",
+      "color": "blue",
+      "mode": "keytimes",
+      "short": [
+        {"up": [{"type": "cc", "cc": 20, "value": 127}], "color": "white"},
+        {"up": [{"type": "cc", "cc": 20, "value": 0}],   "color": "off"}
+      ],
+      "long": [
+        {"down": [{"type": "cc", "cc": 21, "value": 127}], "color": "blue"},
+        {"down": [{"type": "cc", "cc": 21, "value": 0}],   "color": "white"}
+      ]
+    },
+    {
+      "label": "LEAD",
+      "color": "red",
+      "mode": "keytimes",
+      "short": [
+        {"down": [{"type": "pc", "program": 10}], "color": "green",  "label": "CLEAN"},
+        {"down": [{"type": "pc", "program": 11}], "color": "orange", "label": "CRNCH"},
+        {"down": [{"type": "pc", "program": 12}], "color": "red",    "label": "LEAD"}
+      ],
+      "long": [
+        {"down": [{"type": "cc", "cc": 30, "value": 64}],  "color": "cyan",    "label": "HALL"},
+        {"down": [{"type": "cc", "cc": 30, "value": 127}], "color": "magenta", "label": "PLATE"}
+      ]
+    },
+    {
+      "label": "TAP",
+      "color": "white",
+      "mode": "keytimes",
+      "long_press_threshold_ms": 700,
+      "short": [
+        {"down": [{"type": "cc", "cc": 64, "value": 127}], "color": "white"}
+      ],
+      "long": [
+        {"down": [{"type": "cc", "cc": 65, "value": 127}], "color": "purple", "label": "TUNER"}
+      ]
+    },
+    {
+      "label": "MUTE",
+      "color": "yellow",
+      "mode": "keytimes",
+      "short": [
+        {
+          "down": [{"type": "cc", "cc": 66, "value": 127}],
+          "up":   [{"type": "cc", "cc": 66, "value": 0}],
+          "color": "yellow"
+        }
+      ]
+    },
+    {
+      "label": "DLY",
+      "color": "cyan",
+      "mode": "keytimes",
+      "short": [
+        {"down": [{"type": "cc", "cc": 67, "value": 127}], "color": "cyan"},
+        {"down": [{"type": "cc", "cc": 67, "value": 0}],   "color": "cyan", "dim": true}
+      ]
+    },
+    {"label": "COMP", "cc": 22, "color": "green"},
+    {"label": "OD", "cc": 23, "color": "orange"},
+    {"label": "OCT", "cc": 24, "color": "purple"},
+    {"label": "MOD", "cc": 25, "color": "magenta"},
+    {"label": "ROOM", "cc": 26, "color": "white"}
+  ],
+  "encoder": {
+    "enabled": true,
+    "cc": 11,
+    "label": "ENC",
+    "min": 0,
+    "max": 127,
+    "initial": 64,
+    "steps": null,
+    "push": {
+      "enabled": true,
+      "cc": 14,
+      "label": "PUSH",
+      "mode": "momentary"
+    }
+  },
+  "expression": {
+    "exp1": {
+      "enabled": true,
+      "cc": 12,
+      "label": "EXP1",
+      "min": 0,
+      "max": 127,
+      "polarity": "normal",
+      "threshold": 2
+    },
+    "exp2": {
+      "enabled": true,
+      "cc": 13,
+      "label": "EXP2",
+      "min": 0,
+      "max": 127,
+      "polarity": "normal",
+      "threshold": 2
+    }
+  }
+}

--- a/firmware/dev/config-example-keytimes.json
+++ b/firmware/dev/config-example-keytimes.json
@@ -5,26 +5,29 @@
     "status_text_size": "medium",
     "expression_text_size": "medium"
   },
+  "long_press_threshold_ms": 500,
   "buttons": [
     {
       "label": "VERB",
-      "cc": 20,
       "color": "blue",
-      "keytimes": 3,
-      "states": [
-        {"cc_on": 64, "color": "blue"},
-        {"cc_on": 96, "color": "cyan"},
-        {"cc_on": 127, "color": "white"}
+      "mode": "keytimes",
+      "short": [
+        {"down": [{"type": "cc", "cc": 20, "value": 64}],  "color": "blue"},
+        {"down": [{"type": "cc", "cc": 20, "value": 96}],  "color": "cyan"},
+        {"down": [{"type": "cc", "cc": 20, "value": 127}], "color": "white"}
       ]
     },
     {
       "label": "DELAY",
-      "cc": 21,
       "color": "yellow",
-      "keytimes": 2,
-      "states": [
-        {"cc_on": 64, "color": "yellow"},
-        {"cc_on": 127, "color": "orange"}
+      "mode": "keytimes",
+      "short": [
+        {"up": [{"type": "cc", "cc": 21, "value": 127}], "color": "yellow"},
+        {"up": [{"type": "cc", "cc": 21, "value": 0}],   "color": "off"}
+      ],
+      "long": [
+        {"down": [{"type": "cc", "cc": 22, "value": 64}],  "color": "magenta"},
+        {"down": [{"type": "cc", "cc": 22, "value": 127}], "color": "purple"}
       ]
     },
     {"label": "COMP", "cc": 22, "color": "red"},

--- a/firmware/dev/config-example-mini6-keytimes.json
+++ b/firmware/dev/config-example-mini6-keytimes.json
@@ -5,26 +5,25 @@
     "status_text_size": "medium",
     "expression_text_size": "medium"
   },
+  "long_press_threshold_ms": 500,
   "buttons": [
     {
       "label": "DRIVE",
-      "cc": 20,
       "color": "red",
-      "keytimes": 3,
-      "states": [
-        {"cc_on": 64, "color": "orange"},
-        {"cc_on": 96, "color": "red"},
-        {"cc_on": 127, "color": "magenta"}
+      "mode": "keytimes",
+      "short": [
+        {"down": [{"type": "cc", "cc": 20, "value": 64}],  "color": "orange"},
+        {"down": [{"type": "cc", "cc": 20, "value": 96}],  "color": "red"},
+        {"down": [{"type": "cc", "cc": 20, "value": 127}], "color": "magenta"}
       ]
     },
     {
       "label": "DELAY",
-      "cc": 21,
       "color": "yellow",
-      "keytimes": 2,
-      "states": [
-        {"cc_on": 80, "color": "yellow"},
-        {"cc_on": 127, "color": "orange"}
+      "mode": "keytimes",
+      "short": [
+        {"down": [{"type": "cc", "cc": 21, "value": 80}],  "color": "yellow"},
+        {"down": [{"type": "cc", "cc": 21, "value": 127}], "color": "orange"}
       ]
     },
     {"label": "VERB", "cc": 22, "color": "blue"},

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -152,3 +152,78 @@ class ButtonState:
         """Reset keytime cycle back to position 1."""
         self.current_keytime = 1
         self._state = False
+
+
+class PressTracker:
+    """Classifies button press events into short/long timing slots.
+
+    Consumes (pressed, now) on every poll and returns a list of timing events
+    that fired during the transition. Designed to compose with Switch — the
+    caller passes Switch.pressed and time.monotonic() each loop.
+
+    Threshold defines the boundary between short and long presses. A release
+    before threshold emits short_up; a release after emits long_up. The
+    short_down event fires immediately on every physical press; long_down
+    fires once when the threshold is reached while still held.
+
+    Used only by buttons in mode: "keytimes" (see #48 / docs/plans/2026-05-13-...).
+    """
+
+    def __init__(self, threshold_ms):
+        self.threshold_s = threshold_ms / 1000.0
+        self._pressed = False
+        self._down_at = None
+        self._long_fired = False
+
+    def update(self, pressed, now):
+        """Process one poll. Returns a list of event names that fired.
+
+        Event names: "short_down", "short_up", "long_down", "long_up".
+        Multiple events can fire in one update (e.g. long_down arriving during
+        a steady hold). Returned list preserves firing order.
+        """
+        events = []
+
+        if pressed and not self._pressed:
+            self._pressed = True
+            self._down_at = now
+            self._long_fired = False
+            events.append("short_down")
+        elif pressed and self._pressed:
+            if not self._long_fired and (now - self._down_at) >= self.threshold_s:
+                self._long_fired = True
+                events.append("long_down")
+        elif not pressed and self._pressed:
+            self._pressed = False
+            if self._long_fired:
+                events.append("long_up")
+            else:
+                events.append("short_up")
+            self._down_at = None
+            self._long_fired = False
+
+        return events
+
+
+class PressCycle:
+    """Tracks the current entry index for one timing class (short or long).
+
+    Independent of PressTracker — a button has two PressCycles (short, long)
+    each managing its own index. Advanced once per physical press in which
+    at least one event from this class fired.
+
+    Used only by buttons in mode: "keytimes".
+    """
+
+    def __init__(self, length):
+        self.length = length
+        self.index = 0
+
+    def advance(self):
+        """Advance index by 1, wrapping at length. No-op when length <= 0."""
+        if self.length > 0:
+            self.index = (self.index + 1) % self.length
+
+    def reset(self):
+        """Reset index to 0 (e.g. on power cycle or config reload)."""
+        self.index = 0

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -306,32 +306,48 @@ def dispatch_keytimes_events(events, state, btn_config, message_callback):
             idx = cycle.index
             if 0 <= idx < len(entries):
                 entry = entries[idx]
-                for msg in entry.get(slot, []) or []:
+                slot_messages = entry.get(slot, []) or []
+                for msg in slot_messages:
                     message_callback(msg)
-                # Update inherited render state from this entry. color inherits across
-                # entries (only updates if entry has one); dim and label are per-entry
-                # but treated symmetrically here — only updated if the field is present.
-                if "color" in entry:
-                    if cycle_name == "short":
-                        state.short_color = entry["color"]
+                # Render-state updates piggyback on the slot's MIDI dispatch: an event
+                # whose slot has no messages does nothing — no MIDI, no LED change.
+                # This keeps the user mental model consistent (the slot you populate
+                # is the slot where stuff happens) and avoids the short_down "flash"
+                # during long presses when the user only configured *_up slots.
+                if slot_messages:
+                    # color/dim/label are all per-entry with no carry-forward — a missing
+                    # field clears the layer's state so the render falls back to the
+                    # button-level color/label. Matches the UI's "(inherit)" reading.
+                    if "color" in entry:
+                        if cycle_name == "short":
+                            state.short_color = entry["color"]
+                        else:
+                            state.long_color = entry["color"]
                     else:
-                        state.long_color = entry["color"]
-                if "dim" in entry:
-                    if cycle_name == "short":
-                        state.short_dim = bool(entry["dim"])
+                        if cycle_name == "short":
+                            state.short_color = None
+                        else:
+                            state.long_color = None
+                    if "dim" in entry:
+                        if cycle_name == "short":
+                            state.short_dim = bool(entry["dim"])
+                        else:
+                            state.long_dim = bool(entry["dim"])
                     else:
-                        state.long_dim = bool(entry["dim"])
-                else:
-                    # Entry without explicit dim resets dim to False (non-inheriting).
-                    if cycle_name == "short":
-                        state.short_dim = False
+                        if cycle_name == "short":
+                            state.short_dim = False
+                        else:
+                            state.long_dim = False
+                    if "label" in entry:
+                        if cycle_name == "short":
+                            state.short_label = entry["label"]
+                        else:
+                            state.long_label = entry["label"]
                     else:
-                        state.long_dim = False
-                if "label" in entry:
-                    if cycle_name == "short":
-                        state.short_label = entry["label"]
-                    else:
-                        state.long_label = entry["label"]
+                        if cycle_name == "short":
+                            state.short_label = None
+                        else:
+                            state.long_label = None
 
         # On press-end, advance cycles whose events fired during this press, then reset flags.
         if event in ("short_up", "long_up"):

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -227,3 +227,117 @@ class PressCycle:
     def reset(self):
         """Reset index to 0 (e.g. on power cycle or config reload)."""
         self.index = 0
+
+
+class KeytimesButtonState:
+    """All per-button runtime state for a mode: "keytimes" button.
+
+    Aggregates PressTracker (timing classifier), two PressCycles (one per timing
+    class), and the inherited color/label/dim state for each layer. The dispatcher
+    reads from a button's config to fire messages and updates this state's
+    cycle indices and inherited colors after each press.
+    """
+
+    def __init__(self, threshold_ms, short_length, long_length):
+        self.tracker = PressTracker(threshold_ms)
+        self.short_cycle = PressCycle(short_length)
+        self.long_cycle = PressCycle(long_length)
+        # Inherited render state — updated when an entry sets a color/label/dim.
+        # color is None until the first event with a color fires; rendering falls
+        # through to button-level color or LED-off depending on the layer.
+        self.short_color = None
+        self.long_color = None
+        self.short_dim = False
+        self.long_dim = False
+        self.short_label = None
+        self.long_label = None
+        # Per-press "did any event from this cycle fire" flags. Cycles advance
+        # at press-end (short_up or long_up) if their flag is set.
+        self._fired_short = False
+        self._fired_long = False
+
+
+# Map from event names emitted by PressTracker to (cycle_name, slot_name).
+_KEYTIMES_EVENT_MAP = {
+    "short_down": ("short", "down"),
+    "short_up":   ("short", "up"),
+    "long_down":  ("long",  "down"),
+    "long_up":    ("long",  "up"),
+}
+
+
+def dispatch_keytimes_events(events, state, btn_config, message_callback):
+    """Dispatch a sequence of timing events through a keytimes-mode button's config.
+
+    Pure logic — no hardware, no time, no I/O. Tests inject a callback to capture
+    dispatched messages and assert behavior; the live firmware passes a real
+    MIDI/HID dispatch function.
+
+    Args:
+        events: list of event names from PressTracker.update()
+        state: KeytimesButtonState for this button
+        btn_config: validated button config dict (must have mode == "keytimes")
+        message_callback: fn(message_dict) called for each Message to dispatch
+
+    Side effects:
+        - Calls message_callback for each Message in the entries' down/up arrays
+        - Updates state.{short,long}_color/dim/label from entries that set them
+        - Sets state._fired_short / _fired_long
+        - Advances state.short_cycle / long_cycle on press-end events (short_up/long_up)
+    """
+    short_entries = btn_config.get("short", []) or []
+    long_entries = btn_config.get("long", []) or []
+
+    for event in events:
+        cycle_name, slot = _KEYTIMES_EVENT_MAP.get(event, (None, None))
+        if cycle_name is None:
+            continue
+
+        if cycle_name == "short":
+            entries = short_entries
+            cycle = state.short_cycle
+            state._fired_short = True
+        else:
+            entries = long_entries
+            cycle = state.long_cycle
+            state._fired_long = True
+
+        if entries:
+            idx = cycle.index
+            if 0 <= idx < len(entries):
+                entry = entries[idx]
+                for msg in entry.get(slot, []) or []:
+                    message_callback(msg)
+                # Update inherited render state from this entry. color inherits across
+                # entries (only updates if entry has one); dim and label are per-entry
+                # but treated symmetrically here — only updated if the field is present.
+                if "color" in entry:
+                    if cycle_name == "short":
+                        state.short_color = entry["color"]
+                    else:
+                        state.long_color = entry["color"]
+                if "dim" in entry:
+                    if cycle_name == "short":
+                        state.short_dim = bool(entry["dim"])
+                    else:
+                        state.long_dim = bool(entry["dim"])
+                else:
+                    # Entry without explicit dim resets dim to False (non-inheriting).
+                    if cycle_name == "short":
+                        state.short_dim = False
+                    else:
+                        state.long_dim = False
+                if "label" in entry:
+                    if cycle_name == "short":
+                        state.short_label = entry["label"]
+                    else:
+                        state.long_label = entry["label"]
+
+        # On press-end, advance cycles whose events fired during this press, then reset flags.
+        if event in ("short_up", "long_up"):
+            if state._fired_short:
+                state.short_cycle.advance()
+            if state._fired_long:
+                state.long_cycle.advance()
+            state._fired_short = False
+            state._fired_long = False

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -296,11 +296,9 @@ def dispatch_keytimes_events(events, state, btn_config, message_callback):
         if cycle_name == "short":
             entries = short_entries
             cycle = state.short_cycle
-            state._fired_short = True
         else:
             entries = long_entries
             cycle = state.long_cycle
-            state._fired_long = True
 
         if entries:
             idx = cycle.index
@@ -309,12 +307,18 @@ def dispatch_keytimes_events(events, state, btn_config, message_callback):
                 slot_messages = entry.get(slot, []) or []
                 for msg in slot_messages:
                     message_callback(msg)
-                # Render-state updates piggyback on the slot's MIDI dispatch: an event
-                # whose slot has no messages does nothing — no MIDI, no LED change.
-                # This keeps the user mental model consistent (the slot you populate
-                # is the slot where stuff happens) and avoids the short_down "flash"
-                # during long presses when the user only configured *_up slots.
+                # MIDI dispatch, render-state updates, AND cycle advancement all
+                # piggyback on the slot's content: an event whose slot has no messages
+                # does nothing on any axis. The slot the user populates is the slot
+                # where stuff happens. This avoids two surprises:
+                # (1) the short_down "flash" when only *_up slots are populated, and
+                # (2) the short cycle advancing during a long press just because
+                #     short_down fired as an event (with no MIDI to back it up).
                 if slot_messages:
+                    if cycle_name == "short":
+                        state._fired_short = True
+                    else:
+                        state._fired_long = True
                     # color/dim/label are all per-entry with no carry-forward — a missing
                     # field clears the layer's state so the render falls back to the
                     # button-level color/label. Matches the UI's "(inherit)" reading.

--- a/firmware/dev/core/colors.py
+++ b/firmware/dev/core/colors.py
@@ -85,3 +85,38 @@ def get_off_color_for_display(color_rgb, off_mode="dim"):
     """
     # Always return dim color to keep labels visible on display
     return dim_color(color_rgb)
+
+
+def compute_keytimes_led_color(short_color, short_dim, long_color, long_dim):
+    """Resolve the LED color for a mode: "keytimes" button per the two-layer render rule.
+
+    Render rule (from docs/plans/2026-05-13-issue-48-press-timings.md):
+      - short.color == "off"         -> LED off (short is a kill switch)
+      - long.color set (not "off")   -> LED = long.color (decoration over primary)
+      - short.color set              -> LED = short.color
+      - else                         -> LED off
+
+    The 'dim' flag on whichever layer wins applies via dim_color() (15% brightness).
+
+    Args:
+        short_color: color name from short cycle layer, or None if unset
+        short_dim: True to render short layer at reduced brightness
+        long_color: color name from long cycle layer, or None if unset
+        long_dim: True to render long layer at reduced brightness
+
+    Returns:
+        RGB tuple (r, g, b) with values 0-255
+    """
+    if short_color == "off":
+        return COLORS["off"]
+    if long_color and long_color != "off":
+        rgb = get_color(long_color)
+        if long_dim:
+            rgb = dim_color(rgb)
+        return rgb
+    if short_color:
+        rgb = get_color(short_color)
+        if short_dim:
+            rgb = dim_color(rgb)
+        return rgb
+    return COLORS["off"]

--- a/firmware/dev/core/colors.py
+++ b/firmware/dev/core/colors.py
@@ -87,22 +87,30 @@ def get_off_color_for_display(color_rgb, off_mode="dim"):
     return dim_color(color_rgb)
 
 
-def compute_keytimes_led_color(short_color, short_dim, long_color, long_dim):
+def compute_keytimes_led_color(short_color, short_dim, long_color, long_dim, button_color=None):
     """Resolve the LED color for a mode: "keytimes" button per the two-layer render rule.
 
     Render rule (from docs/plans/2026-05-13-issue-48-press-timings.md):
       - short.color == "off"         -> LED off (short is a kill switch)
       - long.color set (not "off")   -> LED = long.color (decoration over primary)
       - short.color set              -> LED = short.color
+      - button_color set             -> LED = button_color (fallback when all entries inherit)
       - else                         -> LED off
 
     The 'dim' flag on whichever layer wins applies via dim_color() (15% brightness).
+    For the button-level fallback, dim applies if either layer's dim flag is set —
+    the user can dim an inherit-color entry without specifying a color.
+    The button-level fallback mirrors the label precedence used in code.py:
+    `long_label or short_label or btn_config["label"]`.
 
     Args:
         short_color: color name from short cycle layer, or None if unset
         short_dim: True to render short layer at reduced brightness
         long_color: color name from long cycle layer, or None if unset
         long_dim: True to render long layer at reduced brightness
+        button_color: button-level color name (required schema field) used as
+            fallback when no cycle entry has set a color. Pass None to render
+            OFF in that case.
 
     Returns:
         RGB tuple (r, g, b) with values 0-255
@@ -117,6 +125,13 @@ def compute_keytimes_led_color(short_color, short_dim, long_color, long_dim):
     if short_color:
         rgb = get_color(short_color)
         if short_dim:
+            rgb = dim_color(rgb)
+        return rgb
+    if button_color:
+        rgb = get_color(button_color)
+        # Either layer's dim applies — the user marked the current entry as dim
+        # even though they left its color as "(inherit)".
+        if short_dim or long_dim:
             rgb = dim_color(rgb)
         return rgb
     return COLORS["off"]

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -11,7 +11,16 @@ except ImportError:
     json = None
 
 VALID_TYPES = ("cc", "note", "pc", "pc_inc", "pc_dec", "hid")
+VALID_MODES = ("toggle", "momentary", "flash", "select", "keytimes")
 STATE_OVERRIDE_FIELDS = ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "program", "pc_step", "color", "label", "hid_action", "hid_key", "hid_modifier", "hid_delay_ms")
+
+# Default and global-clamping bounds for long-press threshold (used by mode: "keytimes").
+LONG_PRESS_THRESHOLD_DEFAULT_MS = 500
+LONG_PRESS_THRESHOLD_MIN_MS = 50
+LONG_PRESS_THRESHOLD_MAX_MS = 5000
+
+# Valid colors for keytimes-mode cycle entries (button palette plus "off" for explicit LED-dark).
+_CYCLE_ENTRY_COLORS = ("red", "green", "blue", "yellow", "cyan", "magenta", "orange", "purple", "white", "off")
 
 
 def load_config(config_path="/config.json", button_count=10):
@@ -66,6 +75,134 @@ def _clamp_state_field(field, value):
     return value  # color, label, hid_action, hid_key, hid_modifier — pass through as-is
 
 
+def _clamp_threshold_ms(value):
+    """Clamp a long-press threshold value to schema bounds; non-int returns default."""
+    if not isinstance(value, int):
+        return LONG_PRESS_THRESHOLD_DEFAULT_MS
+    return max(LONG_PRESS_THRESHOLD_MIN_MS, min(LONG_PRESS_THRESHOLD_MAX_MS, value))
+
+
+def _clamp_midi_byte(value, default=0):
+    if not isinstance(value, int):
+        return default
+    return max(0, min(127, value))
+
+
+def _validate_keytimes_message(msg):
+    """Validate a single Message object inside a keytimes-mode entry's down/up array.
+
+    Returns a sanitized dict, or None if msg is not a valid dict.
+    Discriminated by 'type'. Unknown/missing type defaults to "cc".
+    """
+    if not isinstance(msg, dict):
+        return None
+    mtype = msg.get("type")
+    if mtype not in VALID_TYPES:
+        mtype = "cc"
+    out = {"type": mtype}
+    if "channel" in msg and isinstance(msg["channel"], int) and 0 <= msg["channel"] <= 15:
+        out["channel"] = msg["channel"]
+    if mtype == "cc":
+        out["cc"] = _clamp_midi_byte(msg.get("cc"), default=0)
+        out["value"] = _clamp_midi_byte(msg.get("value"), default=127)
+    elif mtype == "note":
+        out["note"] = _clamp_midi_byte(msg.get("note"), default=60)
+        out["velocity"] = _clamp_midi_byte(msg.get("velocity"), default=127)
+    elif mtype == "pc":
+        out["program"] = _clamp_midi_byte(msg.get("program"), default=0)
+    elif mtype in ("pc_inc", "pc_dec"):
+        step = msg.get("step", 1)
+        if not isinstance(step, int):
+            step = 1
+        out["step"] = max(1, min(127, step))
+    elif mtype == "hid":
+        action = msg.get("action", "send")
+        if action not in ("send", "press", "release", "delay"):
+            action = "send"
+        out["action"] = action
+        if "key" in msg and msg["key"] is not None:
+            out["key"] = str(msg["key"])
+        if msg.get("modifier") in ("ctrl", "shift", "alt", "option", "windows"):
+            out["modifier"] = msg["modifier"]
+        delay = msg.get("delay_ms")
+        if isinstance(delay, int):
+            out["delay_ms"] = max(1, min(5000, delay))
+    return out
+
+
+def _validate_keytimes_message_list(messages):
+    """Validate an array of messages (down or up slot). Returns a list (possibly empty)."""
+    if not isinstance(messages, list):
+        return []
+    validated = []
+    for msg in messages:
+        v = _validate_keytimes_message(msg)
+        if v is not None:
+            validated.append(v)
+    return validated
+
+
+def _validate_keytimes_entry(entry):
+    """Validate one cycle entry inside a keytimes-mode short[] or long[] array."""
+    if not isinstance(entry, dict):
+        return {}
+    out = {}
+    if "down" in entry:
+        out["down"] = _validate_keytimes_message_list(entry["down"])
+    if "up" in entry:
+        out["up"] = _validate_keytimes_message_list(entry["up"])
+    if "color" in entry:
+        color = entry["color"]
+        if isinstance(color, str) and color.lower() in _CYCLE_ENTRY_COLORS:
+            out["color"] = color.lower()
+    if entry.get("dim") is True:
+        out["dim"] = True
+    if "label" in entry and isinstance(entry["label"], str):
+        out["label"] = entry["label"]
+    return out
+
+
+def _validate_keytimes_cycle(entries):
+    """Validate a list of cycle entries. Returns a list (possibly empty)."""
+    if not isinstance(entries, list):
+        return []
+    return [_validate_keytimes_entry(e) for e in entries]
+
+
+def _validate_keytimes_button(btn, index, default_channel):
+    """Dedicated validation path for mode: 'keytimes' buttons.
+
+    Keytimes-mode buttons carry their message data inside per-entry down/up arrays,
+    not at the top of the button — so the legacy CC/Note/PC/HID per-button fields
+    do not apply here. short[] and long[] are independent cycle arrays.
+    """
+    label = btn.get("label", str(index + 1))
+    color = btn.get("color", "white")
+    off_mode = btn.get("off_mode", "dim")
+    channel = btn.get("channel", default_channel)
+
+    validated = {
+        "label": label,
+        "color": color,
+        "mode": "keytimes",
+        "off_mode": off_mode,
+        "channel": channel,
+        "type": "cc",  # vestigial; not used by keytimes dispatch but kept for cross-tool consistency
+    }
+
+    if "long_press_threshold_ms" in btn:
+        validated["long_press_threshold_ms"] = _clamp_threshold_ms(btn.get("long_press_threshold_ms"))
+
+    short = btn.get("short")
+    if short is not None:
+        validated["short"] = _validate_keytimes_cycle(short)
+    long_ = btn.get("long")
+    if long_ is not None:
+        validated["long"] = _validate_keytimes_cycle(long_)
+
+    return validated
+
+
 def validate_button(btn, index=0, global_channel=None):
     """Validate a button config dict, filling in defaults.
 
@@ -96,7 +233,9 @@ def validate_button(btn, index=0, global_channel=None):
         keytimes = 1
     keytimes = max(1, min(99, keytimes))
 
-    # Determine message type, fall back to cc if invalid
+    # Determine message type, fall back to cc if invalid.
+    # For mode "keytimes" this field is ignored — message types live inside each cycle entry's
+    # down/up Message objects. Keep parsing for legacy modes where button-level type still applies.
     msg_type = btn.get("type", "cc")
     if msg_type not in VALID_TYPES:
         msg_type = "cc"
@@ -104,6 +243,11 @@ def validate_button(btn, index=0, global_channel=None):
     # PC types default to "flash" (brief LED pulse); CC/Note default to "toggle"
     default_mode = "flash" if msg_type in ("pc", "pc_inc", "pc_dec") else "toggle"
     raw_mode = btn.get("mode", default_mode)
+
+    # mode: "keytimes" — short-circuit to a dedicated validation path. Other modes follow legacy.
+    if raw_mode == "keytimes":
+        return _validate_keytimes_button(btn, index, default_channel)
+
     # "select" (radio-group) is valid only on pc and cc, and only with keytimes==1.
     # Other invalid modes (and select on disallowed types) coerce back to default.
     if raw_mode == "select":
@@ -219,12 +363,30 @@ def validate_config(cfg, button_count=10):
         validate_button(btn, i, global_channel) for i, btn in enumerate(buttons[:button_count])
     ]
     
+    # Top-level long-press threshold (used by keytimes-mode buttons; per-button override allowed).
+    raw_threshold = cfg.get("long_press_threshold_ms", LONG_PRESS_THRESHOLD_DEFAULT_MS)
+    long_press_threshold_ms = _clamp_threshold_ms(raw_threshold)
+
     result = {}
     for k, v in cfg.items():
         result[k] = v
     result["buttons"] = validated_buttons
     result["global_channel"] = global_channel
+    result["long_press_threshold_ms"] = long_press_threshold_ms
     return result
+
+
+def get_long_press_threshold_ms(cfg, btn_config):
+    """Resolve the effective long-press threshold for a keytimes-mode button.
+
+    Resolution order: per-button override > top-level config > default (500ms).
+    Returns an integer in [LONG_PRESS_THRESHOLD_MIN_MS, LONG_PRESS_THRESHOLD_MAX_MS].
+    """
+    if "long_press_threshold_ms" in btn_config:
+        return _clamp_threshold_ms(btn_config.get("long_press_threshold_ms"))
+    if "long_press_threshold_ms" in cfg:
+        return _clamp_threshold_ms(cfg.get("long_press_threshold_ms"))
+    return LONG_PRESS_THRESHOLD_DEFAULT_MS
 
 
 def get_button_state_config(btn_config, keytime_index):

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -535,6 +535,29 @@ def get_display_config(cfg):
     }
 
 
+def get_midi_thru_usb_to_din(cfg):
+    """USB input -> 5-pin DIN output (cross-thru). Default True."""
+    return bool(cfg.get("midi_thru_usb_to_din", True))
+
+
+def get_midi_thru_din_to_usb(cfg):
+    """5-pin DIN input -> USB output (cross-thru). Default True."""
+    return bool(cfg.get("midi_thru_din_to_usb", True))
+
+
+def get_midi_thru_din_to_din(cfg):
+    """5-pin DIN input -> 5-pin DIN output (classic MIDI THRU pass-through
+    for daisy-chaining controllers downstream). Default True (matches OEM)."""
+    return bool(cfg.get("midi_thru_din_to_din", True))
+
+
+def get_midi_thru_usb_to_usb(cfg):
+    """USB input -> USB output (loopback to host). Default False — echoing
+    back to the host can cause duplicate notes or feedback when the DAW also
+    has MIDI echo enabled. Opt-in for niche routing setups."""
+    return bool(cfg.get("midi_thru_usb_to_usb", False))
+
+
 def get_dev_mode(cfg):
     """Extract development mode setting from config.
 

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -333,6 +333,19 @@ def validate_button(btn, index=0, global_channel=None):
             if validated_states:
                 validated["states"] = validated_states
 
+    # Deprecation warning: keytimes/states on non-keytimes-mode buttons are functional in v2.0
+    # but will be removed in v3.0. Tell the user to migrate to mode: "keytimes".
+    # The check happens here (after parsing) so any legacy config that actually uses these
+    # fields produces a single warning per button at boot.
+    if keytimes > 1 or btn.get("states"):
+        _btn_label = validated.get("label", "")
+        print(
+            f"[CONFIG WARN] Button {index + 1} ({_btn_label!r}) uses keytimes/states on mode={raw_mode!r}; "
+            f"these fields are DEPRECATED and will be removed in v3.0. "
+            f"Migrate to mode='keytimes' with short[]/long[] arrays. See "
+            f"docs/plans/2026-05-13-issue-48-press-timings.md."
+        )
+
     return validated
 
 

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -339,11 +339,12 @@ def validate_button(btn, index=0, global_channel=None):
     # fields produces a single warning per button at boot.
     if keytimes > 1 or btn.get("states"):
         _btn_label = validated.get("label", "")
+        # CircuitPython 7.x doesn't support !r in f-strings — wrap values in explicit quotes.
         print(
-            f"[CONFIG WARN] Button {index + 1} ({_btn_label!r}) uses keytimes/states on mode={raw_mode!r}; "
-            f"these fields are DEPRECATED and will be removed in v3.0. "
-            f"Migrate to mode='keytimes' with short[]/long[] arrays. See "
-            f"docs/plans/2026-05-13-issue-48-press-timings.md."
+            "[CONFIG WARN] Button " + str(index + 1) + " '" + str(_btn_label) + "' uses keytimes/states on mode='" + str(raw_mode) + "'; "
+            "these fields are DEPRECATED and will be removed in v3.0. "
+            "Migrate to mode='keytimes' with short[]/long[] arrays. See "
+            "docs/plans/2026-05-13-issue-48-press-timings.md."
         )
 
     return validated

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -848,3 +848,274 @@ class TestHidButtonType:
         btn = validate_button({"type": "hid", "color": "blue", "label": "K",
                                "hid_key": "A"}, index=0, global_channel=3)
         assert btn["channel"] == 3
+
+
+class TestKeytimesMode:
+    """Tests for mode: 'keytimes' validation (#48)."""
+
+    def test_keytimes_mode_recognized(self):
+        btn = validate_button({"label": "X", "color": "red", "mode": "keytimes"}, index=0)
+        assert btn["mode"] == "keytimes"
+
+    def test_keytimes_mode_preserves_label_and_color(self):
+        btn = validate_button({"label": "VERB", "color": "blue", "mode": "keytimes"}, index=0)
+        assert btn["label"] == "VERB"
+        assert btn["color"] == "blue"
+
+    def test_keytimes_mode_no_legacy_cc_fields(self):
+        """Keytimes-mode buttons don't get the legacy cc/cc_on/cc_off button-level defaults."""
+        btn = validate_button({"label": "X", "color": "red", "mode": "keytimes"}, index=0)
+        assert "cc" not in btn
+        assert "cc_on" not in btn
+        assert "cc_off" not in btn
+
+    def test_short_cycle_parsed(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [
+                {"down": [{"type": "cc", "cc": 20, "value": 127}], "color": "white"},
+                {"down": [{"type": "cc", "cc": 20, "value": 0}], "color": "off"},
+            ]
+        }, index=0)
+        assert len(btn["short"]) == 2
+        assert btn["short"][0]["down"][0] == {"type": "cc", "cc": 20, "value": 127}
+        assert btn["short"][0]["color"] == "white"
+        assert btn["short"][1]["color"] == "off"
+
+    def test_long_cycle_parsed(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "long": [{"down": [{"type": "cc", "cc": 21, "value": 127}], "color": "blue"}]
+        }, index=0)
+        assert len(btn["long"]) == 1
+        assert btn["long"][0]["down"][0]["cc"] == 21
+
+    def test_short_and_long_independent_lengths(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"color": "blue"}, {"color": "cyan"}, {"color": "white"}],
+            "long": [{"color": "red"}, {"color": "orange"}],
+        }, index=0)
+        assert len(btn["short"]) == 3
+        assert len(btn["long"]) == 2
+
+    def test_entry_with_dim_flag(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"color": "blue", "dim": True}],
+        }, index=0)
+        assert btn["short"][0]["dim"] is True
+
+    def test_entry_dim_false_dropped(self):
+        """Default dim=False is not stored — only explicit True is persisted."""
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"color": "blue", "dim": False}],
+        }, index=0)
+        assert "dim" not in btn["short"][0]
+
+    def test_entry_with_label(self):
+        btn = validate_button({
+            "label": "VERB", "color": "blue", "mode": "keytimes",
+            "short": [{"color": "blue", "label": "VERB+"}],
+        }, index=0)
+        assert btn["short"][0]["label"] == "VERB+"
+
+    def test_entry_color_off_preserved(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"color": "off"}],
+        }, index=0)
+        assert btn["short"][0]["color"] == "off"
+
+    def test_entry_invalid_color_dropped(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"color": "fuchsia"}],
+        }, index=0)
+        assert "color" not in btn["short"][0]
+
+    def test_entry_missing_color_inherits_implicitly(self):
+        """No color on entry → no 'color' key in validated output (inherit at render time)."""
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "cc", "cc": 20, "value": 127}]}],
+        }, index=0)
+        assert "color" not in btn["short"][0]
+
+
+class TestKeytimesMessageValidation:
+    """Tests for Message object validation inside down/up arrays."""
+
+    def test_cc_message(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "cc", "cc": 20, "value": 127}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg == {"type": "cc", "cc": 20, "value": 127}
+
+    def test_note_message(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "note", "note": 60, "velocity": 100}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg == {"type": "note", "note": 60, "velocity": 100}
+
+    def test_pc_message(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "pc", "program": 5}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg == {"type": "pc", "program": 5}
+
+    def test_pc_inc_message_defaults_step(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "pc_inc"}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["type"] == "pc_inc"
+        assert msg["step"] == 1
+
+    def test_pc_dec_message_with_step(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "pc_dec", "step": 5}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["step"] == 5
+
+    def test_hid_message(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "hid", "action": "send", "key": "A"}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["type"] == "hid"
+        assert msg["action"] == "send"
+        assert msg["key"] == "A"
+
+    def test_hid_message_with_modifier(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "hid", "action": "send", "key": "C", "modifier": "ctrl"}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["modifier"] == "ctrl"
+
+    def test_message_channel_preserved(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "cc", "cc": 20, "value": 127, "channel": 5}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["channel"] == 5
+
+    def test_message_unknown_type_defaults_to_cc(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "unknown", "cc": 20, "value": 127}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["type"] == "cc"
+
+    def test_message_clamps_out_of_range_values(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [{"type": "cc", "cc": 200, "value": -5}]}],
+        }, index=0)
+        msg = btn["short"][0]["down"][0]
+        assert msg["cc"] == 127
+        assert msg["value"] == 0
+
+    def test_multi_message_array_preserved(self):
+        """Multi-element down[] array survives validation (schema-reserved for #47)."""
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": [
+                {"type": "cc", "cc": 20, "value": 127},
+                {"type": "pc", "program": 5},
+            ]}],
+        }, index=0)
+        assert len(btn["short"][0]["down"]) == 2
+
+    def test_non_list_messages_become_empty(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "short": [{"down": "not a list"}],
+        }, index=0)
+        assert btn["short"][0]["down"] == []
+
+
+class TestKeytimesThreshold:
+    """Tests for long_press_threshold_ms resolution (button > top > default)."""
+
+    def test_button_override_stored(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "long_press_threshold_ms": 700,
+        }, index=0)
+        assert btn["long_press_threshold_ms"] == 700
+
+    def test_button_override_clamped_high(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "long_press_threshold_ms": 10000,
+        }, index=0)
+        assert btn["long_press_threshold_ms"] == 5000
+
+    def test_button_override_clamped_low(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+            "long_press_threshold_ms": 10,
+        }, index=0)
+        assert btn["long_press_threshold_ms"] == 50
+
+    def test_no_button_threshold_field_absent(self):
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes",
+        }, index=0)
+        assert "long_press_threshold_ms" not in btn
+
+    def test_validate_config_adds_top_level_default(self):
+        cfg = validate_config({"buttons": [{"label": "X", "color": "red"}]}, button_count=1)
+        assert cfg["long_press_threshold_ms"] == 500
+
+    def test_validate_config_preserves_explicit_top_level(self):
+        cfg = validate_config({
+            "long_press_threshold_ms": 300,
+            "buttons": [{"label": "X", "color": "red"}]
+        }, button_count=1)
+        assert cfg["long_press_threshold_ms"] == 300
+
+    def test_validate_config_clamps_top_level(self):
+        cfg = validate_config({
+            "long_press_threshold_ms": 99999,
+            "buttons": [{"label": "X", "color": "red"}]
+        }, button_count=1)
+        assert cfg["long_press_threshold_ms"] == 5000
+
+
+class TestKeytimesThresholdResolution:
+    """Test the get_long_press_threshold_ms helper for button > top > default order."""
+
+    def test_button_override_wins(self):
+        from core.config import get_long_press_threshold_ms
+        cfg = {"long_press_threshold_ms": 300}
+        btn = {"long_press_threshold_ms": 700}
+        assert get_long_press_threshold_ms(cfg, btn) == 700
+
+    def test_falls_back_to_top_level(self):
+        from core.config import get_long_press_threshold_ms
+        cfg = {"long_press_threshold_ms": 300}
+        btn = {}
+        assert get_long_press_threshold_ms(cfg, btn) == 300
+
+    def test_falls_back_to_default(self):
+        from core.config import get_long_press_threshold_ms
+        cfg = {}
+        btn = {}
+        assert get_long_press_threshold_ms(cfg, btn) == 500

--- a/tests/test_keytimes_color.py
+++ b/tests/test_keytimes_color.py
@@ -1,0 +1,106 @@
+"""Tests for compute_keytimes_led_color render rule (#48).
+
+The two-layer render rule:
+- short.color == "off"        -> LED off (kill switch)
+- long.color set (not "off")  -> LED = long.color (long modifies short)
+- short.color set             -> LED = short.color
+- else                        -> LED off
+"""
+
+import sys
+from pathlib import Path
+
+FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
+sys.path.insert(0, str(FIRMWARE_DIR))
+
+from core.colors import compute_keytimes_led_color, get_color, dim_color, COLORS
+
+OFF = COLORS["off"]
+
+
+class TestKeytimesRenderRule:
+    def test_both_unset_returns_off(self):
+        assert compute_keytimes_led_color(None, False, None, False) == OFF
+
+    def test_short_only(self):
+        assert compute_keytimes_led_color("blue", False, None, False) == get_color("blue")
+
+    def test_long_only(self):
+        # Long without short still renders (long is a modifier, not strictly require short).
+        assert compute_keytimes_led_color(None, False, "blue", False) == get_color("blue")
+
+    def test_both_set_long_wins(self):
+        # User's reverb+shimmer expectation: blue (long) shows over white (short).
+        result = compute_keytimes_led_color("white", False, "blue", False)
+        assert result == get_color("blue")
+
+    def test_short_off_kills_led_even_when_long_set(self):
+        # The asymmetric kill-switch: short="off" overrides everything.
+        result = compute_keytimes_led_color("off", False, "blue", False)
+        assert result == OFF
+
+    def test_long_off_falls_through_to_short(self):
+        # Long="off" is just "no decoration" — short shows.
+        result = compute_keytimes_led_color("white", False, "off", False)
+        assert result == get_color("white")
+
+    def test_both_off_returns_off(self):
+        result = compute_keytimes_led_color("off", False, "off", False)
+        assert result == OFF
+
+
+class TestKeytimesRenderDim:
+    def test_short_dim_applied_when_short_wins(self):
+        result = compute_keytimes_led_color("blue", True, None, False)
+        assert result == dim_color(get_color("blue"))
+
+    def test_long_dim_applied_when_long_wins(self):
+        result = compute_keytimes_led_color("white", False, "blue", True)
+        assert result == dim_color(get_color("blue"))
+
+    def test_short_dim_ignored_when_long_wins(self):
+        # When long wins, short's dim doesn't apply.
+        result = compute_keytimes_led_color("blue", True, "red", False)
+        assert result == get_color("red")
+
+    def test_long_dim_ignored_when_short_wins(self):
+        # When long is unset/off, long's dim is moot.
+        result = compute_keytimes_led_color("blue", False, None, True)
+        assert result == get_color("blue")
+
+    def test_dim_does_not_apply_to_kill_switch(self):
+        # short="off" with dim is still pure off (dim of off is off).
+        result = compute_keytimes_led_color("off", True, "blue", False)
+        assert result == OFF
+
+
+class TestReverbShimmerTrace:
+    """Trace the user's worked example sequence and verify each step renders correctly."""
+
+    def test_initial(self):
+        # Before any press: both layers unset.
+        assert compute_keytimes_led_color(None, False, None, False) == OFF
+
+    def test_step1_reverb_on_white(self):
+        # short_up_1 fires: short = white. Long still unset.
+        assert compute_keytimes_led_color("white", False, None, False) == get_color("white")
+
+    def test_step2_shimmer_on_blue(self):
+        # long_down_1 fires: long = blue. Short still white.
+        # Result: blue (long modifies short)
+        assert compute_keytimes_led_color("white", False, "blue", False) == get_color("blue")
+
+    def test_step3_reverb_off_kills(self):
+        # short_up_2 fires: short = off. Long still blue from earlier.
+        # Result: off (kill switch)
+        assert compute_keytimes_led_color("off", False, "blue", False) == OFF
+
+    def test_step4_reverb_on_again_long_still_modifies(self):
+        # short_up_1 fires again (wrapped): short = white. Long still blue.
+        # Result: blue (long modifies short again)
+        assert compute_keytimes_led_color("white", False, "blue", False) == get_color("blue")
+
+    def test_step5_shimmer_off(self):
+        # long_down_2 fires: long = white (config says "shimmer off, white"). Short still white.
+        # Result: white (long set to white, wins)
+        assert compute_keytimes_led_color("white", False, "white", False) == get_color("white")

--- a/tests/test_keytimes_color.py
+++ b/tests/test_keytimes_color.py
@@ -4,6 +4,7 @@ The two-layer render rule:
 - short.color == "off"        -> LED off (kill switch)
 - long.color set (not "off")  -> LED = long.color (long modifies short)
 - short.color set             -> LED = short.color
+- button_color set            -> LED = button_color (fallback when all entries inherit)
 - else                        -> LED off
 """
 
@@ -21,6 +22,34 @@ OFF = COLORS["off"]
 class TestKeytimesRenderRule:
     def test_both_unset_returns_off(self):
         assert compute_keytimes_led_color(None, False, None, False) == OFF
+
+    def test_both_unset_falls_back_to_button_color(self):
+        # When every cycle entry leaves color as "(inherit)" (i.e. unset), neither
+        # layer is ever populated. Fall back to the button-level color so the LED
+        # still lights — matching the label precedence used in _render_keytimes_led.
+        assert compute_keytimes_led_color(None, False, None, False, "red") == get_color("red")
+
+    def test_short_set_overrides_button_color_fallback(self):
+        assert compute_keytimes_led_color("blue", False, None, False, "red") == get_color("blue")
+
+    def test_short_off_kills_led_even_with_button_color_fallback(self):
+        # Kill-switch semantics must survive the new fallback path.
+        assert compute_keytimes_led_color("off", False, None, False, "red") == OFF
+
+    def test_button_color_fallback_applies_short_dim(self):
+        # User scenario: every short entry is "(inherit)" but one has dim=true.
+        # The button-level fallback should still dim.
+        result = compute_keytimes_led_color(None, True, None, False, "red")
+        assert result == dim_color(get_color("red"))
+
+    def test_button_color_fallback_applies_long_dim(self):
+        # Same dim path via the long layer.
+        result = compute_keytimes_led_color(None, False, None, True, "red")
+        assert result == dim_color(get_color("red"))
+
+    def test_button_color_fallback_no_dim_when_neither_set(self):
+        result = compute_keytimes_led_color(None, False, None, False, "red")
+        assert result == get_color("red")
 
     def test_short_only(self):
         assert compute_keytimes_led_color("blue", False, None, False) == get_color("blue")

--- a/tests/test_keytimes_dispatch.py
+++ b/tests/test_keytimes_dispatch.py
@@ -1,0 +1,265 @@
+"""Tests for dispatch_keytimes_events (#48).
+
+The dispatcher is a pure function that takes events from PressTracker, a
+KeytimesButtonState, and a button config, then:
+  - calls a message_callback for each Message in the matching cycle entry's slot
+  - updates state's inherited color/dim/label from the entry
+  - advances the relevant PressCycle(s) on press-end events
+"""
+
+import sys
+from pathlib import Path
+
+FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
+sys.path.insert(0, str(FIRMWARE_DIR))
+
+from core.button import KeytimesButtonState, dispatch_keytimes_events
+
+
+def _msg_collector():
+    """Helper: returns (callback, captured_list)."""
+    captured = []
+    return captured.append, captured
+
+
+def _make_state(short_len, long_len, threshold_ms=500):
+    return KeytimesButtonState(threshold_ms=threshold_ms, short_length=short_len, long_length=long_len)
+
+
+CC = lambda cc, value: {"type": "cc", "cc": cc, "value": value}
+
+
+class TestDispatchBasic:
+    def test_no_events_no_messages(self):
+        state = _make_state(1, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes", "short": [{"down": [CC(20, 127)]}]}
+        dispatch_keytimes_events([], state, cfg, cb)
+        assert captured == []
+        assert state.short_cycle.index == 0
+
+    def test_short_down_fires_message(self):
+        state = _make_state(1, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes", "short": [{"down": [CC(20, 127)]}]}
+        dispatch_keytimes_events(["short_down"], state, cfg, cb)
+        assert captured == [CC(20, 127)]
+
+    def test_short_up_fires_up_message(self):
+        state = _make_state(1, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes", "short": [{"up": [CC(20, 0)]}]}
+        dispatch_keytimes_events(["short_up"], state, cfg, cb)
+        assert captured == [CC(20, 0)]
+
+    def test_long_down_fires_long_message(self):
+        state = _make_state(1, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes", "long": [{"down": [CC(21, 127)]}]}
+        dispatch_keytimes_events(["long_down"], state, cfg, cb)
+        assert captured == [CC(21, 127)]
+
+    def test_unknown_event_ignored(self):
+        state = _make_state(1, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes", "short": [{"down": [CC(20, 127)]}]}
+        dispatch_keytimes_events(["bogus"], state, cfg, cb)
+        assert captured == []
+
+
+class TestDispatchCycleAdvancement:
+    def test_short_tap_advances_short_cycle(self):
+        state = _make_state(2, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)]}, {"down": [CC(20, 127)]}]}
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_cycle.index == 1
+        # First press fires entry[0]'s down message.
+        assert captured == [CC(20, 64)]
+
+    def test_next_short_tap_fires_next_entry(self):
+        state = _make_state(2, 1)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)]}, {"down": [CC(20, 127)]}]}
+        # First tap
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        # Second tap should fire entry[1].down
+        captured.clear()
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert captured == [CC(20, 127)]
+        assert state.short_cycle.index == 0  # wrapped
+
+    def test_long_press_advances_long_cycle_when_short_down_undefined(self):
+        # short_down doesn't fire (no entries on the short side? Actually short_down ALWAYS fires
+        # from the tracker — but if short cycle has 0 entries, advance is a no-op).
+        state = _make_state(0, 2)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "long": [{"down": [CC(21, 127)]}, {"down": [CC(21, 0)]}]}
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], state, cfg, cb)
+        # short_cycle length is 0, advance is no-op
+        assert state.short_cycle.index == 0
+        # long_cycle advances
+        assert state.long_cycle.index == 1
+        # First long press fires long entry[0].down
+        assert captured == [CC(21, 127)]
+
+    def test_long_press_advances_both_when_short_down_has_entries(self):
+        state = _make_state(2, 2)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)]}, {"down": [CC(20, 127)]}],
+               "long":  [{"down": [CC(21, 127)]}, {"down": [CC(21, 0)]}]}
+        # Full long press fires short_down, long_down, long_up
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], state, cfg, cb)
+        # Both cycles advance: short_down fired -> short advances; long_down/long_up fired -> long advances
+        assert state.short_cycle.index == 1
+        assert state.long_cycle.index == 1
+        # Messages dispatched in order
+        assert captured == [CC(20, 64), CC(21, 127)]  # no long_up message defined in cfg
+
+    def test_advance_only_once_per_press_with_both_down_and_up_short(self):
+        state = _make_state(3, 0)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [
+                   {"down": [CC(20, 1)], "up": [CC(20, 2)]},
+                   {"down": [CC(20, 3)], "up": [CC(20, 4)]},
+                   {"down": [CC(20, 5)], "up": [CC(20, 6)]},
+               ]}
+        # short_down AND short_up both fire — short cycle should advance ONCE
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_cycle.index == 1  # advanced by 1, not 2
+        assert captured == [CC(20, 1), CC(20, 2)]  # both entry[0]'s down and up fired
+
+
+class TestDispatchColorState:
+    def test_color_updated_from_entry(self):
+        state = _make_state(2, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)], "color": "blue"},
+                         {"down": [CC(20, 127)], "color": "cyan"}]}
+        dispatch_keytimes_events(["short_down"], state, cfg, cb)
+        assert state.short_color == "blue"
+
+    def test_color_inherits_when_entry_has_no_color(self):
+        # entry[1] has no color — state should keep entry[0]'s color across press-end.
+        state = _make_state(2, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)], "color": "blue"},
+                         {"down": [CC(20, 127)]}]}  # no color on entry 1
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        # state advances to index 1; state.short_color stayed "blue" (inherit)
+        assert state.short_color == "blue"
+        # Fire next press — entry[1] has no color, so still "blue"
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_color == "blue"
+
+    def test_long_color_updates_on_long_event(self):
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "long": [{"down": [CC(21, 127)], "color": "red"}]}
+        dispatch_keytimes_events(["long_down"], state, cfg, cb)
+        assert state.long_color == "red"
+        assert state.short_color is None
+
+    def test_dim_true_set_on_entry(self):
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)], "color": "blue", "dim": True}]}
+        dispatch_keytimes_events(["short_down"], state, cfg, cb)
+        assert state.short_dim is True
+
+    def test_dim_resets_when_next_entry_has_no_dim(self):
+        state = _make_state(2, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)], "color": "blue", "dim": True},
+                         {"down": [CC(20, 127)], "color": "blue"}]}
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_dim is True  # entry 0 had dim
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_dim is False  # entry 1 has no dim — resets
+
+    def test_label_updated_from_entry(self):
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)], "label": "VERB+"}]}
+        dispatch_keytimes_events(["short_down"], state, cfg, cb)
+        assert state.short_label == "VERB+"
+
+
+class TestDispatchReverbShimmerScenario:
+    """End-to-end trace of the reverb+shimmer scenario.
+
+    Config (button-level mode: "keytimes"):
+      short: 2 entries — reverb on (color: white), reverb off (color: off)
+      long:  2 entries — shimmer on (color: blue), shimmer off (color: white)
+    """
+
+    def setup_method(self):
+        self.state = _make_state(2, 2)
+        self.cfg = {
+            "mode": "keytimes",
+            "short": [
+                {"up": [CC(20, 127)], "color": "white"},  # reverb on
+                {"up": [CC(20, 0)],   "color": "off"},    # reverb off
+            ],
+            "long": [
+                {"down": [CC(21, 127)], "color": "blue"},   # shimmer on
+                {"down": [CC(21, 0)],   "color": "white"},  # shimmer off
+            ],
+        }
+
+    def test_full_sequence(self):
+        cb, captured = _msg_collector()
+        # 1. Short tap -> reverb on
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        assert captured == [CC(20, 127)]  # only "up" defined; "short_down" had no messages
+        assert self.state.short_cycle.index == 1
+        assert self.state.short_color == "white"
+        assert self.state.long_color is None
+        captured.clear()
+
+        # 2. Long hold -> shimmer on
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], self.state, self.cfg, cb)
+        assert captured == [CC(21, 127)]  # long entry[0].down
+        # short_cycle: short_down fired -> advance (wraps to 0)
+        assert self.state.short_cycle.index == 0
+        # long_cycle: long_down/long_up fired -> advance to 1
+        assert self.state.long_cycle.index == 1
+        # short_color: short_down on entry[0] (after wrap... no wait, sequence is)
+        # Actually short_cycle was at 1 before this; short_down event used entry at index 1
+        # (the "reverb off, color: off" entry). After firing, advance to 0.
+        # So short_color was updated from entry[1].color = "off"
+        assert self.state.short_color == "off"
+        assert self.state.long_color == "blue"
+        captured.clear()
+
+        # 3. Long hold -> shimmer off
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], self.state, self.cfg, cb)
+        # short_down on entry[0] (after previous wrap-to-0): color "white"
+        # short_cycle advances to 1
+        # long_down on entry[1]: color "white", message CC(21, 0)
+        # long_cycle advances to 0
+        assert captured == [CC(21, 0)]
+        assert self.state.short_cycle.index == 1
+        assert self.state.long_cycle.index == 0
+        assert self.state.short_color == "white"
+        assert self.state.long_color == "white"
+        captured.clear()
+
+        # 4. Short tap -> reverb off
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        # short entry[1]: up message CC(20, 0), color "off"
+        assert captured == [CC(20, 0)]
+        # short_cycle advances to 0 (wrap)
+        assert self.state.short_cycle.index == 0
+        assert self.state.short_color == "off"

--- a/tests/test_keytimes_dispatch.py
+++ b/tests/test_keytimes_dispatch.py
@@ -145,19 +145,49 @@ class TestDispatchColorState:
         dispatch_keytimes_events(["short_down"], state, cfg, cb)
         assert state.short_color == "blue"
 
-    def test_color_inherits_when_entry_has_no_color(self):
-        # entry[1] has no color — state should keep entry[0]'s color across press-end.
+    def test_color_clears_when_entry_has_no_color(self):
+        # An entry with no "color" field clears the layer's color so the render
+        # falls back to the button-level color. "(inherit)" means "no override",
+        # not "carry forward the previous entry's color".
         state = _make_state(2, 1)
         cb, _ = _msg_collector()
         cfg = {"mode": "keytimes",
                "short": [{"down": [CC(20, 64)], "color": "blue"},
                          {"down": [CC(20, 127)]}]}  # no color on entry 1
         dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
-        # state advances to index 1; state.short_color stayed "blue" (inherit)
+        # After short_up, cycle advanced to index 1. The next press will hit entry 1.
+        # state.short_color still reflects entry 0 (the one that just fired).
         assert state.short_color == "blue"
-        # Fire next press — entry[1] has no color, so still "blue"
+        # Next press hits entry 1 — no color → clear so render falls back to button color.
         dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
-        assert state.short_color == "blue"
+        assert state.short_color is None
+
+    def test_render_state_unchanged_when_slot_has_no_messages(self):
+        # Strict rule: short_down with no down messages does nothing — neither MIDI
+        # nor render. This is the fix for the "short_down flash" during long presses.
+        state = _make_state(1, 0)
+        state.short_color = "white"  # simulate prior state from a previous press
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"up": [CC(20, 127)], "color": "off"}]}  # only up has content
+        dispatch_keytimes_events(["short_down"], state, cfg, cb)
+        assert captured == []
+        assert state.short_color == "white"  # unchanged — slot was empty
+
+    def test_off_does_not_persist_through_inherit_entry(self):
+        # Regression: previously [inherit, off] would stick at "off" after the
+        # first wrap because the inherit entry left short_color unchanged.
+        state = _make_state(2, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"down": [CC(20, 64)]},                      # inherit
+                         {"down": [CC(20, 0)], "color": "off"}]}
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_color is None  # entry 0 inherit
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_color == "off"  # entry 1 kill
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_color is None  # wrap to entry 0 — kill cleared
 
     def test_long_color_updates_on_long_event(self):
         state = _make_state(1, 1)
@@ -231,15 +261,17 @@ class TestDispatchReverbShimmerScenario:
         # 2. Long hold -> shimmer on
         dispatch_keytimes_events(["short_down", "long_down", "long_up"], self.state, self.cfg, cb)
         assert captured == [CC(21, 127)]  # long entry[0].down
-        # short_cycle: short_down fired -> advance (wraps to 0)
+        # short_cycle: short_down fired (no messages, but the event itself fired) -> advance.
+        # Cycle was at 1; advances to 0 (wraps).
         assert self.state.short_cycle.index == 0
         # long_cycle: long_down/long_up fired -> advance to 1
         assert self.state.long_cycle.index == 1
-        # short_color: short_down on entry[0] (after wrap... no wait, sequence is)
-        # Actually short_cycle was at 1 before this; short_down event used entry at index 1
-        # (the "reverb off, color: off" entry). After firing, advance to 0.
-        # So short_color was updated from entry[1].color = "off"
-        assert self.state.short_color == "off"
+        # short_color: short_down on short entry[1] has no down messages, so render
+        # state is NOT updated. short_color stays at "white" from step 1.
+        # This is the strict slot-has-content rule: an empty slot is silent on every
+        # axis (MIDI and LED) — long-press toggling shimmer doesn't leak into the
+        # short layer's render state.
+        assert self.state.short_color == "white"
         assert self.state.long_color == "blue"
         captured.clear()
 

--- a/tests/test_keytimes_dispatch.py
+++ b/tests/test_keytimes_dispatch.py
@@ -174,6 +174,24 @@ class TestDispatchColorState:
         assert captured == []
         assert state.short_color == "white"  # unchanged — slot was empty
 
+    def test_long_press_does_not_advance_short_cycle_when_short_down_empty(self):
+        # Regression: previously, short_down fired during a long press would mark
+        # _fired_short=True and the short cycle would advance at long_up, even
+        # though no short MIDI fired. Now: short_down with empty slot is silent
+        # on every axis (MIDI, render, cycle) so the short cycle stays put.
+        state = _make_state(2, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"up": [CC(20, 127)]}, {"up": [CC(20, 0)]}],  # only up slots
+               "long":  [{"down": [CC(21, 127)]}]}
+        # One short tap to advance short cycle to index 1.
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.short_cycle.index == 1
+        # Now do a long press. Short cycle should NOT advance.
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], state, cfg, cb)
+        assert state.short_cycle.index == 1   # stays — short_down had no content
+        assert state.long_cycle.index == 0    # advanced and wrapped (len=1)
+
     def test_off_does_not_persist_through_inherit_entry(self):
         # Regression: previously [inherit, off] would stick at "off" after the
         # first wrap because the inherit entry left short_color unchanged.
@@ -261,16 +279,17 @@ class TestDispatchReverbShimmerScenario:
         # 2. Long hold -> shimmer on
         dispatch_keytimes_events(["short_down", "long_down", "long_up"], self.state, self.cfg, cb)
         assert captured == [CC(21, 127)]  # long entry[0].down
-        # short_cycle: short_down fired (no messages, but the event itself fired) -> advance.
-        # Cycle was at 1; advances to 0 (wraps).
-        assert self.state.short_cycle.index == 0
-        # long_cycle: long_down/long_up fired -> advance to 1
+        # short_cycle: short_down fired BUT short entry[1] has no down messages,
+        # so the cycle does NOT advance — the slot-has-content rule applies to
+        # cycle advancement too. short_cycle.index stays at 1.
+        assert self.state.short_cycle.index == 1
+        # long_cycle: long_down fired with messages -> advance to 1
         assert self.state.long_cycle.index == 1
         # short_color: short_down on short entry[1] has no down messages, so render
         # state is NOT updated. short_color stays at "white" from step 1.
-        # This is the strict slot-has-content rule: an empty slot is silent on every
-        # axis (MIDI and LED) — long-press toggling shimmer doesn't leak into the
-        # short layer's render state.
+        # The strict slot-has-content rule: an empty slot is silent on every axis
+        # (MIDI, LED, cycle) — long-press toggling shimmer doesn't leak into the
+        # short layer.
         assert self.state.short_color == "white"
         assert self.state.long_color == "blue"
         captured.clear()

--- a/tests/test_keytimes_dispatch.py
+++ b/tests/test_keytimes_dispatch.py
@@ -26,7 +26,8 @@ def _make_state(short_len, long_len, threshold_ms=500):
     return KeytimesButtonState(threshold_ms=threshold_ms, short_length=short_len, long_length=long_len)
 
 
-CC = lambda cc, value: {"type": "cc", "cc": cc, "value": value}
+def CC(cc, value):
+    return {"type": "cc", "cc": cc, "value": value}
 
 
 class TestDispatchBasic:

--- a/tests/test_keytimes_dispatch.py
+++ b/tests/test_keytimes_dispatch.py
@@ -314,3 +314,170 @@ class TestDispatchReverbShimmerScenario:
         # short_cycle advances to 0 (wrap)
         assert self.state.short_cycle.index == 0
         assert self.state.short_color == "off"
+
+
+class TestDispatchMixedSlotPopulation:
+    """Test 1: a single cycle whose entries have different slot population —
+    one with both down+up, one with down only, one with up only. Each entry
+    should fire/render/advance only on the events whose slots have content.
+    The cycle index must advance once per physical press as long as at least
+    one of that cycle's events fired with content."""
+
+    def setup_method(self):
+        self.state = _make_state(3, 0)
+        self.cfg = {
+            "mode": "keytimes",
+            "short": [
+                # entry 0: both slots populated
+                {"down": [CC(20, 1)], "up": [CC(20, 2)], "color": "red"},
+                # entry 1: down only
+                {"down": [CC(20, 3)],                    "color": "green"},
+                # entry 2: up only
+                {                     "up": [CC(20, 4)], "color": "blue"},
+            ],
+        }
+
+    def test_tap_at_entry_with_both_slots(self):
+        cb, captured = _msg_collector()
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        # Both slots fire MIDI, render uses entry 0's color, cycle advances to 1.
+        assert captured == [CC(20, 1), CC(20, 2)]
+        assert self.state.short_color == "red"
+        assert self.state.short_cycle.index == 1
+
+    def test_tap_at_entry_with_down_only(self):
+        cb, captured = _msg_collector()
+        # advance to entry 1 first
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        assert self.state.short_cycle.index == 1
+        captured.clear()
+
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        # Only the down slot fires; up is empty. Render updates from the down event.
+        # Cycle still advances because short_down fired with content.
+        assert captured == [CC(20, 3)]
+        assert self.state.short_color == "green"
+        assert self.state.short_cycle.index == 2
+
+    def test_tap_at_entry_with_up_only(self):
+        cb, captured = _msg_collector()
+        # advance to entry 2
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        assert self.state.short_cycle.index == 2
+        captured.clear()
+
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        # short_down has no content → no MIDI, no render, no cycle flag from this event.
+        # short_up has content → fires MIDI, renders, sets flag → cycle advances (wraps).
+        assert captured == [CC(20, 4)]
+        assert self.state.short_color == "blue"
+        assert self.state.short_cycle.index == 0
+
+    def test_full_cycle_returns_to_start(self):
+        cb, captured = _msg_collector()
+        for _ in range(3):
+            dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        # After three taps the cycle index is back at 0. The LED still shows
+        # whatever the last entry rendered (entry 2's "blue") — the color only
+        # updates to "red" again on the next press, when entry 0 fires.
+        assert self.state.short_cycle.index == 0
+        assert self.state.short_color == "blue"
+        # One more press confirms entry 0 fires next and re-renders red.
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        assert self.state.short_color == "red"
+        assert self.state.short_cycle.index == 1
+
+    def test_entry_with_no_slots_is_noop(self):
+        # A color-only entry with no down or up content is a no-op: no MIDI,
+        # no render, no cycle advance. The cycle gets stuck at this entry.
+        state = _make_state(2, 0)
+        cb, captured = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"color": "purple"},                    # no slots
+                         {"up": [CC(20, 9)], "color": "yellow"}]}
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        # Entry 0 has no slot content → silent on every axis.
+        assert captured == []
+        assert state.short_color is None
+        assert state.short_cycle.index == 0  # stays put — color-only entries are no-ops
+
+
+class TestDispatchIndependentCycleProgression:
+    """Test 2: short cycle of 3, long cycle of 2, with empty *_down slots on
+    both cycles. Confirms that long presses advance only the long cycle and
+    short taps advance only the short cycle, even though short_down fires on
+    every physical press.
+    """
+
+    def setup_method(self):
+        self.state = _make_state(3, 2)
+        self.cfg = {
+            "mode": "keytimes",
+            "short": [
+                {"up": [CC(20, 1)], "color": "red"},
+                {"up": [CC(20, 2)], "color": "green"},
+                {"up": [CC(20, 3)], "color": "blue"},
+            ],
+            "long": [
+                {"down": [CC(21, 1)], "color": "white"},
+                {"down": [CC(21, 2)], "color": "off"},
+            ],
+        }
+
+    def test_taps_and_longs_advance_independently(self):
+        cb, captured = _msg_collector()
+        # Pattern: tap, tap, tap, long, tap, long, tap.
+        # Short cycle (len 3) should reach: 1, 2, 0, 0, 1, 1, 2.
+        # Long  cycle (len 2) should reach: 0, 0, 0, 1, 1, 0, 0.
+        steps = [
+            ("tap",  ["short_down", "short_up"]),
+            ("tap",  ["short_down", "short_up"]),
+            ("tap",  ["short_down", "short_up"]),
+            ("long", ["short_down", "long_down", "long_up"]),
+            ("tap",  ["short_down", "short_up"]),
+            ("long", ["short_down", "long_down", "long_up"]),
+            ("tap",  ["short_down", "short_up"]),
+        ]
+        expected_short_idx = [1, 2, 0, 0, 1, 1, 2]
+        expected_long_idx  = [0, 0, 0, 1, 1, 0, 0]
+
+        for i, (kind, events) in enumerate(steps):
+            dispatch_keytimes_events(events, self.state, self.cfg, cb)
+            assert self.state.short_cycle.index == expected_short_idx[i], (
+                f"after step {i} ({kind}): expected short_idx="
+                f"{expected_short_idx[i]}, got {self.state.short_cycle.index}"
+            )
+            assert self.state.long_cycle.index == expected_long_idx[i], (
+                f"after step {i} ({kind}): expected long_idx="
+                f"{expected_long_idx[i]}, got {self.state.long_cycle.index}"
+            )
+
+    def test_long_presses_do_not_touch_short_state(self):
+        cb, captured = _msg_collector()
+        # Do a tap to advance short_color to "red".
+        dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        assert self.state.short_color == "red"
+        assert self.state.short_cycle.index == 1
+
+        # Long press: short layer's color and cycle should remain untouched.
+        captured.clear()
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], self.state, self.cfg, cb)
+        assert captured == [CC(21, 1)]
+        assert self.state.short_color == "red"          # unchanged
+        assert self.state.short_cycle.index == 1        # unchanged
+        assert self.state.long_color == "white"
+        assert self.state.long_cycle.index == 1
+
+    def test_short_taps_do_not_touch_long_state(self):
+        cb, captured = _msg_collector()
+        # First trigger a long press to set long state to non-default.
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], self.state, self.cfg, cb)
+        assert self.state.long_color == "white"
+        assert self.state.long_cycle.index == 1
+
+        # Now several short taps; long state must not change.
+        for _ in range(5):
+            dispatch_keytimes_events(["short_down", "short_up"], self.state, self.cfg, cb)
+        assert self.state.long_color == "white"         # unchanged
+        assert self.state.long_cycle.index == 1         # unchanged

--- a/tests/test_press_cycle.py
+++ b/tests/test_press_cycle.py
@@ -1,0 +1,64 @@
+"""Tests for press-cycle state (PressCycle).
+
+PressCycle tracks the current entry index for one timing class (short or long).
+A keytimes-mode button has two PressCycles, one per class, advancing independently.
+See docs/plans/2026-05-13-issue-48-press-timings.md for design.
+"""
+
+import sys
+from pathlib import Path
+
+FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
+sys.path.insert(0, str(FIRMWARE_DIR))
+
+from core.button import PressCycle
+
+
+class TestPressCycleAdvancement:
+    def test_initial_index_zero(self):
+        cycle = PressCycle(length=3)
+        assert cycle.index == 0
+
+    def test_advance_increments(self):
+        cycle = PressCycle(length=3)
+        cycle.advance()
+        assert cycle.index == 1
+
+    def test_advance_wraps(self):
+        cycle = PressCycle(length=3)
+        cycle.advance()
+        cycle.advance()
+        cycle.advance()
+        assert cycle.index == 0
+
+    def test_advance_continues_wrapping(self):
+        cycle = PressCycle(length=2)
+        for _ in range(5):
+            cycle.advance()
+        # 5 advances mod 2 = 1
+        assert cycle.index == 1
+
+    def test_length_one_advance_stays_at_zero(self):
+        cycle = PressCycle(length=1)
+        cycle.advance()
+        assert cycle.index == 0
+
+    def test_length_zero_no_advance(self):
+        """Zero-length cycle (no events defined) doesn't change index."""
+        cycle = PressCycle(length=0)
+        cycle.advance()
+        assert cycle.index == 0
+
+
+class TestPressCycleReset:
+    def test_reset_from_zero(self):
+        cycle = PressCycle(length=3)
+        cycle.reset()
+        assert cycle.index == 0
+
+    def test_reset_from_middle(self):
+        cycle = PressCycle(length=3)
+        cycle.advance()
+        cycle.advance()
+        cycle.reset()
+        assert cycle.index == 0

--- a/tests/test_press_tracker.py
+++ b/tests/test_press_tracker.py
@@ -1,0 +1,128 @@
+"""Tests for press-timing classification (PressTracker).
+
+PressTracker classifies a button's press lifecycle into four timing events
+(short_down, short_up, long_down, long_up) based on a configurable threshold.
+See docs/plans/2026-05-13-issue-48-press-timings.md for design.
+"""
+
+import sys
+from pathlib import Path
+
+FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
+sys.path.insert(0, str(FIRMWARE_DIR))
+
+from core.button import PressTracker
+
+
+class TestPressTrackerIdle:
+    def test_idle_no_events(self):
+        tracker = PressTracker(threshold_ms=500)
+        events = tracker.update(pressed=False, now=0.0)
+        assert events == []
+
+
+class TestPressTrackerShortPress:
+    def test_press_emits_short_down(self):
+        tracker = PressTracker(threshold_ms=500)
+        events = tracker.update(pressed=True, now=0.0)
+        assert events == ["short_down"]
+
+    def test_release_before_threshold_emits_short_up(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=False, now=0.2)
+        assert events == ["short_up"]
+
+    def test_hold_steady_no_events(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=True, now=0.1)
+        assert events == []
+
+
+class TestPressTrackerLongPress:
+    def test_threshold_emits_long_down(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=True, now=0.5)
+        assert events == ["long_down"]
+
+    def test_long_down_fires_once(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        events = tracker.update(pressed=True, now=1.0)
+        assert events == []
+
+    def test_release_after_threshold_emits_long_up(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        events = tracker.update(pressed=False, now=0.7)
+        assert events == ["long_up"]
+
+    def test_release_after_threshold_does_not_emit_short_up(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        events = tracker.update(pressed=False, now=0.7)
+        assert "short_up" not in events
+
+
+class TestPressTrackerSubsequentPresses:
+    def test_two_short_presses_independent(self):
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=False, now=0.1)
+        events = tracker.update(pressed=True, now=0.5)
+        assert events == ["short_down"]
+
+    def test_long_then_short(self):
+        # Long press completes, then a fresh short press starts.
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=True, now=0.5)
+        tracker.update(pressed=False, now=0.7)
+        events = tracker.update(pressed=True, now=1.0)
+        assert events == ["short_down"]
+
+    def test_short_then_long(self):
+        # Short press completes, then a long press fires long_down at threshold.
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        tracker.update(pressed=False, now=0.1)
+        tracker.update(pressed=True, now=1.0)
+        events = tracker.update(pressed=True, now=1.5)
+        assert events == ["long_down"]
+
+
+class TestPressTrackerEdgeCases:
+    def test_threshold_exactly(self):
+        """Crossing the threshold exactly counts as long (>= comparison)."""
+        tracker = PressTracker(threshold_ms=500)
+        tracker.update(pressed=True, now=0.0)
+        events = tracker.update(pressed=True, now=0.5)
+        assert events == ["long_down"]
+
+    def test_immediate_long_press_from_initial_state(self):
+        """First update with pressed=True at t=0 fires short_down; later update past threshold fires long_down."""
+        tracker = PressTracker(threshold_ms=500)
+        events_t0 = tracker.update(pressed=True, now=0.0)
+        events_t1 = tracker.update(pressed=True, now=0.6)
+        assert events_t0 == ["short_down"]
+        assert events_t1 == ["long_down"]
+
+    def test_release_with_no_prior_press(self):
+        """Defensive: spurious release without preceding press emits nothing."""
+        tracker = PressTracker(threshold_ms=500)
+        events = tracker.update(pressed=False, now=0.0)
+        assert events == []
+
+    def test_custom_threshold(self):
+        """Verify threshold is configurable."""
+        tracker = PressTracker(threshold_ms=200)
+        tracker.update(pressed=True, now=0.0)
+        events_before = tracker.update(pressed=True, now=0.1)
+        events_at = tracker.update(pressed=True, now=0.2)
+        assert events_before == []
+        assert events_at == ["long_down"]

--- a/tests/test_press_tracker_cycle_integration.py
+++ b/tests/test_press_tracker_cycle_integration.py
@@ -1,0 +1,145 @@
+"""Integration: PressTracker + PressCycle traces real-world scenarios.
+
+Verifies that the timing classifier and the per-class cycle counters compose
+the way the keytimes-mode design intends. See docs/plans/2026-05-13-issue-48-press-timings.md.
+"""
+
+import sys
+from pathlib import Path
+
+FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
+sys.path.insert(0, str(FIRMWARE_DIR))
+
+from core.button import PressTracker, PressCycle
+
+
+def _advance_cycles(events, short_cycle, long_cycle):
+    """Advance the relevant cycle at most once per call (one physical press → one advance per class with events)."""
+    fired_short = any(e in ("short_down", "short_up") for e in events)
+    fired_long = any(e in ("long_down", "long_up") for e in events)
+    if fired_short:
+        short_cycle.advance()
+    if fired_long:
+        long_cycle.advance()
+
+
+def test_reverb_shimmer_sequence():
+    """User's OEM config: short-press cycles reverb on/off; long-press cycles shimmer on/off.
+
+    Sequence:
+      1. short tap  -> reverb on
+      2. long hold  -> shimmer on
+      3. long hold  -> shimmer off
+      4. short tap  -> reverb off
+    """
+    tracker = PressTracker(threshold_ms=500)
+    short = PressCycle(length=2)
+    long_ = PressCycle(length=2)
+
+    assert short.index == 0
+    assert long_.index == 0
+
+    # 1. Short tap -> reverb on
+    tracker.update(pressed=True, now=0.0)
+    events = tracker.update(pressed=False, now=0.1)
+    assert "short_up" in events
+    _advance_cycles(events, short, long_)
+    assert short.index == 1
+    assert long_.index == 0
+
+    # 2. Long hold -> shimmer on
+    tracker.update(pressed=True, now=1.0)
+    events_threshold = tracker.update(pressed=True, now=1.5)
+    events_release = tracker.update(pressed=False, now=1.7)
+    assert "long_down" in events_threshold
+    assert "long_up" in events_release
+    _advance_cycles(events_threshold + events_release, short, long_)
+    assert short.index == 1  # short cycle unchanged — no short event fired
+    assert long_.index == 1
+
+    # 3. Long hold -> shimmer off (wraps to 0)
+    tracker.update(pressed=True, now=2.0)
+    events_threshold = tracker.update(pressed=True, now=2.5)
+    events_release = tracker.update(pressed=False, now=2.7)
+    _advance_cycles(events_threshold + events_release, short, long_)
+    assert short.index == 1
+    assert long_.index == 0
+
+    # 4. Short tap -> reverb off (wraps to 0)
+    tracker.update(pressed=True, now=3.0)
+    events = tracker.update(pressed=False, now=3.1)
+    _advance_cycles(events, short, long_)
+    assert short.index == 0
+    assert long_.index == 0
+
+
+def test_short_tap_with_both_down_and_up_advances_once():
+    """A short tap with both short_down and short_up firing advances short cycle by 1, not 2.
+
+    Rule: each cycle advances at most once per physical press, when ≥1 of its events fired.
+    """
+    tracker = PressTracker(threshold_ms=500)
+    short = PressCycle(length=2)
+    long_ = PressCycle(length=2)
+
+    events_down = tracker.update(pressed=True, now=0.0)
+    events_up = tracker.update(pressed=False, now=0.1)
+    assert events_down == ["short_down"]
+    assert events_up == ["short_up"]
+
+    # Caller collects events from one physical press and advances cycles once total.
+    all_events = events_down + events_up
+    _advance_cycles(all_events, short, long_)
+    assert short.index == 1  # advanced once, not twice
+    assert long_.index == 0
+
+
+def test_long_press_with_short_down_defined_advances_both_cycles():
+    """A long press where both short_down and long_down would fire advances both cycles by 1.
+
+    Per advancement rule: each cycle advances if ≥1 of its events fired. short_down belongs to
+    short cycle; long_down belongs to long cycle. Different cycles, each fires once → each advances once.
+    """
+    tracker = PressTracker(threshold_ms=500)
+    short = PressCycle(length=3)
+    long_ = PressCycle(length=3)
+
+    events_down = tracker.update(pressed=True, now=0.0)
+    events_threshold = tracker.update(pressed=True, now=0.5)
+    events_release = tracker.update(pressed=False, now=0.7)
+    assert events_down == ["short_down"]
+    assert events_threshold == ["long_down"]
+    assert events_release == ["long_up"]
+
+    all_events = events_down + events_threshold + events_release
+    _advance_cycles(all_events, short, long_)
+    assert short.index == 1  # short_down fired -> short advanced
+    assert long_.index == 1  # long_down/long_up fired -> long advanced
+
+
+def test_asymmetric_cycle_lengths_lead_button():
+    """Lead button: 3 short states (Clean/Crunch/Lead) and 2 long states (Hall/Plate).
+
+    Verifies cycle lengths are independent — short and long wrap at different periods.
+    """
+    tracker = PressTracker(threshold_ms=500)
+    short = PressCycle(length=3)
+    long_ = PressCycle(length=2)
+
+    # 3 short taps: 0 -> 1 -> 2 -> 0 (wrap)
+    for i, t in enumerate([0.0, 1.0, 2.0]):
+        tracker.update(pressed=True, now=t)
+        events = tracker.update(pressed=False, now=t + 0.1)
+        _advance_cycles(events, short, long_)
+    assert short.index == 0  # 3 advances mod 3 = 0
+    assert long_.index == 0  # no long events fired
+
+    # 5 long holds: 0 -> 1 -> 0 -> 1 -> 0 -> 1 (wrap several times)
+    for i in range(5):
+        t = 10.0 + i * 1.0
+        tracker.update(pressed=True, now=t)
+        ev1 = tracker.update(pressed=True, now=t + 0.5)
+        ev2 = tracker.update(pressed=False, now=t + 0.7)
+        _advance_cycles(ev1 + ev2, short, long_)
+    assert short.index == 0  # short cycle untouched
+    assert long_.index == 1  # 5 advances mod 2 = 1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -49,6 +49,113 @@ def test_schema_is_valid_draft7(schema):
   Draft7Validator.check_schema(schema)
 
 
+class TestKeytimesMode:
+  """Schema acceptance of mode='keytimes' buttons with short/long cycle arrays."""
+
+  def test_keytimes_mode_accepted(self, validator):
+    config = {
+      "buttons": [{
+        "label": "VERB",
+        "color": "blue",
+        "mode": "keytimes",
+        "short": [
+          {"down": [{"type": "cc", "cc": 20, "value": 127}], "color": "white"}
+        ]
+      }]
+    }
+    errors = list(validator.iter_errors(config))
+    assert errors == [], f"keytimes button rejected: {[e.message for e in errors]}"
+
+  def test_keytimes_mode_full_example(self, validator):
+    config = {
+      "buttons": [{
+        "label": "VERB",
+        "color": "blue",
+        "mode": "keytimes",
+        "long_press_threshold_ms": 500,
+        "short": [
+          {"down": [{"type": "cc", "cc": 20, "value": 64}],  "color": "blue",  "label": "VERB1"},
+          {"down": [{"type": "cc", "cc": 20, "value": 96}],  "color": "cyan"},
+          {"down": [{"type": "cc", "cc": 20, "value": 127}], "color": "white", "dim": True}
+        ],
+        "long": [
+          {"down": [{"type": "cc", "cc": 21, "value": 127}], "color": "blue"},
+          {"down": [{"type": "cc", "cc": 21, "value": 0}],   "color": "off"}
+        ]
+      }]
+    }
+    errors = list(validator.iter_errors(config))
+    assert errors == [], f"full keytimes example rejected: {[e.message for e in errors]}"
+
+  def test_message_type_cc(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"down": [{"type": "cc", "cc": 20, "value": 127}]}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_message_type_note(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"down": [{"type": "note", "note": 60, "velocity": 127}]}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_message_type_pc(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"down": [{"type": "pc", "program": 5}]}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_message_type_pc_inc(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"down": [{"type": "pc_inc", "step": 1}]}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_message_type_hid(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"down": [{"type": "hid", "action": "send", "key": "A"}]}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_cc_message_missing_value_rejected(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"down": [{"type": "cc", "cc": 20}]}]}]}
+    errors = list(validator.iter_errors(config))
+    assert len(errors) > 0
+
+  def test_color_off_accepted_in_entry(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"color": "off"}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_invalid_color_in_entry_rejected(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"color": "fuchsia"}]}]}
+    errors = list(validator.iter_errors(config))
+    assert len(errors) > 0
+
+  def test_top_level_threshold(self, validator):
+    config = {"long_press_threshold_ms": 300, "buttons": [{"label": "X", "color": "red"}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_threshold_too_low_rejected(self, validator):
+    config = {"long_press_threshold_ms": 10, "buttons": [{"label": "X", "color": "red"}]}
+    errors = list(validator.iter_errors(config))
+    assert len(errors) > 0
+
+  def test_per_button_threshold(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "long_press_threshold_ms": 700}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_dim_boolean_accepted(self, validator):
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"color": "blue", "dim": True}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+  def test_long_cycle_independent_length(self, validator):
+    """short.length and long.length can differ — independent cycles."""
+    config = {"buttons": [{"label": "X", "color": "red", "mode": "keytimes",
+                           "short": [{"color": "blue"}, {"color": "cyan"}, {"color": "white"}],
+                           "long":  [{"color": "red"},  {"color": "orange"}]}]}
+    assert list(validator.iter_errors(config)) == []
+
+
 # --- Negative tests: schema must reject bad input ---
 
 class TestRejectsInvalidLabel:

--- a/tests/test_usb_drive_name.py
+++ b/tests/test_usb_drive_name.py
@@ -8,7 +8,15 @@ import os
 # Add firmware/dev to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../firmware/dev"))
 
-from core.config import validate_usb_drive_name, get_usb_drive_name, get_dev_mode
+from core.config import (
+    validate_usb_drive_name,
+    get_usb_drive_name,
+    get_dev_mode,
+    get_midi_thru_usb_to_din,
+    get_midi_thru_din_to_usb,
+    get_midi_thru_din_to_din,
+    get_midi_thru_usb_to_usb,
+)
 
 
 def test_validate_usb_drive_name_valid():
@@ -111,4 +119,79 @@ def test_get_dev_mode_falsy_values():
     """dev_mode coerces falsy non-bool values to False."""
     assert get_dev_mode({"dev_mode": 0}) is False
     assert get_dev_mode({"dev_mode": None}) is False
+
+
+# ── midi_thru routing matrix tests ────────────────────────────────────────────
+# Routes: USB->DIN, DIN->USB, DIN->DIN default True (classic / cross-thru).
+# USB->USB defaults False (host loopback feedback risk).
+
+
+def test_get_midi_thru_usb_to_din_default_true():
+    assert get_midi_thru_usb_to_din({}) is True
+
+
+def test_get_midi_thru_usb_to_din_explicit_false():
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": False}) is False
+
+
+def test_get_midi_thru_usb_to_din_coercion():
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": 1}) is True
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": 0}) is False
+    assert get_midi_thru_usb_to_din({"midi_thru_usb_to_din": None}) is False
+
+
+def test_get_midi_thru_din_to_usb_default_true():
+    assert get_midi_thru_din_to_usb({}) is True
+
+
+def test_get_midi_thru_din_to_usb_explicit_false():
+    assert get_midi_thru_din_to_usb({"midi_thru_din_to_usb": False}) is False
+
+
+def test_get_midi_thru_din_to_usb_coercion():
+    assert get_midi_thru_din_to_usb({"midi_thru_din_to_usb": 1}) is True
+    assert get_midi_thru_din_to_usb({"midi_thru_din_to_usb": 0}) is False
+
+
+def test_get_midi_thru_din_to_din_default_true():
+    """DIN->DIN is the classic MIDI THRU pass-through; defaults True (matches OEM)."""
+    assert get_midi_thru_din_to_din({}) is True
+
+
+def test_get_midi_thru_din_to_din_explicit_false():
+    assert get_midi_thru_din_to_din({"midi_thru_din_to_din": False}) is False
+
+
+def test_get_midi_thru_din_to_din_coercion():
+    assert get_midi_thru_din_to_din({"midi_thru_din_to_din": 1}) is True
+    assert get_midi_thru_din_to_din({"midi_thru_din_to_din": 0}) is False
+
+
+def test_get_midi_thru_usb_to_usb_default_false():
+    """USB->USB defaults False — host loopback can cause DAW feedback. Opt-in only."""
+    assert get_midi_thru_usb_to_usb({}) is False
+
+
+def test_get_midi_thru_usb_to_usb_explicit_true():
+    assert get_midi_thru_usb_to_usb({"midi_thru_usb_to_usb": True}) is True
+
+
+def test_get_midi_thru_usb_to_usb_coercion():
+    assert get_midi_thru_usb_to_usb({"midi_thru_usb_to_usb": 1}) is True
+    assert get_midi_thru_usb_to_usb({"midi_thru_usb_to_usb": 0}) is False
+
+
+def test_midi_thru_routes_independent():
+    """Each route is gated independently — setting one does not affect any other."""
+    cfg = {"midi_thru_usb_to_din": False}
+    assert get_midi_thru_usb_to_din(cfg) is False
+    assert get_midi_thru_din_to_usb(cfg) is True
+    assert get_midi_thru_din_to_din(cfg) is True
+    assert get_midi_thru_usb_to_usb(cfg) is False  # default
+
+    cfg = {"midi_thru_usb_to_usb": True}
+    assert get_midi_thru_usb_to_usb(cfg) is True
+    assert get_midi_thru_usb_to_din(cfg) is True  # default
+    assert get_midi_thru_din_to_usb(cfg) is True
+    assert get_midi_thru_din_to_din(cfg) is True
 

--- a/tools/test-all.sh
+++ b/tools/test-all.sh
@@ -40,6 +40,13 @@ step "cargo test (Rust)"
 (cd config-editor/src-tauri && cargo test)
 
 step "svelte-check (TypeScript)"
+# Self-heal: fresh worktrees / clones won't have config-editor/node_modules,
+# so `npm run check` would die with `svelte-kit: command not found`. Install
+# on demand the first time the suite runs in a new tree.
+if [ ! -x config-editor/node_modules/.bin/svelte-kit ]; then
+  echo "config-editor/node_modules missing — installing deps..."
+  (cd config-editor && npm install --no-audit --no-fund)
+fi
 (cd config-editor && npm run check)
 
 step "generate:types (schema → TS)"


### PR DESCRIPTION
## Summary
- Introduces a new button `mode: "keytimes"` that dispatches different MIDI/HID messages based on short vs long press, with optional multi-cycle slots. Resolves #48.
- Adds `PressTracker` + `PressCycle` core primitives (poll-driven, no async), wired into the firmware main loop via `dispatch_keytimes_events`.
- Adds a global `long_press_threshold_ms` config (50–5000ms, default 500) with per-button override; exposes `off_mode` and relabels it "Start Mode" in the editor.
- Schema + validator + Rust types + JSON Schema → TS regen all kept in sync. Editor UI gains a keytimes editor (with empty-slot semantics, color fallback to button-level) and hides the legacy spinner unless already in use.
- Example configs migrated to `mode: "keytimes"`; legacy `keytimes` array still parses with a deprecation warning.
- Drive-by: CircuitPython 7.x f-string `!r` incompatibility fix + banlist doc; two pre-existing clippy warnings cleared.

## Test plan
- [x] `pytest tests/` — 562 passed (incl. new `test_press_tracker`, `test_press_cycle`, `test_press_tracker_cycle_integration`, `test_keytimes_dispatch`, `test_keytimes_color`, extended `test_schema` + `test_config`)
- [x] `cargo test` (config-editor/src-tauri) — 55 passed
- [x] `./tools/check-circuitpython-parse.sh` — all `firmware/dev/*.py` parse cleanly under `mpy-cross`
- [x] `ruff check firmware/ tests/` — clean
- [x] Manual: flash to STD10 + Mini6, verify short/long press dispatch + multi-cycle advancement + LED rendering (two-layer rule)
- [x] Manual: editor round-trip — open config, switch button to `keytimes`, edit slots, save, reload

Closes #48, #47, #73, #22