### PR TITLE
Bundle CP 7.3.1 .uf2 + Reflash CircuitPython GUI flow (#134)

### DIFF
--- a/.github/actions/stage-firmware-for-editor/action.yml
+++ b/.github/actions/stage-firmware-for-editor/action.yml
@@ -23,3 +23,11 @@ runs:
     - name: Confirm firmware contents
       shell: bash
       run: ls -la config-editor/src-tauri/resources/firmware/
+
+    - name: Stage CircuitPython .uf2 for the GUI reflash button (issue #134)
+      shell: bash
+      run: ./tools/fetch-cp-uf2.sh
+
+    - name: Confirm CircuitPython .uf2 contents
+      shell: bash
+      run: ls -la config-editor/src-tauri/resources/circuitpython/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,13 @@ jobs:
         with:
           workspaces: config-editor/src-tauri
 
+      # Tauri's build script validates that every bundle.resources glob in
+      # tauri.conf.json matches at least one file. resources/circuitpython/*.uf2
+      # is fetched on demand by tools/fetch-cp-uf2.sh (issue #134), so we run
+      # it here too — otherwise `cargo test` fails before any test runs.
+      - name: Stage CircuitPython .uf2 (needed by Tauri build script)
+        run: ./tools/fetch-cp-uf2.sh
+
       - name: Run Rust tests
         working-directory: config-editor/src-tauri
         run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,10 @@ jobs:
           
           ls -la dist/
 
-      - name: Create combined bundle (firmware + all GUI installers)
+      - name: Stage CircuitPython .uf2 for the combined bundle (issue #134)
+        run: ./tools/fetch-cp-uf2.sh
+
+      - name: Create combined bundle (firmware + all GUI installers + CP .uf2)
         run: |
           mkdir -p bundle
           # Copy firmware zip contents (extract so bundle is flat, not a zip-in-zip)
@@ -152,6 +155,8 @@ jobs:
               [ -f "$f" ] && cp "$f" bundle/
             done
           done
+          # CP .uf2 for terminal-only users who can't use the GUI reflash button.
+          cp config-editor/src-tauri/resources/circuitpython/*.uf2 bundle/
           # Create the combined zip
           (cd bundle && zip -r "../dist/MIDI-Captain-MAX-${VERSION}-complete.zip" .)
           echo "✓ Complete bundle: MIDI-Captain-MAX-${VERSION}-complete.zip" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ emulator/*.img
 # Bundled firmware for Config Editor — populated by CI or tools/bundle-firmware-for-dev.sh
 config-editor/src-tauri/resources/firmware/*
 !config-editor/src-tauri/resources/firmware/README.md
+
+# Bundled CircuitPython .uf2 for the GUI reflash button (issue #134) — populated
+# by tools/fetch-cp-uf2.sh (called from bundle-firmware-for-dev.sh + CI).
+config-editor/src-tauri/resources/circuitpython/*.uf2

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ If anything goes wrong, it is fully recoverable:
 2. Erase the contents.
 3. Restore your backup, or re-run the first-install steps above.
 
+### CircuitPython-version mismatch
+
+If the Config Editor refuses to install firmware with a CircuitPython version error, your device is on a newer CircuitPython than this firmware supports (typical for 2026-batch MCs which shipped with CP 9.2.7 from the factory). MIDI Captain MAX currently targets CP 7.3.1 — see [issue #2](https://github.com/MC-Music-Workshop/midi-captain-max/issues/2) for the planned migration to CP 9/10 and [#132](https://github.com/MC-Music-Workshop/midi-captain-max/issues/132) for the preflight check that blocks the silent-brick.
+
+**Easiest fix:** in the Config Editor, click **Reflash CircuitPython 7.3.1** next to "Install Firmware." The editor walks you through the bootloader hold, copies the bundled `.uf2`, and waits for the device to remount automatically.
+
+**Manual / terminal fallback:** the `MIDI-Captain-MAX-vX.Y.Z-complete.zip` release asset includes the verified 7.3.1 `.uf2`. Hold Switch 1 / KEY0 while plugging in USB to expose the `RPI-RP2` bootloader, drag the `.uf2` onto it, and the device reboots into CIRCUITPY automatically. Then re-run the install.
+
 # Configuration
 
 ## Custom USB Drive Name

--- a/config-editor/src-tauri/src/device.rs
+++ b/config-editor/src-tauri/src/device.rs
@@ -55,7 +55,7 @@ pub fn parse_midi_captain_config(config_path: &std::path::Path) -> Option<String
 }
 
 /// Get the volumes directory for the current platform
-fn get_volumes_path() -> PathBuf {
+pub(crate) fn get_volumes_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
         PathBuf::from("/Volumes")
@@ -115,7 +115,7 @@ pub struct DetectedDevice {
 
 /// Get the volume name for a given path
 #[cfg(target_os = "windows")]
-fn get_volume_name(path: &Path) -> Option<String> {
+pub(crate) fn get_volume_name(path: &Path) -> Option<String> {
     use std::os::windows::ffi::OsStrExt;
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
@@ -152,7 +152,7 @@ fn get_volume_name(path: &Path) -> Option<String> {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn get_volume_name(path: &Path) -> Option<String> {
+pub(crate) fn get_volume_name(path: &Path) -> Option<String> {
     path.file_name()?.to_str().map(|s| s.to_string())
 }
 

--- a/config-editor/src-tauri/src/lib.rs
+++ b/config-editor/src-tauri/src/lib.rs
@@ -2,10 +2,12 @@ mod commands;
 mod config;
 mod device;
 mod installer;
+mod reflash;
 
 use commands::{eject_device, read_config, read_config_raw, restart_device, validate_config, write_config, write_config_raw};
 use device::{scan_devices, start_device_watcher, stop_device_watcher};
 use installer::{get_firmware_versions, install_firmware};
+use reflash::{reflash_circuitpython, rpi_rp2_mount_path};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -25,7 +27,9 @@ pub fn run() {
             start_device_watcher,
             stop_device_watcher,
             install_firmware,
-            get_firmware_versions
+            get_firmware_versions,
+            reflash_circuitpython,
+            rpi_rp2_mount_path
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/config-editor/src-tauri/src/reflash.rs
+++ b/config-editor/src-tauri/src/reflash.rs
@@ -1,0 +1,271 @@
+//! "Reflash CircuitPython 7.3.1" feature (issue #134).
+//!
+//! Recovery flow for devices on a CircuitPython newer than this firmware
+//! supports (see issue #132 preflight). The user is walked through the
+//! one manual step we can't automate (unplug → hold Switch 1 / KEY0 → replug
+//! to enter the RP2040 ROM bootloader). Once `RPI-RP2` mounts, this module
+//! copies the bundled `.uf2` onto it. The bootloader handles the flash + reboot
+//! into the freshly written firmware on its own — we just wait for `CIRCUITPY`
+//! to remount and tell the UI.
+
+use crate::commands::ConfigError;
+use crate::device::{get_volume_name, get_volumes_path};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use tauri::ipc::Channel;
+use tauri::{command, AppHandle, Manager};
+
+/// FAT label the RP2040 ROM bootloader presents when BOOTSEL is held during
+/// USB enumeration. Case-insensitive match — Windows sometimes uppercases,
+/// macOS preserves as-mastered.
+const RPI_RP2_LABEL: &str = "RPI-RP2";
+
+/// Filename of the .uf2 we ship in `resources/circuitpython/`. Kept identical
+/// to Adafruit's canonical filename so users who go looking at the bootloader
+/// drive see something recognisable.
+pub(crate) const BUNDLED_UF2_FILENAME: &str =
+    "adafruit-circuitpython-raspberry_pi_pico-en_US-7.3.1.uf2";
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ReflashPhase {
+    Copying,
+    AwaitingReboot,
+    Done,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReflashProgress {
+    pub phase: ReflashPhase,
+    pub message: String,
+}
+
+/// Scan platform-appropriate volume roots for an `RPI-RP2` bootloader mount.
+/// Returns the mount path if present, `None` otherwise.
+///
+/// Mirrors the volume-scanning strategy in `device::scan_devices`: drive-letter
+/// walk on Windows, directory listing under `/Volumes` (macOS) or
+/// `/media/$USER` / `/run/media/$USER` (Linux) elsewhere.
+pub fn detect_rpi_rp2() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        for letter in b'A'..=b'Z' {
+            let drive = format!("{}:\\", letter as char);
+            let path = PathBuf::from(&drive);
+            if path.exists() {
+                if let Some(name) = get_volume_name(&path) {
+                    if name.eq_ignore_ascii_case(RPI_RP2_LABEL) {
+                        return Some(path);
+                    }
+                }
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let volumes_path = get_volumes_path();
+        let entries = std::fs::read_dir(&volumes_path).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(name) = get_volume_name(&path) {
+                if name.eq_ignore_ascii_case(RPI_RP2_LABEL) {
+                    return Some(path);
+                }
+            }
+        }
+        None
+    }
+}
+
+fn bundled_uf2_path(app: &AppHandle) -> Result<PathBuf, ConfigError> {
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| ConfigError::msg(format!("Could not resolve app resource directory: {e}")))?;
+    let uf2 = resource_dir
+        .join("resources")
+        .join("circuitpython")
+        .join(BUNDLED_UF2_FILENAME);
+    if !uf2.exists() {
+        return Err(ConfigError::msg(format!(
+            "Bundled CircuitPython .uf2 missing at {}. \
+             This is a build-configuration issue: tools/fetch-cp-uf2.sh must run \
+             before `tauri build` so the .uf2 lands in resources/circuitpython/.",
+            uf2.display()
+        )));
+    }
+    Ok(uf2)
+}
+
+/// Copy the bundled `.uf2` onto the `RPI-RP2` bootloader drive.
+///
+/// The RP2040 ROM bootloader unmounts the drive mid-write once it has enough
+/// bytes to commit, then reboots into the new firmware. The OS surfaces that
+/// disconnect as an IO error on `fs::copy`'s close. If the drive's gone, that's
+/// the bootloader handing off — treat as success. If the drive's still there
+/// and the copy failed, propagate the error.
+pub(crate) fn copy_uf2_to_bootloader(
+    uf2_src: &Path,
+    bootloader: &Path,
+) -> Result<(), ConfigError> {
+    let target = bootloader.join(BUNDLED_UF2_FILENAME);
+    match std::fs::copy(uf2_src, &target) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if !bootloader.exists() {
+                // Bootloader has unmounted itself — write was accepted, reboot incoming.
+                Ok(())
+            } else {
+                Err(ConfigError::msg(format!(
+                    "Failed to copy .uf2 onto {}: {}. \
+                     If the device disconnected mid-copy, try again.",
+                    bootloader.display(),
+                    e
+                )))
+            }
+        }
+    }
+}
+
+/// Tauri command: detect whether `RPI-RP2` is currently mounted.
+/// UI polls this while the user does the BOOTSEL/Switch 1 hold + replug.
+#[command]
+pub fn rpi_rp2_mount_path() -> Option<String> {
+    detect_rpi_rp2().map(|p| p.to_string_lossy().into_owned())
+}
+
+/// Tauri command: copy the bundled CircuitPython 7.3.1 `.uf2` onto a mounted
+/// `RPI-RP2` bootloader. UI must have already prompted the user to enter
+/// bootloader mode and observed `rpi_rp2_mount_path()` returning `Some`.
+///
+/// Returns once bytes are copied (or the bootloader has unmounted itself,
+/// which counts as success). UI then polls `scan_devices` for `CIRCUITPY`
+/// to remount, which signals the new firmware has booted.
+#[command]
+pub async fn reflash_circuitpython(
+    app: AppHandle,
+    on_progress: Channel<ReflashProgress>,
+) -> Result<(), ConfigError> {
+    let uf2 = bundled_uf2_path(&app)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let bootloader = detect_rpi_rp2().ok_or_else(|| {
+            ConfigError::msg(
+                "RPI-RP2 bootloader drive not found. Unplug the device, hold \
+                 Switch 1 / KEY0, then plug USB back in. The RPI-RP2 drive should \
+                 appear within a few seconds — re-try once it does.",
+            )
+        })?;
+
+        let _ = on_progress.send(ReflashProgress {
+            phase: ReflashPhase::Copying,
+            message: format!(
+                "Copying CircuitPython 7.3.1 onto {}",
+                bootloader.display()
+            ),
+        });
+
+        copy_uf2_to_bootloader(&uf2, &bootloader)?;
+
+        let _ = on_progress.send(ReflashProgress {
+            phase: ReflashPhase::AwaitingReboot,
+            message:
+                "Bootloader is flashing the .uf2 and will reboot the device shortly."
+                    .to_string(),
+        });
+
+        let _ = on_progress.send(ReflashProgress {
+            phase: ReflashPhase::Done,
+            message:
+                "CircuitPython 7.3.1 written. Wait for CIRCUITPY to remount, then click Install Firmware."
+                    .to_string(),
+        });
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| ConfigError::msg(format!("Reflash task panicked: {e}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_fake_uf2(dir: &Path) -> PathBuf {
+        let p = dir.join("fake.uf2");
+        // 1 KB of dummy bytes — enough to exercise the copy.
+        fs::write(&p, vec![0xAB; 1024]).unwrap();
+        p
+    }
+
+    #[test]
+    fn copy_uf2_happy_path_writes_file_with_canonical_name() {
+        let bundle = TempDir::new().unwrap();
+        let bootloader = TempDir::new().unwrap();
+        let src = make_fake_uf2(bundle.path());
+
+        copy_uf2_to_bootloader(&src, bootloader.path()).unwrap();
+
+        let dest = bootloader.path().join(BUNDLED_UF2_FILENAME);
+        assert!(dest.exists(), "destination .uf2 must exist after copy");
+        let bytes = fs::read(&dest).unwrap();
+        assert_eq!(bytes.len(), 1024);
+        assert!(bytes.iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn copy_uf2_bootloader_vanished_mid_copy_treated_as_success() {
+        // Simulate: the bootloader drive disappears between fs::copy starting and
+        // finishing. Easiest deterministic model: point bootloader at a path that
+        // doesn't exist by the time we check. fs::copy itself will fail because the
+        // dest dir is missing; the leniency branch then sees `!bootloader.exists()`
+        // and treats it as success.
+        let bundle = TempDir::new().unwrap();
+        let src = make_fake_uf2(bundle.path());
+
+        let phantom_bootloader = PathBuf::from("/tmp/this-mount-point-does-not-exist-9e8a7f");
+        // Make sure it really doesn't exist.
+        let _ = fs::remove_dir_all(&phantom_bootloader);
+
+        // fs::copy fails (no such dir), but the leniency branch should swallow it.
+        let result = copy_uf2_to_bootloader(&src, &phantom_bootloader);
+        assert!(
+            result.is_ok(),
+            "vanished bootloader should be treated as success, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn copy_uf2_real_failure_with_present_bootloader_propagates() {
+        // Bootloader dir exists, but the destination path is a directory — copy
+        // fails. Should NOT be swallowed.
+        let bundle = TempDir::new().unwrap();
+        let bootloader = TempDir::new().unwrap();
+        let src = make_fake_uf2(bundle.path());
+
+        // Pre-create a *directory* at the target filename so fs::copy errors.
+        let blocker = bootloader.path().join(BUNDLED_UF2_FILENAME);
+        fs::create_dir(&blocker).unwrap();
+
+        let result = copy_uf2_to_bootloader(&src, bootloader.path());
+        assert!(
+            result.is_err(),
+            "copy onto present-but-blocked bootloader must error"
+        );
+    }
+
+    #[test]
+    fn bundled_uf2_filename_matches_adafruit_canonical() {
+        // Sanity guard: if someone bumps the pinned CP version, they need to
+        // also update this constant — and the test name forces the diff to
+        // mention the right thing.
+        assert!(BUNDLED_UF2_FILENAME.contains("7.3.1"));
+        assert!(BUNDLED_UF2_FILENAME.contains("raspberry_pi_pico"));
+        assert!(BUNDLED_UF2_FILENAME.ends_with(".uf2"));
+    }
+}

--- a/config-editor/src-tauri/tauri.conf.json
+++ b/config-editor/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": ["resources/firmware/**/*"],
+    "resources": ["resources/firmware/**/*", "resources/circuitpython/*.uf2"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/config-editor/src/lib/api.ts
+++ b/config-editor/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   FirmwareVersions,
   InstallProgress,
   InstallReport,
+  ReflashProgress,
 } from './types';
 
 // Config operations
@@ -65,6 +66,32 @@ export async function installFirmware(
     resetConfig,
     onProgress: channel,
   });
+}
+
+/**
+ * Return the mount path of the RPI-RP2 bootloader drive, or null if not present.
+ * UI polls this while the user does the BOOTSEL/Switch 1 hold + replug to enter
+ * the RP2040 ROM bootloader.
+ */
+export async function rpiRp2MountPath(): Promise<string | null> {
+  return invoke('rpi_rp2_mount_path');
+}
+
+/**
+ * Copy the bundled CircuitPython 7.3.1 .uf2 onto a mounted RPI-RP2 drive.
+ * Caller must have already observed `rpiRp2MountPath()` returning non-null —
+ * the command errors out if the bootloader drive isn't mounted.
+ *
+ * Resolves once bytes are written (or the bootloader has unmounted itself
+ * mid-copy, which counts as success). Reboot back to CIRCUITPY is handled by
+ * the RP2040 ROM bootloader; the UI should poll `scanDevices()` afterward.
+ */
+export async function reflashCircuitpython(
+  onProgress: (p: ReflashProgress) => void,
+): Promise<void> {
+  const channel = new Channel<ReflashProgress>();
+  channel.onmessage = onProgress;
+  return invoke('reflash_circuitpython', { onProgress: channel });
 }
 
 // Event listeners

--- a/config-editor/src/lib/components/FirmwareInstaller.svelte
+++ b/config-editor/src/lib/components/FirmwareInstaller.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ask, message } from '@tauri-apps/plugin-dialog';
   import { getFirmwareVersions, installFirmware } from '$lib/api';
