### PR TITLE
Force sync_all on bootloader copy + Cancel + watchdog (#134 hotfix)

### DIFF
--- a/config-editor/src-tauri/src/reflash.rs
+++ b/config-editor/src-tauri/src/reflash.rs
@@ -11,6 +11,7 @@
 use crate::commands::ConfigError;
 use crate::device::{get_volume_name, get_volumes_path};
 use serde::Serialize;
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use tauri::ipc::Channel;
 use tauri::{command, AppHandle, Manager};
@@ -101,31 +102,72 @@ fn bundled_uf2_path(app: &AppHandle) -> Result<PathBuf, ConfigError> {
 
 /// Copy the bundled `.uf2` onto the `RPI-RP2` bootloader drive.
 ///
-/// The RP2040 ROM bootloader unmounts the drive mid-write once it has enough
-/// bytes to commit, then reboots into the new firmware. The OS surfaces that
-/// disconnect as an IO error on `fs::copy`'s close. If the drive's gone, that's
-/// the bootloader handing off — treat as success. If the drive's still there
-/// and the copy failed, propagate the error.
+/// Uses explicit `OpenOptions` + `io::copy` + `sync_all` rather than
+/// `std::fs::copy`. The bare `fs::copy` closes the destination via `Drop`,
+/// which on macOS USB MSC volumes does not force a kernel buffer flush —
+/// bytes can sit in the page cache indefinitely. The RP2040 bootloader
+/// waits for the actual write, so without an explicit `sync_all` the UI
+/// hangs in the "copying" state with the device never rebooting. This
+/// mirrors `installer::copy_file_synced` for the same reason.
+///
+/// Tolerance for mid-write disconnect: the bootloader unmounts the drive
+/// once it has enough bytes to commit. The OS surfaces that as either a
+/// `WriteZero`/`BrokenPipe` on `io::copy` or a generic IO error on
+/// `sync_all`. If the drive has vanished, treat as success — the
+/// bootloader took over.
 pub(crate) fn copy_uf2_to_bootloader(
     uf2_src: &Path,
     bootloader: &Path,
 ) -> Result<(), ConfigError> {
     let target = bootloader.join(BUNDLED_UF2_FILENAME);
-    match std::fs::copy(uf2_src, &target) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            if !bootloader.exists() {
-                // Bootloader has unmounted itself — write was accepted, reboot incoming.
-                Ok(())
-            } else {
-                Err(ConfigError::msg(format!(
-                    "Failed to copy .uf2 onto {}: {}. \
-                     If the device disconnected mid-copy, try again.",
-                    bootloader.display(),
-                    e
-                )))
-            }
-        }
+
+    let mut reader = File::open(uf2_src).map_err(|e| {
+        ConfigError::msg(format!("Failed to open bundled .uf2 at {}: {}", uf2_src.display(), e))
+    })?;
+    let mut writer = match OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&target)
+    {
+        Ok(f) => f,
+        Err(e) => return classify_post_copy_error(bootloader, "open", e),
+    };
+
+    if let Err(e) = std::io::copy(&mut reader, &mut writer) {
+        return classify_post_copy_error(bootloader, "write", e);
+    }
+
+    if let Err(e) = writer.sync_all() {
+        return classify_post_copy_error(bootloader, "sync", e);
+    }
+
+    // Explicitly drop the writer so the kernel finalises the file handle
+    // before we return success. Belt-and-suspenders with sync_all above.
+    drop(writer);
+    Ok(())
+}
+
+/// Classify an IO error that happened at any step of the copy. If the
+/// bootloader drive has unmounted itself (RP2040 took the bytes and is
+/// flashing), treat as success regardless of which step erred. Otherwise
+/// propagate with context about which step failed.
+fn classify_post_copy_error(
+    bootloader: &Path,
+    step: &str,
+    e: std::io::Error,
+) -> Result<(), ConfigError> {
+    if !bootloader.exists() {
+        // Bootloader has unmounted itself — write accepted, reboot incoming.
+        Ok(())
+    } else {
+        Err(ConfigError::msg(format!(
+            "Failed to {} .uf2 onto {}: {}. \
+             If the device disconnected mid-copy, try again.",
+            step,
+            bootloader.display(),
+            e
+        )))
     }
 }
 

--- a/config-editor/src/lib/components/ReflashCircuitPython.svelte
+++ b/config-editor/src/lib/components/ReflashCircuitPython.svelte
@@ -38,6 +38,11 @@
   // Poll handles — cleared on state change or cancel.
   let bootloaderPollTimer: ReturnType<typeof setInterval> | null = null;
   let rebootPollTimer: ReturnType<typeof setInterval> | null = null;
