### PR TITLE
Beta9 fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,11 +166,13 @@ jobs:
         id: header
         run: |
           echo "PRERELEASE=false" >> $GITHUB_OUTPUT # default to 'latest' for now
+          echo "DRAFT=true" >> $GITHUB_OUTPUT # default to draft; auto-publish only for beta
           if [[ "$VERSION" == *"alpha"* ]]; then
             echo "PRERELEASE=true" >> $GITHUB_OUTPUT
             echo "NOTES=⚠️ **Alpha Release** - For testing only. Not recommended for production use." >> $GITHUB_ENV
           elif [[ "$VERSION" == *"beta"* ]]; then
             echo "PRERELEASE=true" >> $GITHUB_OUTPUT
+            echo "DRAFT=false" >> $GITHUB_OUTPUT # beta releases auto-publish
             echo "NOTES=🧪 **Beta Release** - Feature complete, undergoing final testing." >> $GITHUB_ENV
           elif [[ "$VERSION" == *"rc"* ]]; then
             echo "PRERELEASE=true" >> $GITHUB_OUTPUT
@@ -215,7 +217,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: ${{ steps.header.outputs.DRAFT }}
           prerelease:  ${{ steps.header.outputs.PRERELEASE }}
           make_latest: ${{ steps.header.outputs.PRERELEASE != 'true' }}
           files: dist/*
@@ -226,10 +228,16 @@ jobs:
       - name: Print Release
         run: |
           {
-            echo "## Draft release \`$VERSION\` created"
-            echo ""
-            echo "Release URL: ${{ steps.create_release.outputs.url }}"
-            echo ""
-            echo "**Next steps:** Download and test the artifacts, then publish the release."
+            if [ "${{ steps.header.outputs.DRAFT }}" = "true" ]; then
+              echo "## Draft release \`$VERSION\` created"
+              echo ""
+              echo "Release URL: ${{ steps.create_release.outputs.url }}"
+              echo ""
+              echo "**Next steps:** Download and test the artifacts, then publish the release."
+            else
+              echo "## Release \`$VERSION\` published"
+              echo ""
+              echo "Release URL: ${{ steps.create_release.outputs.url }}"
+            fi
           } >> $GITHUB_STEP_SUMMARY
 

--- a/docs/plans/2026-05-13-issue-48-press-timings.md
+++ b/docs/plans/2026-05-13-issue-48-press-timings.md
@@ -65,7 +65,11 @@ elif button.color is set:    LED = button.color (fallback for "(inherit)" entrie
 else:                        LED = off
 ```
 
-An entry with no `color` field — "(inherit)" in the editor — means **no override**: the layer's color clears on that entry and the LED falls back to the button-level `color` field. This mirrors the label rendering precedence (`long_label or short_label or button.label`) and matches the boot-time dim glow. An explicit `"off"` is distinct from unset: `"off"` overrides; `(inherit)` does not.
+An entry with no `color` field — "(inherit)" in the editor — means **no override**: the layer's color clears on that entry and the LED falls back to the button-level `color` field. An explicit `"off"` is distinct from unset: `"off"` overrides; `(inherit)` does not.
+
+> **Revision (beta.9 follow-up, #143):** the rule above describes `compute_keytimes_led_color()`, which resolves whatever layers it's handed. At *render* time `_render_keytimes_led()` no longer hands it both layers — it passes only the **last-fired** timing class (short or long), suppressing the other. So the last press's class fully owns BOTH the LED color and the label text until the other class fires; before the first press both fall back to the button-level color/label.
+>
+> Why: a text label shows one string and the LED one color, so a long layer can't *compose* on top of short — it just clobbers. The original `long_label or short_label` precedence never cleared the long layer, so the first long press left the long label/color stuck on every subsequent short press. Tester report: "Long label always sticks" — repro is long-press then short-press (order-dependent, which is why it evaded earlier testing). Last-fired ownership fixes both the label and the LED.
 
 Note: this is *not* "inherit the previous entry's color". An earlier draft of #48 carried the previous entry's color forward, but that caused a wrap-around surprise — a kill-switch `"off"` entry would persist through subsequent inherit entries because the inherit didn't clear the layer. The current rule is per-entry: each press resets the layer to exactly what the entry specifies, or to the button-level fallback if the entry specifies nothing.
 
@@ -196,6 +200,8 @@ Pedalboard mental model: the short cycle is the *primary* effect indicator. The 
 Concretely, this preserves the user's traced expectation: with reverb (short=white) + shimmer (long=blue), the LED is blue while both are on. Hit short again to turn reverb off (short=`off`); LED goes dark even though shimmer is still on, because there's no primary effect to color.
 
 **Rejected:** symmetric override ("long always wins when set"). Loses the kill-switch semantic and surprises users who turn off the primary effect.
+
+> **Superseded at render time (beta.9, #143):** "long always wins when set" is exactly the bug that shipped — `long_label or short_label` with no clear path meant the long layer stuck after the first long press. The composition rationale above still describes `compute_keytimes_led_color()` in isolation, but the live render now shows only the last-fired class (see the Color Render Rule revision note). The reverb+shimmer trace still holds because each step's expectation matches the most recent press; what changes is that a stale long layer no longer bleeds onto later short presses.
 
 **Rejected:** RGB blending of short + long colors. Cute but unpredictable and impossible to reason about during a gig.
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -1042,15 +1042,36 @@ def _dispatch_keytimes_message(msg, default_channel, btn_num):
 def _render_keytimes_led(btn_num, state, btn_config):
     """Update LED + display for a mode: "keytimes" button based on its current state.
 
-    Uses compute_keytimes_led_color() to apply the two-layer render rule. Label
-    precedence: long_label > short_label > button-level label.
+    Render is driven by state.last_fired — the timing class ("short"/"long") whose
+    most recent event actually fired. That class fully owns BOTH the LED color and
+    the label text until the other class fires; before the first press (last_fired
+    is None) both fall back to the button-level color/label.
+
+    This is deliberately NOT the old "long decorates over short" precedence
+    (`long_label or short_label`). A text label shows one string and the LED one
+    color, so the long layer can't "compose" on top — it just clobbers. Under the
+    old rule the long layer was never cleared, so the first long press left the
+    long label/color stuck on every subsequent short press (#143 follow-up).
     """
     idx = btn_num - 1
     if idx < 0 or idx >= BUTTON_COUNT:
         return
 
-    rgb = compute_keytimes_led_color(state.short_color, state.short_dim,
-                                     state.long_color, state.long_dim,
+    # Suppress the inactive layer so the last-fired class owns the render. Passing
+    # the other layer's color as None makes compute_keytimes_led_color() fall
+    # through to the active layer, then the button-level color.
+    if state.last_fired == "long":
+        a_short_color, a_short_dim = None, False
+        a_long_color, a_long_dim = state.long_color, state.long_dim
+    elif state.last_fired == "short":
+        a_short_color, a_short_dim = state.short_color, state.short_dim
+        a_long_color, a_long_dim = None, False
+    else:
+        a_short_color, a_short_dim = None, False
+        a_long_color, a_long_dim = None, False
+
+    rgb = compute_keytimes_led_color(a_short_color, a_short_dim,
+                                     a_long_color, a_long_dim,
                                      btn_config.get("color"))
 
     led_idx = switch_to_led(btn_num)
@@ -1062,16 +1083,23 @@ def _render_keytimes_led(btn_num, state, btn_config):
         pixels.show()
 
     if HAS_TFT and idx < len(button_labels):
-        # Label precedence: long override (if non-empty) > short override > button-level label.
-        effective_label = (state.long_label or state.short_label or btn_config.get("label", ""))[:6]
+        # Label follows the same last-fired class. long falls back to short_label
+        # then button label (a labelless long entry shows the prior short label);
+        # short falls straight to the button label.
+        if state.last_fired == "long":
+            effective_label = (state.long_label or state.short_label or btn_config.get("label", ""))[:6]
+        elif state.last_fired == "short":
+            effective_label = (state.short_label or btn_config.get("label", ""))[:6]
+        else:
+            effective_label = btn_config.get("label", "")[:6]
         button_labels[idx].text = effective_label
         # Label text must stay readable regardless of the `dim` flag: a dimmed LED
         # color is 15% brightness — near-black and invisible against the black
         # display. Recompute the winning layer color at full brightness, and never
         # render black-on-black (kill-switch / no-color cases fall back to the
         # button color, then white). The LED + box border below keep the dim color.
-        label_rgb = compute_keytimes_led_color(state.short_color, False,
-                                               state.long_color, False,
+        label_rgb = compute_keytimes_led_color(a_short_color, False,
+                                               a_long_color, False,
                                                btn_config.get("color"))
         if not any(label_rgb):
             label_rgb = get_color(btn_config.get("color") or "white")

--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -255,6 +255,11 @@ class KeytimesButtonState:
         # at press-end (short_up or long_up) if their flag is set.
         self._fired_short = False
         self._fired_long = False
+        # Timing class ("short"/"long") of the most recent event that actually
+        # fired (slot had messages). Drives LED + label render: the last class
+        # exercised fully owns the display until the other class fires. None
+        # until the first press, when the render falls back to button-level color/label.
+        self.last_fired = None
 
 
 # Map from event names emitted by PressTracker to (cycle_name, slot_name).
@@ -282,7 +287,7 @@ def dispatch_keytimes_events(events, state, btn_config, message_callback):
     Side effects:
         - Calls message_callback for each Message in the entries' down/up arrays
         - Updates state.{short,long}_color/dim/label from entries that set them
-        - Sets state._fired_short / _fired_long
+        - Sets state._fired_short / _fired_long and state.last_fired ("short"/"long")
         - Advances state.short_cycle / long_cycle on press-end events (short_up/long_up)
     """
     short_entries = btn_config.get("short", []) or []
@@ -315,6 +320,7 @@ def dispatch_keytimes_events(events, state, btn_config, message_callback):
                 # (2) the short cycle advancing during a long press just because
                 #     short_down fired as an event (with no MIDI to back it up).
                 if slot_messages:
+                    state.last_fired = cycle_name
                     if cycle_name == "short":
                         state._fired_short = True
                     else:

--- a/firmware/dev/core/colors.py
+++ b/firmware/dev/core/colors.py
@@ -100,8 +100,12 @@ def compute_keytimes_led_color(short_color, short_dim, long_color, long_dim, but
     The 'dim' flag on whichever layer wins applies via dim_color() (15% brightness).
     For the button-level fallback, dim applies if either layer's dim flag is set —
     the user can dim an inherit-color entry without specifying a color.
-    The button-level fallback mirrors the label precedence used in code.py:
-    `long_label or short_label or btn_config["label"]`.
+
+    NOTE: the short>long precedence below resolves whatever layers the CALLER
+    passes. _render_keytimes_led() suppresses the inactive layer (passes its color
+    as None) so the last-fired timing class owns the render — see its docstring.
+    Passing both layers populated keeps the original "long decorates over short"
+    composition, which the unit tests exercise directly.
 
     Args:
         short_color: color name from short cycle layer, or None if unset

--- a/tests/test_keytimes_dispatch.py
+++ b/tests/test_keytimes_dispatch.py
@@ -245,6 +245,55 @@ class TestDispatchColorState:
         assert state.short_label == "VERB+"
 
 
+class TestLastFired:
+    """state.last_fired drives which timing class owns the LED + label render.
+
+    Regression for the beta.9 "long label always sticks" bug (#143 follow-up):
+    a long entry's label/color must not bleed onto subsequent short presses.
+    """
+
+    def test_unset_before_any_press(self):
+        state = _make_state(1, 1)
+        assert state.last_fired is None
+
+    def test_short_press_sets_short(self):
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes", "short": [{"up": [CC(20, 127)]}]}
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.last_fired == "short"
+
+    def test_long_press_sets_long(self):
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes", "long": [{"down": [CC(21, 127)]}]}
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], state, cfg, cb)
+        assert state.last_fired == "long"
+
+    def test_short_after_long_flips_back_to_short(self):
+        # The user's PUP config: short msg in `up`, long msg in `down`. A long
+        # press then a short tap must leave last_fired == "short" so the render
+        # shows the short label, not the stuck long label.
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes",
+               "short": [{"up": [CC(20, 1)], "label": "PUP"}],
+               "long": [{"down": [CC(20, 4)], "label": "BUP"}]}
+        dispatch_keytimes_events(["short_down", "long_down", "long_up"], state, cfg, cb)
+        assert state.last_fired == "long"
+        dispatch_keytimes_events(["short_down", "short_up"], state, cfg, cb)
+        assert state.last_fired == "short"
+
+    def test_empty_slot_does_not_change_last_fired(self):
+        # short_down on an entry whose down slot is empty fires nothing, so it
+        # must not claim last_fired (mirrors the slot-has-content rule).
+        state = _make_state(1, 1)
+        cb, _ = _msg_collector()
+        cfg = {"mode": "keytimes", "short": [{"up": [CC(20, 127)]}]}
+        dispatch_keytimes_events(["short_down"], state, cfg, cb)
+        assert state.last_fired is None
+
+
 class TestDispatchReverbShimmerScenario:
     """End-to-end trace of the reverb+shimmer scenario.
 


### PR DESCRIPTION
- Fix keytimes long label/LED sticking after first long press #143 
- make beta releases auto-publish instead of draft