### PR TITLE
Gate reflash button on RPI-RP2 detection (#134 polish)

### DIFF
--- a/config-editor/src/lib/components/FirmwareInstaller.svelte
+++ b/config-editor/src/lib/components/FirmwareInstaller.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { ask, message } from '@tauri-apps/plugin-dialog';
   import { getFirmwareVersions, installFirmware } from '$lib/api';
-  import ReflashCircuitPython from './ReflashCircuitPython.svelte';
   import type {
     DetectedDevice,
     FirmwareVersions,
@@ -53,15 +52,6 @@
     progress && progress.total > 0
       ? Math.round((progress.current / progress.total) * 100)
       : 0,
-  );
-
-  // The Rust preflight (issue #132) refuses installs on CP >= 8 with an error
-  // mentioning "CircuitPython" and pointing at the RPI-RP2 recovery path. When
-  // we see that shape, surface the reflash flow more prominently. False
-  // positives are harmless (the button is always available) — we're just
-  // drawing the eye to it when we know it's the right next step.
-  let cpVersionMismatch = $derived(
-    errorMsg.includes('CircuitPython') && errorMsg.includes('RPI-RP2'),
   );
 
   async function startInstall() {
@@ -181,13 +171,6 @@
       <strong>Error:</strong> {errorMsg}
     </div>
   {/if}
-
-  <div class="reflash-row">
-    <ReflashCircuitPython
-      highlight={cpVersionMismatch}
-      onComplete={() => refreshVersions(device)}
-    />
-  </div>
 </section>
 
 <style>
@@ -342,13 +325,5 @@
   .result ul {
     margin: 6px 0 0 0;
     padding-left: 20px;
-  }
-
-  .reflash-row {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding-top: 8px;
-    border-top: 1px solid var(--border-color);
   }
 </style>

--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -9,7 +9,8 @@
   } from '$lib/stores';
   import {
     scanDevices, startDeviceWatcher, readConfigRaw, writeConfigRaw,
-    onDeviceConnected, onDeviceDisconnected, restartDevice, ejectDevice
+    onDeviceConnected, onDeviceDisconnected, restartDevice, ejectDevice,
+    rpiRp2MountPath
   } from '$lib/api';
   import type { DetectedDevice } from '$lib/types';
   import ConfigForm from '$lib/components/ConfigForm.svelte';
@@ -24,7 +25,13 @@
   import { loadConfig, validate, normalizeConfig, config } from '$lib/formStore';
 
   let appVersion = $state('');
-  
+
+  // RPI-RP2 (RP2040 ROM bootloader) detection state. Polled at app level so
+  // the reflash affordance only surfaces when the user has actually staged
+  // the device into bootloader mode — no clutter in the normal UI.
+  let rpiRp2DetectedPath = $state<string | null>(null);
+  let rpiRp2PollTimer: ReturnType<typeof setInterval> | null = null;
+
   // Event listener cleanup functions
   let unlistenConnect: (() => void) | undefined;
   let unlistenDisconnect: (() => void) | undefined;
@@ -118,17 +125,33 @@
         }
       };
       document.addEventListener('keydown', keydownHandler);
+
+      // Poll for RPI-RP2 bootloader presence at 2s. Cheap call (one filesystem
+      // read_dir on /Volumes); UI affordance only renders when detected.
+      const pollRpiRp2 = async () => {
+        try {
+          rpiRp2DetectedPath = await rpiRp2MountPath();
+        } catch {
+          // Transient — keep polling on next tick.
+        }
+      };
+      await pollRpiRp2();
+      rpiRp2PollTimer = setInterval(pollRpiRp2, 2000);
     } catch (e: any) {
       $statusMessage = `Error initializing: ${e.message || e}`;
     }
   });
-  
+
   onDestroy(() => {
     // Clean up event listeners to prevent memory leaks
     unlistenConnect?.();
     unlistenDisconnect?.();
     if (keydownHandler) {
       document.removeEventListener('keydown', keydownHandler);
+    }
+    if (rpiRp2PollTimer !== null) {
+      clearInterval(rpiRp2PollTimer);
+      rpiRp2PollTimer = null;
     }
   });
   
@@ -328,7 +351,29 @@
       {/if}
     </div>
   </header>
