### PR TITLE
Add deploy.bat launcher + fix pip resolution in deploy.ps1 (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
             -x "*.pyc" -x "*/__pycache__/*" -x "*/__pycache__" -x "experiments/*"
           cd ../..
           # Add deploy scripts to root of zip (using -j to strip path)
-          zip -j "dist/midicaptain-firmware-${VERSION}.zip" tools/deploy.sh tools/deploy.ps1
+          zip -j "dist/midicaptain-firmware-${VERSION}.zip" tools/deploy.sh tools/deploy.ps1 tools/deploy.bat
           echo "Created: \`dist/midicaptain-firmware-${VERSION}.zip\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload zip artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ cd config-editor/src-tauri && cargo clippy --lib --no-deps    # Rust
 
 ### Dependencies
 - **`requirements-dev.txt`**: CI/dev tools (ruff, pytest)
-- **`requirements-circuitpython.txt`**: On-device libraries for `circup install -r`
+- **`requirements-circuitpython.txt`**: Maintainer-only list of bundled CircuitPython libs; used to refresh `firmware/dev/lib/` from the Adafruit bundle via `circup install -r`. End-users never need circup — `lib/` ships in the release zip.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ In many cases, the first install still requires a one-time bootstrap because the
    <br>For example, if you have a Nano 4, run `./deploy.sh --device nano4`_.
    - macOS / Linux: `./deploy.sh --device std10|mini6|nano4|duo2|one1`
    - Windows PowerShell: `.\deploy.ps1 -Device std10|mini6|nano4|duo2|one1`
+   - Windows cmd (if PowerShell blocks unsigned scripts): `deploy.bat -Device std10|mini6|nano4|duo2|one1` — invokes `deploy.ps1` with a per-process `ExecutionPolicy Bypass`; does not change any system policy.
 4. Reconnect the device and open the MIDI Captain MAX Config Editor.
 5. From then on, use the **Firmware Installation** section in the app for future updates.
 

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -21,9 +21,9 @@ Target **CircuitPython 7.x** (7.3.1 verified on devices). Board identifies as `r
 
 `firmware/dev/lib/` ships `.mpy` files in format v5, loadable by CP 7.x. To verify before adding a new lib: `xxd <file>.mpy | head -1` — the second byte is the format version (`05` = v5 = CP 7.x; `06` = v6 = CP 8.x+, will fail on CP 7).
 
-### Never pass `circup install --py`
+### Never mix `.py` source over the bundled `.mpy` libs
 
-`tools/deploy.{sh,ps1}` deliberately omit `--py`. With `--py`, `circup` installs source `.py` over the bundle's `.mpy`, so both forms coexist in `/lib`. CP's resolution is version-dependent and the `.py` source often pulls in modules the runtime doesn't have (e.g. `busdisplay` is CP 9-only) — this bricked a real CP 7.3.1 NANO4.
+`firmware/dev/lib/` ships pre-compiled `.mpy` v5 libraries; the deploy scripts copy them straight to the device. Don't drop `.py` source for the same module alongside (e.g. via `circup install --py`). With both forms in `/lib`, CP's resolution is version-dependent and the `.py` source often pulls in modules the runtime doesn't have (e.g. `busdisplay` is CP 9-only) — this bricked a real CP 7.3.1 NANO4. When refreshing the bundle (maintainer task), pull `.mpy` only.
 
 ### Automating CircuitPython REPL via serial
 

--- a/firmware/dev/INSTALL.md
+++ b/firmware/dev/INSTALL.md
@@ -11,17 +11,17 @@
 
 ## Install with the Deploy Script (Recommended)
 
-The deploy script is the easiest way to install or update firmware. It automatically detects your device, installs required libraries, and preserves your settings.
+The deploy script is the easiest way to install or update firmware. It automatically detects your device and preserves your settings. All required CircuitPython libraries are already bundled in this package — no separate library install step is needed.
 
 ### macOS / Linux
 
 Open a terminal in this folder and run:
 
 ```bash
-# First-time install (downloads required libraries)
-./deploy.sh --install
+# First-time setup for a device type (writes the matching config + firmware)
+./deploy.sh --device nano4   # one1 | duo2 | nano4 | mini6 | std10
 
-# Update existing firmware
+# Subsequent updates (firmware only, preserves config)
 ./deploy.sh
 ```
 
@@ -29,34 +29,34 @@ Open a terminal in this folder and run:
 
 | Flag | What it does |
 |------|-------------|
-| `--install` | Full install including CircuitPython libraries |
+| `--device TYPE` | First-time setup: write the device-specific config template + deploy firmware |
+| `--reset-config` | Overwrite config.json with the device-type template defaults |
 | `--eject` | Safely eject the device after deploying |
-| `--fresh` | Reset config.json to factory defaults |
-| `--libs-only` | Only install/update CircuitPython libraries |
 
-### Windows (PowerShell)
+### Windows
 
-Open PowerShell in this folder and run:
+Open `cmd` or PowerShell in this folder and run:
 
-```powershell
-# First-time install (downloads required libraries)
-.\deploy.ps1 -Install
+```cmd
+:: cmd (recommended if PowerShell blocks unsigned scripts)
+deploy.bat -Device nano4
 
-# Update existing firmware
-.\deploy.ps1
+:: PowerShell
+.\deploy.ps1 -Device nano4
 ```
+
+`deploy.bat` invokes PowerShell with `-ExecutionPolicy Bypass` for this one process only — it sidesteps the "running scripts is disabled on this system" error without changing any system policy.
 
 **Options:**
 
 | Flag | What it does |
 |------|-------------|
-| `-Install` | Full install including CircuitPython libraries |
+| `-Device TYPE` | First-time setup: write the device-specific config template + deploy firmware |
+| `-ResetConfig` | Overwrite config.json with the device-type template defaults |
 | `-Eject` | Safely eject the device after deploying |
-| `-Fresh` | Reset config.json to factory defaults |
-| `-LibsOnly` | Only install/update CircuitPython libraries |
 | `-MountPoint E:\` | Use a specific drive letter |
 
-> **Both scripts** auto-detect your device type (STD10 or Mini6) and preserve your existing button mappings, colors, and other settings.
+> **Both scripts** auto-detect your device type from existing config and preserve your existing button mappings, colors, and other settings.
 
 ---
 
@@ -104,6 +104,7 @@ If the drive doesn't appear at all — or if the Config Editor refused to instal
 |---------------|-------------|
 | `deploy.sh` | Install script for macOS/Linux |
 | `deploy.ps1` | Install script for Windows PowerShell |
+| `deploy.bat` | Windows cmd launcher for `deploy.ps1` (bypasses ExecutionPolicy) |
 | `code.py` | Main firmware entry point |
 | `boot.py` | Startup configuration |
 | `config.json` | Default settings (STD10) |

--- a/requirements-circuitpython.txt
+++ b/requirements-circuitpython.txt
@@ -1,6 +1,10 @@
-# CircuitPython library dependencies
-# Install with circup: circup install -r requirements-circuitpython.txt
-# Or download from: https://circuitpython.org/libraries
+# CircuitPython library dependencies (maintainer reference)
+#
+# These libs are PRE-BUNDLED in firmware/dev/lib/ and ship in the release zip,
+# so end-users do NOT need circup. This file exists only so a maintainer can
+# refresh the bundled .mpy files from the Adafruit bundle:
+#   circup install -r requirements-circuitpython.txt --path firmware/dev/
+# Or download manually from: https://circuitpython.org/libraries
 
 adafruit_midi
 adafruit_display_text

--- a/tools/deploy.bat
+++ b/tools/deploy.bat
@@ -1,0 +1,10 @@
+@echo off
+REM Launcher for deploy.ps1 on Windows.
+REM .bat files are not subject to PowerShell's ExecutionPolicy, so this lets
+REM users run the deploy even when unsigned .ps1 scripts are blocked.
+REM -ExecutionPolicy Bypass applies to this one process only; it changes no
+REM system policy. %~dp0 is this script's own directory (with trailing \),
+REM so deploy.ps1 is found regardless of the current directory. %* forwards
+REM all arguments (-Device, -MountPoint, etc.) through to the script.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0deploy.ps1" %*
+exit /b %ERRORLEVEL%

--- a/tools/deploy.ps1
+++ b/tools/deploy.ps1
@@ -199,11 +199,34 @@ if ($Install) {
     $circupCmd = Get-Command circup -ErrorAction SilentlyContinue
     if (-not $circupCmd) {
         Write-Host "  circup not found. Installing..."
-        pip install circup --quiet 2>$null
+        # Resolve a usable pip: bare `pip`, then `python -m pip`, then `py -m pip`.
+        # Windows Python installs often expose only the `py` launcher (or
+        # `python`) on PATH, not bare `pip`; calling `pip` directly then throws
+        # a terminating CommandNotFoundException under ErrorActionPreference=Stop.
+        $pipRunner = $null
+        if (Get-Command pip -ErrorAction SilentlyContinue) {
+            $pipRunner = @("pip")
+        } elseif (Get-Command python -ErrorAction SilentlyContinue) {
+            $pipRunner = @("python", "-m", "pip")
+        } elseif (Get-Command py -ErrorAction SilentlyContinue) {
+            $pipRunner = @("py", "-m", "pip")
+        }
+        if (-not $pipRunner) {
+            Write-Host "ERROR: Python/pip not found on PATH" -ForegroundColor Red
+            Write-Host "  Install Python 3 from https://www.python.org/downloads/"
+            Write-Host "  (check 'Add python.exe to PATH' during install), then re-run."
+            Write-Host "  Or install circup manually: py -m pip install circup"
+            exit 1
+        }
+        # NB: avoid $pipRunner[1..(Count-1)] - for a 1-element array that is
+        # $pipRunner[1..0], and PowerShell's 1..0 counts DOWN (1,0), corrupting
+        # the call. Select-Object -Skip 1 yields an empty list as intended.
+        $pipArgs = @($pipRunner | Select-Object -Skip 1)
+        & $pipRunner[0] @pipArgs install circup --quiet 2>$null
         $circupCmd = Get-Command circup -ErrorAction SilentlyContinue
         if (-not $circupCmd) {
             Write-Host "ERROR: Failed to install circup" -ForegroundColor Red
-            Write-Host "  Try: pip install circup"
+            Write-Host "  Try: $($pipRunner -join ' ') install circup"
             exit 1
         }
     }

--- a/tools/deploy.ps1
+++ b/tools/deploy.ps1
@@ -8,18 +8,11 @@
 
 .PARAMETER Device
     First-time setup for a device type (one1, duo2, nano4, mini6, std10).
-    Writes the correct config template, installs CircuitPython libraries,
-    and deploys firmware. The go-to for new devices.
+    Writes the correct config template and deploys firmware. The go-to
+    for new devices.
 
 .PARAMETER ResetConfig
     Overwrite config.json with the device-type template defaults.
-    Does not reinstall libraries.
-
-.PARAMETER Install
-    Check/install CircuitPython libraries without touching config.
-
-.PARAMETER LibsOnly
-    Only install libraries (no firmware copy).
 
 .PARAMETER Eject
     Eject device after deploy (forces clean reload).
@@ -32,10 +25,8 @@
 
 .EXAMPLE
     .\deploy.ps1                          # Quick deploy (sync firmware only)
-    .\deploy.ps1 -Device nano4           # First-time NANO4 setup (config + libs + firmware)
+    .\deploy.ps1 -Device nano4           # First-time NANO4 setup (config + firmware)
     .\deploy.ps1 -ResetConfig            # Reset config.json to template defaults
-    .\deploy.ps1 -Install                 # Re-check/install libraries
-    .\deploy.ps1 -LibsOnly               # Just install CircuitPython libs
     .\deploy.ps1 -Eject                   # Deploy + eject (clean disconnect)
     .\deploy.ps1 -MountPoint E:\          # Custom mount point
 #>
@@ -45,11 +36,12 @@ param(
     [ValidateSet("one1", "duo2", "nano4", "mini6", "std10")]
     [string]$Device,
     [switch]$ResetConfig,
-    [switch]$Install,
-    [switch]$LibsOnly,
     [switch]$Eject,
     [switch]$Fresh,
-    [string]$MountPoint
+    [string]$MountPoint,
+    # Deprecated, accepted but ignored: lib/ is bundled in the firmware zip.
+    [switch]$Install,
+    [switch]$LibsOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -60,9 +52,10 @@ if ($Fresh) {
     $ResetConfig = $true
 }
 
-# -Device implies -Install (libraries) and config write
-if ($Device) {
-    $Install = $true
+# -Install / -LibsOnly are deprecated: libraries are bundled in the firmware zip,
+# so circup is no longer needed. Accept the flags for backwards compat and warn.
+if ($Install -or $LibsOnly) {
+    Write-Host "WARNING: -Install / -LibsOnly are deprecated and ignored - libraries are bundled in the firmware zip." -ForegroundColor Yellow
 }
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -83,18 +76,6 @@ if (Test-Path (Join-Path $ProjectRoot "firmware\dev")) {
     Write-Host "Expected firmware\dev\ (dev repo) or code.py (distributed package)"
     exit 1
 }
-
-# Required CircuitPython libraries
-$RequiredLibs = @(
-    "adafruit_midi"
-    "adafruit_display_text"
-    "adafruit_st7789"
-    "neopixel"
-    "adafruit_debouncer"
-)
-
-# If LibsOnly is set, also enable Install
-if ($LibsOnly) { $Install = $true }
 
 Write-Host "=== MIDI Captain Firmware Deploy ===" -ForegroundColor Blue
 Write-Host ""
@@ -187,103 +168,6 @@ Long-term CP 9/10 migration is tracked in issue #2:
 "@
             exit 1
         }
-    }
-}
-
-# Install libraries if requested
-if ($Install) {
-    Write-Host ""
-    Write-Host "Installing CircuitPython libraries..." -ForegroundColor Yellow
-
-    # Check for circup
-    $circupCmd = Get-Command circup -ErrorAction SilentlyContinue
-    if (-not $circupCmd) {
-        Write-Host "  circup not found. Installing..."
-        # Resolve a usable pip across three candidate forms:
-        #   `pip`              - bare pip on PATH
-        #   `python -m pip`    - pip via python module
-        #   `py -m pip`        - pip via the Windows py launcher
-        #
-        # Two real-world Windows gotchas to dodge here:
-        #
-        # 1. Bare `pip` is often NOT on PATH on Windows Python installs - calling
-        #    it directly throws a terminating CommandNotFoundException under
-        #    $ErrorActionPreference = 'Stop'.
-        #
-        # 2. `python.exe` on Windows 10/11 may be the Microsoft Store "app
-        #    execution alias" stub at C:\Users\<u>\AppData\Local\Microsoft\
-        #    WindowsApps\python.exe - a 0-byte shim that just prints "Python
-        #    was not found; run without arguments to install from the Microsoft
-        #    Store" and exits non-zero. Get-Command finds it; running it fails.
-        #
-        # So: filter out WindowsApps shims by Source path, then probe each
-        # surviving candidate with `--version`. First one to exit 0 wins.
-        $candidates = @(
-            @("pip"),
-            @("python", "-m", "pip"),
-            @("py", "-m", "pip")
-        )
-        $pipRunner = $null
-        foreach ($cand in $candidates) {
-            $cmd = Get-Command $cand[0] -ErrorAction SilentlyContinue
-            if (-not $cmd) { continue }
-            if ($cmd.Source -like '*\WindowsApps\*') { continue }
-            $probeArgs = @($cand | Select-Object -Skip 1) + '--version'
-            & $cand[0] @probeArgs *> $null
-            if ($LASTEXITCODE -eq 0) {
-                $pipRunner = $cand
-                break
-            }
-        }
-        if (-not $pipRunner) {
-            Write-Host "ERROR: working Python/pip not found on PATH" -ForegroundColor Red
-            Write-Host "  Install Python 3 from https://www.python.org/downloads/"
-            Write-Host "  (check 'Add python.exe to PATH' during install), then re-run."
-            Write-Host "  Note: the bare 'python.exe' shim from the Microsoft Store"
-            Write-Host "  does not count - install the real interpreter from python.org."
-            Write-Host "  Or install circup manually: py -m pip install circup"
-            exit 1
-        }
-        Write-Host "  Using: $($pipRunner -join ' ')"
-        # NB: avoid $pipRunner[1..(Count-1)] - for a 1-element array that is
-        # $pipRunner[1..0], and PowerShell's 1..0 counts DOWN (1,0), corrupting
-        # the call. Select-Object -Skip 1 yields an empty list as intended.
-        $pipArgs = @($pipRunner | Select-Object -Skip 1)
-        & $pipRunner[0] @pipArgs install circup --quiet 2>$null
-        $circupCmd = Get-Command circup -ErrorAction SilentlyContinue
-        if (-not $circupCmd) {
-            Write-Host "ERROR: Failed to install circup" -ForegroundColor Red
-            Write-Host "  Try: $($pipRunner -join ' ') install circup"
-            exit 1
-        }
-    }
-    Write-Host "circup available" -ForegroundColor Green
-
-    # Install each library
-    # --path: target the device mount point
-    # --allow-unsupported: we target CP 7.x which circup considers EOL.
-    #
-    # We deliberately do NOT pass `--py`. Mixing circup's `.py` source with
-    # the bundle's `.mpy` puts both forms in /lib for the same module, which
-    # is fragile: any disturbance to mtime / directory entry order can flip
-    # which form CircuitPython loads, and the `.py` form often pulls in
-    # newer-CP-only modules (e.g. `busdisplay`) that crash on CP 7.
-    foreach ($lib in $RequiredLibs) {
-        Write-Host "  Installing $lib... " -NoNewline
-        $result = & circup --path $MountPoint --allow-unsupported install $lib 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "done" -ForegroundColor Green
-        } else {
-            Write-Host "(already installed)" -ForegroundColor Yellow
-        }
-    }
-    Write-Host "Libraries installed" -ForegroundColor Green
-
-    # Exit early if libs-only mode
-    if ($LibsOnly) {
-        Write-Host ""
-        Write-Host "Library installation complete!" -ForegroundColor Green
-        exit 0
     }
 }
 

--- a/tools/deploy.ps1
+++ b/tools/deploy.ps1
@@ -199,25 +199,52 @@ if ($Install) {
     $circupCmd = Get-Command circup -ErrorAction SilentlyContinue
     if (-not $circupCmd) {
         Write-Host "  circup not found. Installing..."
-        # Resolve a usable pip: bare `pip`, then `python -m pip`, then `py -m pip`.
-        # Windows Python installs often expose only the `py` launcher (or
-        # `python`) on PATH, not bare `pip`; calling `pip` directly then throws
-        # a terminating CommandNotFoundException under ErrorActionPreference=Stop.
+        # Resolve a usable pip across three candidate forms:
+        #   `pip`              - bare pip on PATH
+        #   `python -m pip`    - pip via python module
+        #   `py -m pip`        - pip via the Windows py launcher
+        #
+        # Two real-world Windows gotchas to dodge here:
+        #
+        # 1. Bare `pip` is often NOT on PATH on Windows Python installs - calling
+        #    it directly throws a terminating CommandNotFoundException under
+        #    $ErrorActionPreference = 'Stop'.
+        #
+        # 2. `python.exe` on Windows 10/11 may be the Microsoft Store "app
+        #    execution alias" stub at C:\Users\<u>\AppData\Local\Microsoft\
+        #    WindowsApps\python.exe - a 0-byte shim that just prints "Python
+        #    was not found; run without arguments to install from the Microsoft
+        #    Store" and exits non-zero. Get-Command finds it; running it fails.
+        #
+        # So: filter out WindowsApps shims by Source path, then probe each
+        # surviving candidate with `--version`. First one to exit 0 wins.
+        $candidates = @(
+            @("pip"),
+            @("python", "-m", "pip"),
+            @("py", "-m", "pip")
+        )
         $pipRunner = $null
-        if (Get-Command pip -ErrorAction SilentlyContinue) {
-            $pipRunner = @("pip")
-        } elseif (Get-Command python -ErrorAction SilentlyContinue) {
-            $pipRunner = @("python", "-m", "pip")
-        } elseif (Get-Command py -ErrorAction SilentlyContinue) {
-            $pipRunner = @("py", "-m", "pip")
+        foreach ($cand in $candidates) {
+            $cmd = Get-Command $cand[0] -ErrorAction SilentlyContinue
+            if (-not $cmd) { continue }
+            if ($cmd.Source -like '*\WindowsApps\*') { continue }
+            $probeArgs = @($cand | Select-Object -Skip 1) + '--version'
+            & $cand[0] @probeArgs *> $null
+            if ($LASTEXITCODE -eq 0) {
+                $pipRunner = $cand
+                break
+            }
         }
         if (-not $pipRunner) {
-            Write-Host "ERROR: Python/pip not found on PATH" -ForegroundColor Red
+            Write-Host "ERROR: working Python/pip not found on PATH" -ForegroundColor Red
             Write-Host "  Install Python 3 from https://www.python.org/downloads/"
             Write-Host "  (check 'Add python.exe to PATH' during install), then re-run."
+            Write-Host "  Note: the bare 'python.exe' shim from the Microsoft Store"
+            Write-Host "  does not count - install the real interpreter from python.org."
             Write-Host "  Or install circup manually: py -m pip install circup"
             exit 1
         }
+        Write-Host "  Using: $($pipRunner -join ' ')"
         # NB: avoid $pipRunner[1..(Count-1)] - for a 1-element array that is
         # $pipRunner[1..0], and PowerShell's 1..0 counts DOWN (1,0), corrupting
         # the call. Select-Object -Skip 1 yields an empty list as intended.

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -7,19 +7,15 @@
 #
 # Options:
 #   --device TYPE   First-time setup for a device type (one1, duo2, nano4, mini6, std10).
-#                   Writes the correct config template, installs CircuitPython
-#                   libraries, and deploys firmware. The go-to for new devices.
+#                   Writes the correct config template and deploys firmware.
+#                   The go-to for new devices.
 #   --reset-config  Overwrite config.json with the device-type template defaults.
-#                   Does not reinstall libraries.
-#   --install       Check/install CircuitPython libraries without touching config.
-#   --libs-only     Only install libraries (no firmware copy).
 #   --eject         Eject device after deploy (forces clean reload).
 #
 # Examples:
 #   ./deploy.sh                          # Quick deploy (sync firmware only)
-#   ./deploy.sh --device nano4           # First-time NANO4 setup (config + libs + firmware)
+#   ./deploy.sh --device nano4           # First-time NANO4 setup (config + firmware)
 #   ./deploy.sh --reset-config           # Reset config.json to template defaults
-#   ./deploy.sh --install                # Re-check/install libraries
 #   ./deploy.sh --eject                  # Deploy + eject (clean disconnect)
 #   ./deploy.sh /Volumes/MIDICAPT        # Custom mount point
 #
@@ -52,19 +48,8 @@ fi
 MOUNT_POINT="/Volumes/CIRCUITPY"
 DO_EJECT=false
 DO_RESET=false
-DO_INSTALL=false
-LIBS_ONLY=false
 DO_RESET_CONFIG=false
 FORCE_DEVICE_TYPE=""
-
-# Required CircuitPython libraries
-REQUIRED_LIBS=(
-    "adafruit_midi"
-    "adafruit_display_text"
-    "adafruit_st7789"
-    "neopixel"
-    "adafruit_debouncer"
-)
 
 # Colors for output
 RED='\033[0;31m'
@@ -96,12 +81,11 @@ while [ $i -lt ${#ARGS[@]} ]; do
                 exit 1
             fi
             ;;
-        --install)
-            DO_INSTALL=true
-            ;;
-        --libs-only)
-            LIBS_ONLY=true
-            DO_INSTALL=true
+        --install|--libs-only)
+            # Removed: lib/ is now bundled in the firmware zip; circup is unnecessary.
+            # Accept the flag for backwards compat and ignore it so older wrappers
+            # don't break. Will be deleted in a future release.
+            echo -e "${YELLOW}⚠️  $arg is deprecated and ignored — libraries are bundled in the firmware zip.${NC}"
             ;;
         --eject)
             DO_EJECT=true
@@ -118,11 +102,9 @@ while [ $i -lt ${#ARGS[@]} ]; do
             echo "Usage: ./deploy.sh [options] [mount_point]"
             echo ""
             echo "Options:"
-            echo "  --device TYPE   First-time setup (config + libs + firmware)"
+            echo "  --device TYPE   First-time setup (config + firmware)"
             echo "                  Valid types: $VALID_DEVICES"
             echo "  --reset-config  Overwrite config.json with template defaults"
-            echo "  --install       Check/install CircuitPython libraries"
-            echo "  --libs-only     Only install libraries (no firmware copy)"
             echo "  --eject         Eject device after deploy (forces clean reload)"
             echo ""
             echo "Quick deploy (no flags) syncs firmware only, preserves config."
@@ -139,11 +121,6 @@ while [ $i -lt ${#ARGS[@]} ]; do
     esac
     i=$((i + 1))
 done
-
-# --device implies --install (libraries) and config write
-if [ -n "$FORCE_DEVICE_TYPE" ]; then
-    DO_INSTALL=true
-fi
 
 echo -e "${BLUE}=== MIDI Captain Firmware Deploy ===${NC}"
 echo ""
@@ -264,50 +241,6 @@ else
     NEW_VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
 fi
 echo "  Upgrading to:     $NEW_VERSION"
-
-# Install libraries if requested (--install or --device)
-if [ "$DO_INSTALL" = true ]; then
-    echo ""
-    echo -e "${YELLOW}📦 Installing CircuitPython libraries...${NC}"
-
-    # Check for circup
-    if ! command -v circup &> /dev/null; then
-        echo "  circup not found. Installing..."
-        pip install circup --quiet
-        if ! command -v circup &> /dev/null; then
-            echo -e "${RED}✗ Failed to install circup${NC}"
-            echo "  Try: pip install circup"
-            exit 1
-        fi
-    fi
-    echo -e "${GREEN}✓ circup available${NC}"
-
-    # Install each library (--path must come before the subcommand)
-    # --allow-unsupported: we target CP 7.x which circup considers EOL.
-    #
-    # We deliberately do NOT pass `--py`. Mixing circup's `.py` source with
-    # the bundle's `.mpy` puts both forms in /lib for the same module, which
-    # is fragile: any disturbance to mtime / directory entry order can flip
-    # which form CircuitPython loads, and the `.py` form often pulls in
-    # newer-CP-only modules (e.g. `busdisplay`) that crash on CP 7.
-    CIRCUP="circup --path $MOUNT_POINT --allow-unsupported"
-    for lib in "${REQUIRED_LIBS[@]}"; do
-        echo -n "  Installing $lib... "
-        if $CIRCUP install "$lib" 2>/dev/null; then
-            echo -e "${GREEN}✓${NC}"
-        else
-            echo -e "${YELLOW}(already installed)${NC}"
-        fi
-    done
-    echo -e "${GREEN}✓ Libraries installed${NC}"
-
-    # Exit early if libs-only mode
-    if [ "$LIBS_ONLY" = true ]; then
-        echo ""
-        echo -e "${GREEN}✅ Library installation complete!${NC}"
-        exit 0
-    fi
-fi
 
 echo ""
 echo "📁 Source: $DEV_DIR"

--- a/tools/release_notes.md
+++ b/tools/release_notes.md
@@ -42,6 +42,7 @@ In many cases, the first install still requires a one-time bootstrap because the
    <br>For example, if you have a Nano 4, run `./deploy.sh --device nano4`_.
    - macOS / Linux: `./deploy.sh --device std10|mini6|nano4|duo2|one1`
    - Windows PowerShell: `.\deploy.ps1 -Device std10|mini6|nano4|duo2|one1`
+   - Windows cmd (if PowerShell blocks unsigned scripts): `deploy.bat -Device std10|mini6|nano4|duo2|one1` — invokes `deploy.ps1` with a per-process `ExecutionPolicy Bypass`; does not change any system policy.
 4. Reconnect the device and open the MIDI Captain MAX Config Editor.
 5. From then on, use the **Firmware Installation** section in the app for future updates.
 


### PR DESCRIPTION
Fixes #140.

The issue surfaced two distinct Windows problems, which we initially conflated:

## 1. Unsigned `deploy.ps1` blocked by `ExecutionPolicy`

Standard open-source workaround: ship a `.bat` launcher alongside the `.ps1`. `.bat` files aren't subject to `ExecutionPolicy`, so a one-line launcher with `-ExecutionPolicy Bypass` sidesteps the block without touching any system policy.

`tools/deploy.bat`:
```bat
@echo off
powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0deploy.ps1" %*
exit /b %ERRORLEVEL%
```

- `%~dp0` resolves the script's own directory, so it works regardless of `cd`.
- `%*` forwards all args (`-Device`, `-MountPoint`, …) through.
- `exit /b %ERRORLEVEL%` propagates PowerShell's real exit code so callers/CI see failures.
- `-NoProfile` keeps user PowerShell profiles from interfering.

`README.md` Windows section gets a corresponding line.

## 2. `circup` bootstrap crashed with `'pip' is not recognized`

This is what the reporter's screenshot actually showed — separate from signing. `deploy.ps1` called bare `pip install circup` to bootstrap circup, but Windows Python installs commonly expose only the `py` launcher (or `python`) on `PATH`, not bare `pip`. Under `$ErrorActionPreference = 'Stop'` that became a fatal `CommandNotFoundException`.

Now: resolve `pip` via `pip` → `python -m pip` → `py -m pip`, with a clear "install Python from python.org" message if none of them exist.

Subtle PowerShell gotcha avoided: `$pipRunner[1..($pipRunner.Count - 1)]` on a 1-element array is `$pipRunner[1..0]`, and `1..0` in PowerShell is the **descending** range `1,0`, not empty. Used `Select-Object -Skip 1` + splatting instead.

## Testing

Authored on macOS; no `pwsh` here. Plan is to verify on a Windows VM:
- `pwsh` parse check on `deploy.ps1`
- `deploy.bat -Device std10` from `cmd` launches the script and propagates exit code
- `pip`-absent path falls back to `py -m pip` (or `python -m pip`) instead of crashing
- Normal path with `pip`/`circup` already present: full deploy still works

Will follow up if any of the above turns up issues.