+  import ReflashCircuitPython from './ReflashCircuitPython.svelte';
   import type {
     DetectedDevice,
     FirmwareVersions,
@@ -52,6 +53,15 @@
     progress && progress.total > 0
       ? Math.round((progress.current / progress.total) * 100)
       : 0,
+  );
+
+  // The Rust preflight (issue #132) refuses installs on CP >= 8 with an error
+  // mentioning "CircuitPython" and pointing at the RPI-RP2 recovery path. When
+  // we see that shape, surface the reflash flow more prominently. False
+  // positives are harmless (the button is always available) — we're just
+  // drawing the eye to it when we know it's the right next step.
+  let cpVersionMismatch = $derived(
+    errorMsg.includes('CircuitPython') && errorMsg.includes('RPI-RP2'),
   );
 
   async function startInstall() {
@@ -171,6 +181,13 @@
       <strong>Error:</strong> {errorMsg}
     </div>
   {/if}
+
+  <div class="reflash-row">
+    <ReflashCircuitPython
+      highlight={cpVersionMismatch}
+      onComplete={() => refreshVersions(device)}
+    />
+  </div>
 </section>
 
 <style>
@@ -325,5 +342,13 @@
   .result ul {
     margin: 6px 0 0 0;
     padding-left: 20px;
+  }
+
+  .reflash-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-color);
   }
 </style>