-  
+
+  {#if rpiRp2DetectedPath}
+    <div class="rpi-banner" role="status">
+      <span class="label">
+        <strong>RPI-RP2 bootloader detected</strong> at
+        <code>{rpiRp2DetectedPath}</code>. Reflash CircuitPython 7.3.1 directly
+        from here — the device will reboot back to <code>CIRCUITPY</code>
+        automatically.
+      </span>
+      <ReflashCircuitPython
+        onComplete={async () => {
+          // Once the device returns to CIRCUITPY, refresh the picker so the
+          // user can immediately hit Install Firmware. The device watcher's
+          // connect event should also cover this; the explicit scan handles
+          // platforms where the watcher lags.
+          $devices = await scanDevices();
+          rpiRp2DetectedPath = null;
+        }}
+      />
+    </div>
+  {/if}
+
+
   <div class="editor-container">
     {#if $selectedDevice && !$isLoading}
       <ConfigForm onSave={saveToDevice}>
@@ -350,22 +395,6 @@
       <div class="no-device">
         <p>No device selected</p>
         <p>Connect a MIDI Captain device and select it above.</p>
-        <div class="no-device-rescue">
-          <p class="rescue-label">
-            Device stuck in <code>RPI-RP2</code> bootloader mode, or
-            recovering from a CircuitPython mismatch? Reflash directly:
-          </p>
-          <ReflashCircuitPython
-            onComplete={async () => {
-              // Re-scan once the device has rebooted back to CIRCUITPY so it
-              // shows up in the picker for the follow-up Install Firmware step.
-              // The device watcher's connect event should also catch the
-              // remount, but an explicit re-scan handles platforms where the
-              // watcher lags.
-              $devices = await scanDevices();
-            }}
-          />
-        </div>
       </div>
     {/if}
   </div>
@@ -502,28 +531,27 @@
     font-style: italic;
   }
 
-  .no-device-rescue {
-    margin-top: 24px;
-    padding: 16px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
+  .rpi-banner {
+    margin: 12px 20px 0;
+    padding: 12px 16px;
+    background: rgba(240, 173, 78, 0.15);
+    border: 1px solid var(--warning);
     border-radius: 6px;
-    max-width: 520px;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    font-style: normal;
     color: var(--text-primary);
-  }
-
-  .no-device-rescue .rescue-label {
-    margin: 0;
     font-size: 13px;
     line-height: 1.5;
-    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
   }
 
-  .no-device-rescue code {
+  .rpi-banner .label {
+    flex: 1;
+    min-width: 240px;
+  }
+
+  .rpi-banner code {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     background: var(--bg-tertiary, var(--bg-primary));
     padding: 1px 5px;


### PR DESCRIPTION
Polish for #134. Per request, the reflash button shouldn't clutter the normal UI — only appear when the device is actually in RP2040 ROM bootloader mode.

## What changes

- App-level poll: `rpi_rp2_mount_path` every 2 s. Cheap (a `read_dir` on `/Volumes` or per-platform equivalent).
- When `RPI-RP2` mounts, render a banner under the header with the existing `ReflashCircuitPython` component embedded. Banner clears itself on `onComplete` (also re-scans devices so the user can immediately hit Install Firmware).
- Drop the previous placements: `FirmwareInstaller` no longer embeds the button or the `cpVersionMismatch` highlight (since the button isn't there to highlight anymore). `+page.svelte` no-device branch loses the rescue panel added in #136 — the banner above covers the same case.

## What I considered and dropped

Briefly explored auto-entering bootloader via serial REPL (`microcontroller.on_next_reset(RunMode.UF2); microcontroller.reset()`) so the user wouldn't need to drop into a terminal. Backed it out per the "only if in RPI mode" steer — without auto-entry the button doesn't need to live in the normal UI at all. Auto-entry could come back as a separate issue if it turns out to be the friction we think it is.

## Test plan

- [x] `svelte-check` clean (no Rust changes; existing `cargo test` covers the unchanged Tauri side).
- [ ] Hardware: put nano4 into RPI-RP2 mode → confirm banner appears within ~2 s. Click reflash → confirm copy + reboot completes. Confirm banner disappears after CIRCUITPY remounts.
- [ ] Negative: with nano4 in normal CIRCUITPY mode, banner stays hidden across the whole UI lifecycle.

## Trail

#134 → #135 (bundle + reflash) → #136 (no-device empty state) → #137 (sync_all hotfix) → this PR (gate visibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)