### PR TITLE
Add Linux Config Editor build with GPG signing (#26)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -8,7 +8,7 @@
 - Validates Python syntax + CircuitPython 7.x compatibility guard (greps for banned constructs)
 - Writes `VERSION.txt` into firmware zip from `git describe`
 - Runs pytest suite (`tests/`)
-- Builds Config Editor for macOS and Windows (Tauri + SvelteKit)
+- Builds Config Editor for macOS, Windows, and Linux (Tauri + SvelteKit)
 - Validates all `firmware/dev/config*.json` against `config.schema.json`
 - Checks `types.generated.ts` is up to date
 
@@ -104,12 +104,16 @@ All distribution paths must include the same set of files and write `VERSION.txt
 
 ## Code Signing
 
-See [docs/macos-code-signing.md](../docs/macos-code-signing.md) for full setup. Team ID: `9WNXKEF4SM`.
+See [docs/macos-code-signing.md](../docs/macos-code-signing.md) for macOS setup (Team ID: `9WNXKEF4SM`) and [docs/linux-build.md](../docs/linux-build.md) for Linux GPG signing.
 
 **Notarization 403:** Apple updated the Developer Program License Agreement — Account Holder must accept at App Store Connect, then re-run the failed CI job. No code change needed.
+
+**Linux GPG signing** (`build-config-editor-linux`) mirrors `boomerang-plugin`: imports `GPG_PRIVATE_KEY` (ASCII-armored, not base64), detached-signs each artifact (`.asc`) with `GPG_PASSPHRASE`, then verifies. Both secrets optional — unset → unsigned build with a warning, like the macOS cert. Signatures are over file content, so `release.yml` renames artifact + `.asc` together safely.
 
 ---
 
 ## Linux CI Dependencies
 
-`libudev-dev` required by the `serialport` crate. Cached via `awalsh128/cache-apt-pkgs-action`.
+`libudev-dev` required by the `serialport` crate (used by `test-config-editor-rust` and `build-config-editor-linux`).
+
+**`build-config-editor-linux` pins `ubuntu-22.04`** (not `ubuntu-latest`): AppImage/deb link against the runner's glibc, so the oldest supported runner maximizes user-distro compatibility. Builds `--bundles appimage,deb` only (no rpm — runner has no `rpmbuild`). Needs `libwebkit2gtk-4.1-dev` + `libfuse2`, with `APPIMAGE_EXTRACT_AND_RUN=1` for the FUSE-less runner.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,3 +478,156 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "See \`docs/windows-build.md\` for code signing setup." >> $GITHUB_STEP_SUMMARY
 
+  build-config-editor-linux:
+    name: Build Config Editor (Linux)
+    # Pin to 22.04 (not ubuntu-latest): the AppImage/deb link against the
+    # runner's glibc, so building on the oldest supported runner keeps the
+    # artifacts runnable on the widest range of user distros.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs: [lint, build-zip]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Stage firmware for Config Editor
+        uses: ./.github/actions/stage-firmware-for-editor
+        with:
+          version: ${{ needs.lint.outputs.version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          cache-dependency-path: config-editor/package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: config-editor/src-tauri
+
+      - name: Install system dependencies
+        run: |
+          # Tauri 2 Linux build deps (webkit2gtk 4.1 + bundler tooling) plus
+          # libudev-dev for the serialport crate. libfuse2 lets the AppImage
+          # bundler run linuxdeploy on the FUSE-less runner.
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            libudev-dev \
+            libfuse2 \
+            file \
+            build-essential \
+            curl \
+            wget
+
+      - name: Install frontend dependencies
+        run: |
+          cd config-editor
+          npm install
+
+      - name: Patch version in config editor
+        uses: ./.github/actions/patch-config-editor-version
+        with:
+          semver: ${{ needs.lint.outputs.semver }}
+
+      - name: Build Tauri app (AppImage + deb)
+        env:
+          # Run the bundler's linuxdeploy AppImage by extraction instead of via
+          # FUSE — GitHub runners have no FUSE device.
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+        run: |
+          cd config-editor
+          npm run tauri build -- --bundles appimage,deb
+          ls -lah src-tauri/target/release/bundle/appimage/ src-tauri/target/release/bundle/deb/
+
+      - name: Import GPG key
+        id: import-gpg
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          # Mirrors the Linux signing mechanism from boomerang-plugin.
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "::warning::No GPG key configured — Linux artifacts will not be signed"
+            echo "can_sign=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+          KEY_ID=$(gpg --list-secret-keys --keyid-format=long | grep sec | awk '{print $2}' | cut -d'/' -f2 | head -1)
+          if [ -z "$KEY_ID" ]; then
+            echo "::error::Failed to import GPG secret key."
+            exit 1
+          fi
+
+          echo "KEY_ID=$KEY_ID" >> "$GITHUB_OUTPUT"
+          echo "can_sign=true" >> "$GITHUB_OUTPUT"
+          echo "✓ GPG key imported ($KEY_ID)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sign Linux artifacts
+        if: steps.import-gpg.outputs.can_sign == 'true'
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          cd config-editor/src-tauri/target/release/bundle
+          # Detached, ASCII-armored signature per artifact; verify each one.
+          while IFS= read -r artifact; do
+            echo "Signing: $artifact"
+            echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 \
+              --pinentry-mode loopback --armor --detach-sign \
+              --output "${artifact}.asc" "$artifact"
+
+            gpg --verify "${artifact}.asc" "$artifact" 2>&1 | tee verify.log
+            if grep -q "Good signature" verify.log; then
+              echo "✓ Signature verified: $(basename "$artifact").asc" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error::Signature verification failed for $artifact"
+              exit 1
+            fi
+          done < <(find appimage deb -type f \( -name "*.AppImage" -o -name "*.deb" \))
+          rm -f verify.log
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: config-editor-appimage
+          path: |
+            config-editor/src-tauri/target/release/bundle/appimage/*.AppImage
+            config-editor/src-tauri/target/release/bundle/appimage/*.AppImage.asc
+          retention-days: 90
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: config-editor-deb
+          path: |
+            config-editor/src-tauri/target/release/bundle/deb/*.deb
+            config-editor/src-tauri/target/release/bundle/deb/*.deb.asc
+          retention-days: 90
+
+      - name: Build summary
+        run: |
+          echo "## Linux Build Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "✓ Successfully built Config Editor for Linux" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Artifacts" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **AppImage** (portable, runs on most distros)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **deb** (Debian / Ubuntu package)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.import-gpg.outputs.can_sign }}" = "true" ]; then
+            echo "🔏 Artifacts signed with detached GPG signatures (\`.asc\`)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "⚠️ Unsigned — set \`GPG_PRIVATE_KEY\` / \`GPG_PASSPHRASE\` secrets to sign. See \`docs/linux-build.md\`." >> "$GITHUB_STEP_SUMMARY"
+          fi
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,34 @@ jobs:
           else
             echo "::warning::Config Editor NSIS installer not found in CI artifacts"
           fi
-          
+
+          # Find and rename config editor AppImage + deb (Linux). Copy the
+          # detached GPG signature (.asc) alongside each, renamed to match the
+          # friendly asset name — gpg verifies by content, so renaming is safe.
+          APPIMAGE_FILE=$(find ci-artifacts -name "*.AppImage" | head -1)
+          if [ -n "$APPIMAGE_FILE" ]; then
+            cp "$APPIMAGE_FILE" "dist/MIDI-Captain-MAX-Config-Editor-${VERSION}.AppImage"
+            echo "✓ Config Editor AppImage: MIDI-Captain-MAX-Config-Editor-${VERSION}.AppImage" >> $GITHUB_STEP_SUMMARY
+            if [ -f "${APPIMAGE_FILE}.asc" ]; then
+              cp "${APPIMAGE_FILE}.asc" "dist/MIDI-Captain-MAX-Config-Editor-${VERSION}.AppImage.asc"
+              echo "✓ AppImage signature: MIDI-Captain-MAX-Config-Editor-${VERSION}.AppImage.asc" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "::warning::Config Editor AppImage not found in CI artifacts"
+          fi
+
+          DEB_FILE=$(find ci-artifacts -name "*.deb" | head -1)
+          if [ -n "$DEB_FILE" ]; then
+            cp "$DEB_FILE" "dist/MIDI-Captain-MAX-Config-Editor-${VERSION}.deb"
+            echo "✓ Config Editor deb: MIDI-Captain-MAX-Config-Editor-${VERSION}.deb" >> $GITHUB_STEP_SUMMARY
+            if [ -f "${DEB_FILE}.asc" ]; then
+              cp "${DEB_FILE}.asc" "dist/MIDI-Captain-MAX-Config-Editor-${VERSION}.deb.asc"
+              echo "✓ deb signature: MIDI-Captain-MAX-Config-Editor-${VERSION}.deb.asc" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "::warning::Config Editor deb not found in CI artifacts"
+          fi
+
           ls -la dist/
 
       - name: Stage CircuitPython .uf2 for the combined bundle (issue #134)
@@ -149,8 +176,8 @@ jobs:
           mkdir -p bundle
           # Copy firmware zip contents (extract so bundle is flat, not a zip-in-zip)
           cp "dist/midicaptain-firmware-${VERSION}.zip" bundle/
-          # Copy all GUI installers that were found
-          for ext in dmg msi exe; do
+          # Copy all GUI installers that were found (incl. Linux + .asc sigs)
+          for ext in dmg msi exe AppImage deb asc; do
             for f in dist/*."$ext"; do
               [ -f "$f" ] && cp "$f" bundle/
             done

--- a/docs/linux-build.md
+++ b/docs/linux-build.md
@@ -1,0 +1,183 @@
+# Linux Build Documentation
+
+This document describes the Linux build and GPG signing configuration for the
+MIDI Captain MAX Config Editor.
+
+## Overview
+
+The Config Editor is built for Linux using the same stack as macOS/Windows
+(Tauri 2 + SvelteKit + Rust). The Linux job produces two distributable formats:
+
+1. **AppImage** — a single portable executable that runs on most distributions
+   without installation.
+2. **deb** — a Debian/Ubuntu package for users who prefer their package manager.
+
+`.rpm` is intentionally not built (the Ubuntu runner has no `rpmbuild` toolchain
+and the AppImage already covers RPM-based distros).
+
+Each artifact is signed with a **detached GPG signature** (`.asc`), matching the
+Linux signing mechanism used in
+[`boomerang-plugin`](https://github.com/MC-Music-Workshop/boomerang-plugin/blob/main/.github/workflows/build.yml).
+
+## Build Configuration
+
+### Runner
+
+The build runs on **`ubuntu-22.04`**, not `ubuntu-latest`. The AppImage and deb
+link against the runner's `glibc`; building on the oldest supported runner keeps
+the artifacts runnable on the widest range of user distros. Newer runners would
+raise the minimum `glibc` and break on older systems.
+
+### System dependencies
+
+Tauri 2 needs the WebKitGTK 4.1 stack and bundler tooling; the `serialport`
+crate needs `libudev-dev`; the AppImage bundler runs `linuxdeploy` (itself an
+AppImage), which needs `libfuse2` on the FUSE-less runner:
+
+```bash
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+  librsvg2-dev libxdo-dev libssl-dev libudev-dev libfuse2 \
+  file build-essential curl wget
+```
+
+The build step also sets `APPIMAGE_EXTRACT_AND_RUN=1` so the bundler's
+`linuxdeploy` AppImage runs by extraction instead of via FUSE.
+
+### Bundle selection
+
+```bash
+npm run tauri build -- --bundles appimage,deb
+```
+
+## GPG Signing
+
+### Secrets
+
+Configured as repository secrets (shared with `boomerang-plugin`'s naming):
+
+| Secret | Contents |
+|--------|----------|
+| `GPG_PRIVATE_KEY` | ASCII-armored private signing key (`gpg --armor --export-secret-keys`) |
+| `GPG_PASSPHRASE` | Passphrase that unlocks the key |
+
+If `GPG_PRIVATE_KEY` is unset, the build still succeeds and uploads **unsigned**
+artifacts (a CI warning is emitted) — exactly how the macOS job degrades without
+a signing certificate.
+
+### Generating a signing key
+
+```bash
+# 1. Generate a key (choose a name/email for the project identity)
+gpg --full-generate-key
+
+# 2. Find the key id
+gpg --list-secret-keys --keyid-format=long
+
+# 3. Export the private key (ASCII-armored) for the GPG_PRIVATE_KEY secret
+gpg --armor --export-secret-keys <KEY_ID>
+
+# 4. Export the PUBLIC key so users can verify signatures
+gpg --armor --export <KEY_ID> > midi-captain-max-public.asc
+```
+
+Paste the output of step 3 into the `GPG_PRIVATE_KEY` secret and the key's
+passphrase into `GPG_PASSPHRASE`. Publish the public key (step 4) so users can
+verify downloads.
+
+### How CI signs
+
+For each built artifact:
+
+```bash
+echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 \
+  --pinentry-mode loopback --armor --detach-sign \
+  --output "${artifact}.asc" "$artifact"
+
+gpg --verify "${artifact}.asc" "$artifact"   # fails the build if not "Good signature"
+```
+
+The signature is over the file **contents**, so `release.yml` can rename both
+the artifact and its `.asc` to friendly names without invalidating verification.
+
+### How users verify
+
+```bash
+# Import the project public key once
+gpg --import midi-captain-max-public.asc
+
+# Verify a download
+gpg --verify MIDI-Captain-MAX-Config-Editor-<version>.AppImage.asc \
+            MIDI-Captain-MAX-Config-Editor-<version>.AppImage
+# Look for: "Good signature from ..."
+```
+
+## Build Artifacts
+
+### AppImage
+
+**Filename format:** `MIDI-Captain-MAX-Config-Editor-{version}.AppImage`
+
+```bash
+chmod +x MIDI-Captain-MAX-Config-Editor-<version>.AppImage
+./MIDI-Captain-MAX-Config-Editor-<version>.AppImage
+```
+
+### deb
+
+**Filename format:** `MIDI-Captain-MAX-Config-Editor-{version}.deb`
+
+```bash
+sudo apt install ./MIDI-Captain-MAX-Config-Editor-<version>.deb
+# or
+sudo dpkg -i MIDI-Captain-MAX-Config-Editor-<version>.deb
+```
+
+## Troubleshooting
+
+### AppImage fails to bundle (FUSE error)
+
+Ensure `libfuse2` is installed and `APPIMAGE_EXTRACT_AND_RUN=1` is set on the
+build step (both are configured in CI).
+
+### `webkit2gtk-4.1` not found
+
+Tauri 2 requires the 4.1 (not 4.0) WebKitGTK package. It is available on Ubuntu
+22.04+ as `libwebkit2gtk-4.1-dev`.
+
+### AppImage won't start on an older distro
+
+The build runner's `glibc` is newer than the target system. Keep the build on
+`ubuntu-22.04`; do not bump to `ubuntu-latest`.
+
+## Local Development (Linux)
+
+```bash
+# Install deps (Debian/Ubuntu)
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+  librsvg2-dev libxdo-dev libssl-dev libudev-dev libfuse2 \
+  file build-essential curl wget
+
+cd config-editor
+npm install
+npm run tauri build -- --bundles appimage,deb
+
+# Output in:
+# src-tauri/target/release/bundle/appimage/
+# src-tauri/target/release/bundle/deb/
+```
+
+## Cross-Platform Build Matrix
+
+| Platform | Runner | Artifacts |
+|----------|--------|-----------|
+| macOS | `macos-latest` | `.dmg`, `.app` (signed + notarized) |
+| Windows | `windows-latest` | `.msi`, `-setup.exe` (unsigned) |
+| Linux | `ubuntu-22.04` | `.AppImage`, `.deb` (GPG detached `.asc`) |
+
+## Resources
+
+- [Tauri Linux Bundle Docs](https://tauri.app/distribute/)
+- [AppImage Documentation](https://docs.appimage.org/)
+- [GnuPG Detached Signatures](https://www.gnupg.org/gph/en/manual/x135.html)

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -231,7 +231,7 @@ npm run tauri build
 |----------|--------|------------|-----------|
 | macOS | `macos-latest` | ~15 min | `.dmg`, `.app` |
 | Windows | `windows-latest` | ~20 min | `.msi`, `-setup.exe` |
-| Linux | (not yet) | N/A | `.deb`, `.AppImage` |
+| Linux | `ubuntu-22.04` | ~15 min | `.AppImage`, `.deb` (GPG-signed) — see `docs/linux-build.md` |
 
 ## Resources
 

--- a/tools/release_notes.md
+++ b/tools/release_notes.md
@@ -13,7 +13,7 @@ Once MIDI Captain MAX is installed, manual firmware updates are no longer needed
 
 You can download either:
 
-- The appropriate Config Editor installer for your OS: `.dmg` for macOS, `.exe` or `.msi` for Windows. **The Config Editor includes the bundled firmware, so you don't need to download it separately**, or
+- The appropriate Config Editor installer for your OS: `.dmg` for macOS, `.exe` or `.msi` for Windows, `.AppImage` (portable) or `.deb` (Debian/Ubuntu) for Linux. **The Config Editor includes the bundled firmware, so you don't need to download it separately**, or
 - The `MIDI-Captain-MAX-v1.10.0-complete.zip` package if you want the GUI and the firmware as separate packages.<br>For example, if you need to use the deploy script for the first install, or for an unsupported OS, this package includes everything you need. (The GUI still includes the bundled firmware; the zip is just for convenience if you want to use the deploy script instead of the GUI installer.)
 
 ## Updating an Existing MIDI Captain MAX Install


### PR DESCRIPTION
Closes #26.

## What

Delivers an MCM GUI Config Editor package for Linux, with the same Linux GPG signing mechanism used in [boomerang-plugin](https://github.com/MC-Music-Workshop/boomerang-plugin/blob/main/.github/workflows/build.yml).

## Changes

- **`ci.yml`** — new `build-config-editor-linux` job:
  - Runs on `ubuntu-22.04` (not `ubuntu-latest`): AppImage/deb link against the runner's glibc, so the oldest supported runner maximizes user-distro compatibility.
  - Builds `--bundles appimage,deb`. rpm skipped (no `rpmbuild` on the runner; AppImage covers RPM distros).
  - GPG detached-signs each artifact (`.asc`) and verifies "Good signature". Degrades to an unsigned build + warning when secrets are absent, like the macOS cert path.
  - Uploads AppImage + deb + their `.asc` signatures.
- **`release.yml`** — renames AppImage/deb + `.asc` into release assets; combined bundle now includes `AppImage`, `deb`, and `asc`.
- **`docs/linux-build.md`** (new) — signing setup, key generation, user verification, troubleshooting.
- **`.github/AGENTS.md`**, **`docs/windows-build.md`**, **`tools/release_notes.md`** — Linux coverage.

## Secrets

Uses org-level `GPG_PRIVATE_KEY` (ASCII-armored) + `GPG_PASSPHRASE`. Confirm `midi-captain-max` is in the org secret's repository-access policy, otherwise the secret resolves empty and the build is unsigned (no failure).

## Verification

- `actionlint -shellcheck=` → exit 0 (no workflow/expression/action errors).
- Both workflows parse as valid YAML.
- Remaining shellcheck output is `info`/`style` only, consistent with existing jobs.
- The Linux build + signing only execute on a GitHub runner — push-to-CI is the real proof. Watch this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)