### PR TITLE
Surface reflash button in the no-device empty state (#134 follow-up)

### DIFF
--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -20,6 +20,7 @@
   import DisplaySection from '$lib/components/DisplaySection.svelte';
   import MidiThruSection from '$lib/components/MidiThruSection.svelte';
   import FirmwareInstaller from '$lib/components/FirmwareInstaller.svelte';
+  import ReflashCircuitPython from '$lib/components/ReflashCircuitPython.svelte';
   import { loadConfig, validate, normalizeConfig, config } from '$lib/formStore';
 
   let appVersion = $state('');
@@ -348,7 +349,23 @@
     {:else}
       <div class="no-device">
         <p>No device selected</p>
-        <p>Connect a MIDI Captain device and select it above</p>
+        <p>Connect a MIDI Captain device and select it above.</p>
+        <div class="no-device-rescue">
+          <p class="rescue-label">
+            Device stuck in <code>RPI-RP2</code> bootloader mode, or
+            recovering from a CircuitPython mismatch? Reflash directly:
+          </p>
+          <ReflashCircuitPython
+            onComplete={async () => {
+              // Re-scan once the device has rebooted back to CIRCUITPY so it
+              // shows up in the picker for the follow-up Install Firmware step.
+              // The device watcher's connect event should also catch the
+              // remount, but an explicit re-scan handles platforms where the
+              // watcher lags.
+              $devices = await scanDevices();
+            }}
+          />
+        </div>
       </div>
     {/if}
   </div>
@@ -483,6 +500,35 @@
   .no-device {
     color: var(--text-secondary);
     font-style: italic;
+  }
+
+  .no-device-rescue {
+    margin-top: 24px;
+    padding: 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    max-width: 520px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-style: normal;
+    color: var(--text-primary);
+  }
+
+  .no-device-rescue .rescue-label {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+  }
+
+  .no-device-rescue code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    background: var(--bg-tertiary, var(--bg-primary));
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
   }
   
   .editor-container {


### PR DESCRIPTION
Follow-up to #135.

## Why

While hardware-smoking the reflash flow on a nano4 in `RPI-RP2` mode, the reflash button never appeared in the GUI — `scan_devices` returns nothing when a device is in bootloader mode, so `+page.svelte` falls through to the "No device selected" empty state, which had no actions on it. The reflash button was only rendered inside `FirmwareInstaller`, which is gated by `$selectedDevice && !$isLoading`. That's the wrong condition for a recovery affordance: the button is needed precisely when no normal device is detected.

## Change

`config-editor/src/routes/+page.svelte`:
- Import `ReflashCircuitPython` alongside `FirmwareInstaller`.
- Render it in the `:else` branch (no device selected) with a clear contextual label: "Device stuck in `RPI-RP2` bootloader mode, or recovering from a CircuitPython mismatch? Reflash directly:".
- `onComplete` re-runs `scanDevices()` so the freshly remounted CIRCUITPY shows up in the picker for the follow-up Install Firmware step.
- Styles: new `.no-device-rescue` panel matching the existing editor theme.

The original placement inside `FirmwareInstaller` is kept — the highlighted CTA still fires there when an install is refused with a CP-version mismatch.

## Test plan

- [x] `svelte-check` — clean.
- [ ] Hardware smoke on nano4 in `RPI-RP2` mode: empty state shows the rescue panel, button click hits the fast-path, copy + remount + Install Firmware completes end-to-end.

## Out of scope

- Re-architecting where the button lives long term (e.g., promoting it to the header alongside the device picker). Current placement is fine; revisit if usage patterns suggest otherwise.
- Diagnostic logging on `detect_rpi_rp2` — wasn't needed in the end; the stale dev build was the root cause of the initial null return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)