+  // Watchdog for the copying phase: a healthy copy + bootloader handoff
+  // finishes in under ~10s. If we're still in `copying` after 60s, surface a
+  // diagnostic CTA rather than letting the user stare at the spinner forever.
+  let copyWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  let copyStalled = $state(false);
 
   function clearPollers() {
     if (bootloaderPollTimer !== null) {
@@ -48,6 +53,11 @@
       clearInterval(rebootPollTimer);
       rebootPollTimer = null;
     }
+    if (copyWatchdogTimer !== null) {
+      clearTimeout(copyWatchdogTimer);
+      copyWatchdogTimer = null;
+    }
+    copyStalled = false;
   }
 
   onDestroy(clearPollers);
@@ -83,6 +93,14 @@
       kind: 'copying',
       message: 'Copying CircuitPython 7.3.1 onto the bootloader…',
     };
+    copyStalled = false;
+    copyWatchdogTimer = setTimeout(() => {
+      // Only flip the stalled flag if we're still in copying — if the state
+      // already advanced (or the user cancelled) we don't want to nag them.
+      if (flow.kind === 'copying') {
+        copyStalled = true;
+      }
+    }, 60_000);
     try {
       await reflashCircuitpython((p: ReflashProgress) => {
         // Echo Rust-side progress into our state machine. The Rust command's
@@ -190,6 +208,16 @@
           Don't unplug the device — the bootloader needs the .uf2 to finish
           writing before it can reboot.
         </p>
+        {#if copyStalled}
+          <div class="status error">
+            Copy hasn't completed in 60 seconds. The bootloader may not be
+            accepting the write — try cancelling, unplugging, then re-entering
+            <code>RPI-RP2</code> bootloader mode before retrying.
+          </div>
+        {/if}
+        <div class="actions">
+          <button class="secondary" onclick={cancel}>Cancel</button>
+        </div>
       {:else if flow.kind === 'awaitingReboot'}
         <div class="status">
           <span class="spinner" aria-hidden="true"></span>


### PR DESCRIPTION
Hotfix for the reflash hang reported in #134 follow-up testing.

## Bug

User reported the GUI hung in the `copying` state for several minutes during a real-hardware reflash on a nano4 in `RPI-RP2` mode. Root cause: `copy_uf2_to_bootloader` used bare `std::fs::copy`, which closes the destination handle via `Drop` without calling `fsync`. On macOS USB MSC volumes, written bytes can sit in the kernel page cache indefinitely — the RP2040 ROM bootloader never sees the `.uf2`, never unmounts itself, never reboots. The Rust task eventually returns Ok, but the user is left staring at a spinner while the kernel slowly drains its buffer (or doesn't).

`installer::copy_file_synced` already does the right thing for the same reason (USB MSC writes to a CIRCUITPY device). My reflash copy didn't follow the same pattern.

## Change

`reflash.rs`:
- Refactor `copy_uf2_to_bootloader` to mirror `copy_file_synced`: explicit `OpenOptions` + `io::copy` + `sync_all` + explicit `drop`. `sync_all` blocks until the OS has actually flushed bytes to USB, so by the time we return the bootloader has either taken the full `.uf2` (and is rebooting) or the drive has vanished mid-flush (also a success signal).
- Extract the disconnect-tolerance branch into `classify_post_copy_error` so it applies uniformly to open / write / sync failures — any of which might surface if the bootloader unmounts at exactly that step.

`ReflashCircuitPython.svelte`:
- Add a Cancel button to the `copying` state. The state had no escape hatch before — if anything went wrong mid-copy, the user was stuck staring at the spinner.
- 60s JS watchdog: if the copy hasn't completed in a minute, surface a diagnostic banner ("bootloader may not be accepting the write — unplug + retry") above the spinner. Doesn't abort the Rust task (a blocked kernel call isn't cancellable), just gives the user something actionable to look at.

## Test plan

- [x] `cargo test reflash::` — 4/4 pass. Existing fixtures don't exercise `sync_all` semantics, but the Ok/Err classification still funnels through the same branches.
- [x] `svelte-check` — clean.
- [ ] Hardware re-test on nano4: reflash should complete inside ~10s with the explicit sync, not several minutes.

## Reported context

Real user (PR author) hit the hang on a nano4 reflash; device eventually rebooted but only after minutes of buffered writes draining. Validates the diagnosis: the bootloader did receive the bytes, just very slowly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)