--- a/config-editor/src/lib/components/ReflashCircuitPython.svelte
+++ b/config-editor/src/lib/components/ReflashCircuitPython.svelte
@@ -1,0 +1,380 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { reflashCircuitpython, rpiRp2MountPath, scanDevices } from '$lib/api';
+  import type { ReflashProgress } from '$lib/types';
+
+  interface Props {
+    /** When true, render an attention-grabbing CTA banner above the button.
+     *  Set by FirmwareInstaller when an install was just refused due to a
+     *  CP-version mismatch (issue #132 preflight). */
+    highlight?: boolean;
+    /** Called after a successful reflash so the parent can refresh device
+     *  state (re-scan, re-read VERSION.txt etc.). */
+    onComplete?: () => void;
+  }
+
+  let { highlight = false, onComplete }: Props = $props();
+
+  type State =
+    | { kind: 'idle' }
+    | { kind: 'awaitingBootloader' }
+    | { kind: 'copying'; message: string }
+    | { kind: 'awaitingReboot'; message: string }
+    | { kind: 'done' }
+    | { kind: 'error'; message: string };
+
+  let flow = $state<State>({ kind: 'idle' });
+  let bootloaderPath = $state<string | null>(null);
+
+  // Narrow `flow` into the message field where the branch carries one.
+  // Centralised so template branches can just render `{statusMessage}`
+  // without re-narrowing the union inline.
+  let statusMessage = $derived(
+    flow.kind === 'copying' || flow.kind === 'awaitingReboot' || flow.kind === 'error'
+      ? flow.message
+      : '',
+  );
+
+  // Poll handles — cleared on state change or cancel.
+  let bootloaderPollTimer: ReturnType<typeof setInterval> | null = null;
+  let rebootPollTimer: ReturnType<typeof setInterval> | null = null;
+
+  function clearPollers() {
+    if (bootloaderPollTimer !== null) {
+      clearInterval(bootloaderPollTimer);
+      bootloaderPollTimer = null;
+    }
+    if (rebootPollTimer !== null) {
+      clearInterval(rebootPollTimer);
+      rebootPollTimer = null;
+    }
+  }
+
+  onDestroy(clearPollers);
+
+  async function pollForBootloader() {
+    try {
+      const p = await rpiRp2MountPath();
+      if (p !== null && flow.kind === 'awaitingBootloader') {
+        bootloaderPath = p;
+        clearPollers();
+        await runReflash();
+      }
+    } catch {
+      // Transient — keep polling.
+    }
+  }
+
+  async function pollForCircuitpyReturn() {
+    try {
+      const devices = await scanDevices();
+      if (devices.length > 0 && flow.kind === 'awaitingReboot') {
+        clearPollers();
+        flow = { kind: 'done' };
+        onComplete?.();
+      }
+    } catch {
+      // Transient.
+    }
+  }
+
+  async function runReflash() {
+    flow = {
+      kind: 'copying',
+      message: 'Copying CircuitPython 7.3.1 onto the bootloader…',
+    };
+    try {
+      await reflashCircuitpython((p: ReflashProgress) => {
+        // Echo Rust-side progress into our state machine. The Rust command's
+        // last phase is 'done', but that just means bytes are written — we
+        // still need to wait for the device to reboot back to CIRCUITPY, so
+        // we map 'done' → our `awaitingReboot` state.
+        switch (p.phase) {
+          case 'copying':
+            flow = { kind: 'copying', message: p.message };
+            break;
+          case 'awaitingReboot':
+          case 'done':
+            flow = { kind: 'awaitingReboot', message: p.message };
+            break;
+        }
+      });
+      // After the command resolves, start polling for CIRCUITPY to come back.
+      flow = {
+        kind: 'awaitingReboot',
+        message:
+          'CircuitPython 7.3.1 written. Waiting for the device to reboot back to CIRCUITPY…',
+      };
+      rebootPollTimer = setInterval(pollForCircuitpyReturn, 1500);
+    } catch (e: any) {
+      clearPollers();
+      flow = {
+        kind: 'error',
+        message: e?.message ?? String(e),
+      };
+    }
+  }
+
+  async function startReflash() {
+    // Fast-path: if RPI-RP2 is already mounted (user pre-staged the device into
+    // bootloader mode), skip straight to the copy.
+    try {
+      const existing = await rpiRp2MountPath();
+      if (existing !== null) {
+        bootloaderPath = existing;
+        await runReflash();
+        return;
+      }
+    } catch {
+      // Fall through to polling — the command may transiently fail on first
+      // call while the OS settles.
+    }
+    flow = { kind: 'awaitingBootloader' };
+    bootloaderPollTimer = setInterval(pollForBootloader, 1000);
+  }
+
+  function cancel() {
+    clearPollers();
+    flow = { kind: 'idle' };
+    bootloaderPath = null;
+  }
+
+  function dismiss() {
+    flow = { kind: 'idle' };
+    bootloaderPath = null;
+  }
+</script>
+
+{#if highlight && flow.kind === 'idle'}
+  <div class="cta-banner">
+    <strong>Need CircuitPython 7.3.1?</strong>
+    Use the button below to reflash directly — no manual .uf2 download needed.
+  </div>
+{/if}
+
+<button class="reflash-trigger" onclick={startReflash} disabled={flow.kind !== 'idle'}>
+  Reflash CircuitPython 7.3.1
+</button>
+
+{#if flow.kind !== 'idle'}
+  <div
+    class="modal-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="reflash-title"
+  >
+    <div class="modal">
+      <h3 id="reflash-title">Reflash CircuitPython 7.3.1</h3>
+
+      {#if flow.kind === 'awaitingBootloader'}
+        <p>To enter the RP2040 bootloader:</p>
+        <ol>
+          <li>Unplug the device from USB.</li>
+          <li>Hold down <strong>Switch 1</strong> (top-left footswitch) / <strong>KEY0</strong>.</li>
+          <li>Plug USB back in while still holding the switch.</li>
+          <li>Release the switch once a drive named <code>RPI-RP2</code> appears.</li>
+        </ol>
+        <div class="status">
+          <span class="spinner" aria-hidden="true"></span>
+          Waiting for <code>RPI-RP2</code> to mount…
+        </div>
+        <div class="actions">
+          <button class="secondary" onclick={cancel}>Cancel</button>
+        </div>
+      {:else if flow.kind === 'copying'}
+        <div class="status">
+          <span class="spinner" aria-hidden="true"></span>
+          {statusMessage}
+        </div>
+        <p class="hint">
+          Don't unplug the device — the bootloader needs the .uf2 to finish
+          writing before it can reboot.
+        </p>
+      {:else if flow.kind === 'awaitingReboot'}
+        <div class="status">
+          <span class="spinner" aria-hidden="true"></span>
+          {statusMessage}
+        </div>
+        <p class="hint">
+          The RP2040 bootloader is handling the flash + reboot on its own.
+          We're waiting for <code>CIRCUITPY</code> to remount.
+        </p>
+        <div class="actions">
+          <button class="secondary" onclick={cancel}>
+            Stop waiting (reflash continues on device)
+          </button>
+        </div>
+      {:else if flow.kind === 'done'}
+        <div class="status success">
+          ✓ CircuitPython 7.3.1 installed.
+        </div>
+        <p>
+          The device has rebooted back to <code>CIRCUITPY</code>. Now click
+          <strong>Install Firmware</strong> to deploy MIDI Captain MAX onto the
+          fresh CircuitPython.
+        </p>
+        <div class="actions">
+          <button onclick={dismiss}>Close</button>
+        </div>
+      {:else if flow.kind === 'error'}
+        <div class="status error">
+          ✗ {statusMessage}
+        </div>
+        <div class="actions">
+          <button class="secondary" onclick={cancel}>Close</button>
+          <button onclick={startReflash}>Try again</button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .cta-banner {
+    padding: 10px 12px;
+    background: rgba(240, 173, 78, 0.15);
+    border: 1px solid var(--warning);
+    border-radius: 4px;
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.45;
+  }
+  .cta-banner strong {
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  .reflash-trigger {
+    align-self: flex-start;
+    padding: 6px 12px;
+    font-size: 13px;
+    background: var(--bg-tertiary, var(--bg-secondary));
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .reflash-trigger:hover:not(:disabled) {
+    background: var(--bg-secondary);
+    border-color: var(--accent);
+  }
+  .reflash-trigger:disabled {
+    background: var(--disabled-bg);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 24px;
+  }
+
+  .modal {
+    background: var(--bg-primary, #1e1e1e);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 20px 24px;
+    max-width: 520px;
+    width: 100%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .modal h3 {
+    margin: 0 0 12px 0;
+    font-size: 16px;
+  }
+
+  .modal ol {
+    margin: 8px 0;
+    padding-left: 22px;
+  }
+
+  .modal li {
+    margin: 4px 0;
+  }
+
+  .modal code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    background: var(--bg-secondary);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+  }
+
+  .status {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    margin-top: 8px;
+  }
+
+  .status.success {
+    background: rgba(74, 124, 78, 0.15);
+    border: 1px solid var(--success);
+  }
+
+  .status.error {
+    background: var(--error-bg, rgba(229, 53, 53, 0.15));
+    border: 1px solid var(--error-border, var(--error, #e53535));
+    color: var(--error-text, var(--text-primary));
+  }
+
+  .hint {
+    margin: 12px 0 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 16px;
+  }
+
+  .actions button {
+    padding: 6px 14px;
+    font-size: 13px;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .actions button.secondary {
+    background: transparent;
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+  }
+
+  .actions button:hover {
+    opacity: 0.9;
+  }
+
+  .spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--text-secondary);
+    border-top-color: transparent;
+    border-radius: 50%;
+    display: inline-block;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/config-editor/src/lib/types.ts
+++ b/config-editor/src/lib/types.ts
@@ -94,6 +94,13 @@ export interface InstallReport {
   config_preserved: boolean;
 }
 
+export type ReflashPhase = 'copying' | 'awaitingReboot' | 'done';
+
+export interface ReflashProgress {
+  phase: ReflashPhase;
+  message: string;
+}
+
 // Color mapping for UI
 export const BUTTON_COLORS: Record<ButtonColor, string> = {
   red: '#ff0000',

--- a/firmware/dev/INSTALL.md
+++ b/firmware/dev/INSTALL.md
@@ -82,13 +82,19 @@ If your device ends up in a bad state, don't worry — it's fully recoverable:
 3. Copy the firmware files onto the drive again
 4. Safely eject the drive, then unplug and replug USB to restart
 
-If the drive doesn't appear at all, reinstall CircuitPython:
+If the drive doesn't appear at all — or if the Config Editor refused to install with a CircuitPython-version error — you need to reflash CircuitPython 7.3.1.
 
-1. **Hold Switch 1** (top-left footswitch) while plugging in USB — a drive called **RPI-RP2** will appear
-2. Download the CircuitPython 7.x `.uf2` file for your board
-3. Copy the `.uf2` file to the RPI-RP2 drive
-4. The device will reboot and appear as **CIRCUITPY**
-5. Now copy the firmware files (or run the deploy script)
+> **Why 7.3.1 specifically?** This firmware's bundled libraries are mpy format v5 and `boot.py` uses CP 7-only APIs. CP 8.0 and later silently break it. See issue #132 for details and #2 for the planned migration to CP 9/10.
+
+**Easiest: use the Config Editor's "Reflash CircuitPython 7.3.1" button** (next to "Install Firmware"). It walks you through the bootloader hold, copies the bundled `.uf2`, and waits for the device to come back to `CIRCUITPY` automatically.
+
+**Manual / terminal:**
+
+1. **Hold Switch 1** (top-left footswitch) while plugging in USB — a drive called **RPI-RP2** will appear.
+2. Grab `adafruit-circuitpython-raspberry_pi_pico-en_US-7.3.1.uf2` from the `MIDI-Captain-MAX-vX.Y.Z-complete.zip` release asset (or run `./tools/fetch-cp-uf2.sh` from a repo checkout to download + checksum-verify it).
+3. Copy the `.uf2` file onto the **RPI-RP2** drive.
+4. The device will reboot on its own and appear as **CIRCUITPY**.
+5. Now copy the firmware files (or run the deploy script).
 
 ---
 

--- a/tools/bundle-firmware-for-dev.sh
+++ b/tools/bundle-firmware-for-dev.sh
@@ -40,3 +40,8 @@ echo "Staged firmware version $VERSION at:"
 echo "  $DEST"
 echo "Contents:"
 ls -la "$DEST"
+
+# Also stage the pinned CircuitPython .uf2 used by the GUI reflash button
+# (issue #134). The fetch script is idempotent — no-op after the first run.
+echo ""
+"$REPO_ROOT/tools/fetch-cp-uf2.sh"

--- a/tools/fetch-cp-uf2.sh
+++ b/tools/fetch-cp-uf2.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Fetch the pinned CircuitPython 7.3.1 .uf2 for raspberry_pi_pico and stage it
+# into the Config Editor's Tauri resources so it ships with built apps.
+#
+# Idempotent: if the file is already present and its SHA256 matches the pin,
+# the script is a no-op. Re-downloads only on missing/corrupt file.
+#
+# Usage (from repo root or anywhere):
+#   ./tools/fetch-cp-uf2.sh
+#
+# Bundled by the GUI to support the "Reflash CircuitPython 7.3.1" button
+# (issue #134) — recovery path from CP-version mismatch (#132).
+set -euo pipefail
+
+# Pin to upstream Adafruit canonical URL + the SHA256 captured at pin time.
+# Bumping the CP target: update both URL and SHA256 together; also update
+# MAX_SUPPORTED_CP_MAJOR in installer.rs / deploy.sh / deploy.ps1.
+CP_URL="https://downloads.circuitpython.org/bin/raspberry_pi_pico/en_US/adafruit-circuitpython-raspberry_pi_pico-en_US-7.3.1.uf2"
+CP_SHA256="1f32b7cd998b3375702a1aca19e2c4487ed589f3460d364716748fe88058c84a"
+CP_FILENAME="adafruit-circuitpython-raspberry_pi_pico-en_US-7.3.1.uf2"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST_DIR="$REPO_ROOT/config-editor/src-tauri/resources/circuitpython"
+DEST="$DEST_DIR/$CP_FILENAME"
+
+# Cross-platform sha256: macOS ships `shasum`, Linux ships `sha256sum`.
+sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        echo "error: neither sha256sum nor shasum found on PATH" >&2
+        exit 1
+    fi
+}
+
+mkdir -p "$DEST_DIR"
+
+# No-op fast path: file already present with the right bytes.
+if [[ -f "$DEST" ]]; then
+    GOT=$(sha256 "$DEST")
+    if [[ "$GOT" == "$CP_SHA256" ]]; then
+        echo "✓ CP .uf2 already staged at $DEST (sha256 verified)"
+        exit 0
+    fi
+    echo "! existing $CP_FILENAME has wrong SHA256 (got $GOT, expected $CP_SHA256); re-fetching"
+    rm -f "$DEST"
+fi
+
+echo "Fetching $CP_FILENAME from $CP_URL..."
+# `-fL`: fail on HTTP errors + follow redirects. Adafruit serves these from
+# S3 via a CDN that occasionally 30x's.
+curl -fL --progress-bar -o "$DEST" "$CP_URL"
+
+GOT=$(sha256 "$DEST")
+if [[ "$GOT" != "$CP_SHA256" ]]; then
+    echo "error: SHA256 mismatch — got $GOT, expected $CP_SHA256" >&2
+    echo "   (refusing to ship a .uf2 we can't verify; deleting the bad file)" >&2
+    rm -f "$DEST"
+    exit 1
+fi
+
+echo "✓ CP .uf2 staged at $DEST (sha256 verified)"


### PR DESCRIPTION
Closes #134.

## Summary

- Bundles CircuitPython 7.3.1 `.uf2` into the Config Editor via a fetch-on-demand build step (not committed to the repo) so the GUI can reflash the device without the user finding a 1.5 MB binary on Adafruit's archive.
- Adds a "Reflash CircuitPython 7.3.1" button next to "Install Firmware" with a modal state machine that walks the user through the bootloader hold, copies the bundled `.uf2`, and waits for `CIRCUITPY` to remount.
- Closes the recovery loop for the #132 preflight: when the install errors with a CP-version mismatch, the new button is highlighted as the next step.

## What landed

### Asset pipeline
- `tools/fetch-cp-uf2.sh` — downloads CP 7.3.1 from Adafruit, verifies SHA256 against a pinned hash (`1f32b7cd998b…`), idempotent.
- `tools/bundle-firmware-for-dev.sh` calls the fetch script so local devs get the `.uf2` staged automatically.
- `.github/actions/stage-firmware-for-editor` runs the fetch in CI — every Tauri build picks up the `.uf2` without per-job edits.
- `release.yml` includes the `.uf2` in `MIDI-Captain-MAX-vX.Y.Z-complete.zip` for terminal users.
- `tauri.conf.json` declares `resources/circuitpython/*.uf2` as a bundled resource → ships inside the `.dmg` / `.msi` / `.exe`.

### Reflash logic
- New `reflash.rs` module: `detect_rpi_rp2`, `copy_uf2_to_bootloader` (tolerates the mid-write disconnect from the RP2040 ROM bootloader), `reflash_circuitpython` + `rpi_rp2_mount_path` Tauri commands.
- Reuses `device::get_volumes_path` / `device::get_volume_name` via `pub(crate)` — no scanning duplication.

### UI
- New `ReflashCircuitPython.svelte` — modal with `idle → awaitingBootloader → copying → awaitingReboot → done | error` state machine. Fast-path: skip straight to copy if `RPI-RP2` is already mounted when opened.
- `FirmwareInstaller.svelte` embeds it and sets `highlight=true` when an install was refused with a CP-version error (matches on "CircuitPython" + "RPI-RP2" in the error message — the shape `#132`'s preflight emits).

### Docs
- README + `firmware/dev/INSTALL.md` recovery sections point at the new button; terminal fallback now references `tools/fetch-cp-uf2.sh` and the `-complete.zip` asset.

## Test plan

- [x] `cargo test` — 80/80 (76 previous + 4 new for `reflash`).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `npm run check` (`svelte-check`) — clean.
- [x] `cargo build --release` — clean.
- [x] `tools/fetch-cp-uf2.sh` smoke: fresh download verifies SHA256; second run hits the idempotent cache path; corrupt cache triggers re-download.
- [x] `tools/bundle-firmware-for-dev.sh` smoke: stages both firmware and `.uf2` together.
- [ ] CI: full Windows + macOS Tauri builds with the bundled `.uf2`.
- [ ] Manual on-hardware: reflash a CP 9.x device back to CP 7.3.1 via the GUI button, then install firmware, confirm boot. Optional — synthetic and code-path coverage is good, but real-hardware reflash is the only thing that exercises the bootloader unmount tolerance.

## Out of scope

- Reflashing non-RP2040 variants (none in the current device matrix).
- Automating the BOOTSEL / Switch 1 hold — manual user action.
- CP 9/10 firmware migration — tracked in #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)