### PR TITLE
Fix #157 sticky long color in keytimes mode; add long_overlay opt-in

### DIFF
--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -262,6 +262,10 @@ pub struct ButtonConfig {
     pub long: Option<Vec<KeytimesEntry>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub long_press_threshold_ms: Option<u16>,
+    // #157: latch the long color over short as a status indicator instead of the
+    // default last-press-wins. Only meaningful when mode == "keytimes".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub long_overlay: Option<bool>,
 }
 
 fn is_default_off_mode(mode: &OffMode) -> bool {
@@ -1031,6 +1035,7 @@ mod tests {
                 keytimes: None, states: None,
                 hid_action: None, hid_key: None, hid_modifier: None, hid_delay_ms: None,
                 short: None, long: None, long_press_threshold_ms: None,
+                long_overlay: None,
             });
         }
         MidiCaptainConfig {

--- a/config-editor/src/lib/components/KeytimesEditor.svelte
+++ b/config-editor/src/lib/components/KeytimesEditor.svelte
@@ -45,6 +45,11 @@
     }
   }
 
+  function handleLongOverlayChange(e: Event) {
+    const target = e.target as HTMLInputElement;
+    updateField(`buttons[${index}].long_overlay`, target.checked ? true : undefined);
+  }
+
   let thresholdError = $derived($validationErrors.get(`buttons[${index}].long_press_threshold_ms`));
 </script>
 
@@ -62,6 +67,16 @@
     {#if thresholdError}
       <span class="kt-error">{thresholdError}</span>
     {/if}
+  </div>
+
+  <div class="kt-overlay-row">
+    <label class="inline"
+           title="When on, the long-press color stays lit over the short cycle as a status indicator (e.g. shimmer-on). Off (default): the LED color follows whichever press fired last, matching the label.">
+      <input type="checkbox"
+             checked={button.long_overlay ?? false}
+             onchange={handleLongOverlayChange} />
+      Latch long color over short (status indicator)
+    </label>
   </div>
 
   {#each ['short', 'long'] as cycle (cycle)}

--- a/config-editor/src/lib/components/KeytimesEditor.svelte
+++ b/config-editor/src/lib/components/KeytimesEditor.svelte
@@ -71,11 +71,11 @@
 
   <div class="kt-overlay-row">
     <label class="inline"
-           title="When on, the long-press color stays lit over the short cycle as a status indicator (e.g. shimmer-on). Off (default): the LED color follows whichever press fired last, matching the label.">
+           title="When set, the long-press color is used instead of the short-press color. Short presses send their messages as expected.">
       <input type="checkbox"
              checked={button.long_overlay ?? false}
              onchange={handleLongOverlayChange} />
-      Latch long color over short (status indicator)
+      Long-press color overrides short-press color
     </label>
   </div>
 

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -196,7 +196,7 @@ export interface ButtonConfig {
    */
   long_press_threshold_ms?: number;
   /**
-   * Only meaningful when mode='keytimes'. When true, the long cycle's color latches over the short cycle as a persistent status indicator (e.g. a shimmer-on light riding over a reverb short cycle). Default false: last-press-wins, so the LED color follows whichever timing class fired most recently (matches the label rule, #157).
+   * Only meaningful when mode='keytimes'. When true, the long-press color is used instead of the short-press color; short presses still send their messages as expected (a short 'off' step still turns the LED off). Default false: last-press-wins, so the LED color follows whichever timing class fired most recently (matches the label rule, #157).
    */
   long_overlay?: boolean;
   /**

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -196,6 +196,10 @@ export interface ButtonConfig {
    */
   long_press_threshold_ms?: number;
   /**
+   * Only meaningful when mode='keytimes'. When true, the long cycle's color latches over the short cycle as a persistent status indicator (e.g. a shimmer-on light riding over a reverb short cycle). Default false: last-press-wins, so the LED color follows whichever timing class fired most recently (matches the label rule, #157).
+   */
+  long_overlay?: boolean;
+  /**
    * 'send' = press+release, 'press' = hold key, 'release' = release key(s), 'delay' = pause execution.
    */
   hid_action?: "send" | "press" | "release" | "delay";

--- a/config.schema.json
+++ b/config.schema.json
@@ -378,7 +378,7 @@
         },
         "long_overlay": {
           "type": "boolean",
-          "description": "Only meaningful when mode='keytimes'. When true, the long cycle's color latches over the short cycle as a persistent status indicator (e.g. a shimmer-on light riding over a reverb short cycle). Default false: last-press-wins, so the LED color follows whichever timing class fired most recently (matches the label rule, #157)."
+          "description": "Only meaningful when mode='keytimes'. When true, the long-press color is used instead of the short-press color; short presses still send their messages as expected (a short 'off' step still turns the LED off). Default false: last-press-wins, so the LED color follows whichever timing class fired most recently (matches the label rule, #157)."
         },
         "hid_action": {
           "$ref": "#/definitions/HidAction",

--- a/config.schema.json
+++ b/config.schema.json
@@ -376,6 +376,10 @@
           "maximum": 5000,
           "description": "Per-button long-press threshold override in milliseconds. Only meaningful when mode='keytimes'. Falls back to top-level long_press_threshold_ms (default 500)."
         },
+        "long_overlay": {
+          "type": "boolean",
+          "description": "Only meaningful when mode='keytimes'. When true, the long cycle's color latches over the short cycle as a persistent status indicator (e.g. a shimmer-on light riding over a reverb short cycle). Default false: last-press-wins, so the LED color follows whichever timing class fired most recently (matches the label rule, #157)."
+        },
         "hid_action": {
           "$ref": "#/definitions/HidAction",
           "description": "HID action to perform. Used when type='hid'. Default: 'send'."

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -41,7 +41,7 @@ from adafruit_midi.note_off import NoteOff
 from adafruit_midi.system_exclusive import SystemExclusive
 
 # Import core modules (testable logic)
-from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display, compute_keytimes_led_color
+from core.colors import COLORS, get_color, dim_color, rgb_to_hex, get_off_color, get_off_color_for_display, compute_keytimes_led_color, resolve_keytimes_render_color
 from core.config import (
     load_config as _load_config_from_file,
     validate_config,
@@ -1045,26 +1045,28 @@ def _dispatch_keytimes_message(msg, default_channel, btn_num):
 def _render_keytimes_led(btn_num, state, btn_config):
     """Update LED + display for a mode: "keytimes" button based on its current state.
 
-    LED uses full two-layer composition: long decorates short (the long cycle is a
-    persistent modifier painted over the short cycle). Both layers are always passed
-    to compute_keytimes_led_color() — short="off" is still a kill-switch that overrides
-    long; long="off" is transparent (falls through to short).
+    LED, label TEXT, and label COLOR all key off last_fired: only the most recently
+    fired timing class owns the render. resolve_keytimes_render_color() suppresses the
+    inactive layer so the active class's color wins, then applies the kill-switch /
+    precedence / dim / button-fallback rules. This prevents both the stale-label bug
+    (#143) and the sticky-color bug (#157), where a long press left its label/color
+    stuck on every subsequent short press.
 
-    Label TEXT uses last_fired: only the most recently fired timing class supplies
-    the label string. This prevents the stale-label bug (#143) where the first long
-    press left its label stuck on every subsequent short press.
-
-    Label COLOR is the composed color recomputed at full brightness (dim stripped),
-    with a fallback to the button color so it is never black-on-black (#143).
+    Label COLOR is the same resolved color recomputed at full brightness (dim
+    stripped), with a fallback to the button color so it is never black-on-black (#143).
     """
     idx = btn_num - 1
     if idx < 0 or idx >= BUTTON_COUNT:
         return
 
-    # LED: full composition. long decorates short; last_fired doesn't gate this.
-    rgb = compute_keytimes_led_color(state.short_color, state.short_dim,
-                                     state.long_color, state.long_dim,
-                                     btn_config.get("color"))
+    # LED: last_fired gates which layer wins, so a stale long color can't stick (#157),
+    # unless long_overlay opts into the latching-modifier behavior (long decorates short).
+    long_overlay = btn_config.get("long_overlay", False)
+    rgb = resolve_keytimes_render_color(state.last_fired,
+                                        state.short_color, state.short_dim,
+                                        state.long_color, state.long_dim,
+                                        btn_config.get("color"),
+                                        long_overlay)
 
     led_idx = switch_to_led(btn_num)
     if led_idx is not None:
@@ -1085,11 +1087,13 @@ def _render_keytimes_led(btn_num, state, btn_config):
         else:
             effective_label = btn_config.get("label", "")[:6]
         button_labels[idx].text = effective_label
-        # Label color: composed color at full brightness so dim entries remain legible
+        # Label color: resolved color at full brightness so dim entries remain legible
         # (#143). black-on-black (kill-switch / no-color) falls back to button color.
-        label_rgb = compute_keytimes_led_color(state.short_color, False,
-                                               state.long_color, False,
-                                               btn_config.get("color"))
+        label_rgb = resolve_keytimes_render_color(state.last_fired,
+                                                  state.short_color, False,
+                                                  state.long_color, False,
+                                                  btn_config.get("color"),
+                                                  long_overlay)
         if not any(label_rgb):
             label_rgb = get_color(btn_config.get("color") or "white")
         button_labels[idx].color = rgb_to_hex(label_rgb)

--- a/firmware/dev/core/colors.py
+++ b/firmware/dev/core/colors.py
@@ -139,3 +139,45 @@ def compute_keytimes_led_color(short_color, short_dim, long_color, long_dim, but
             rgb = dim_color(rgb)
         return rgb
     return COLORS["off"]
+
+
+def resolve_keytimes_render_color(last_fired, short_color, short_dim,
+                                  long_color, long_dim, button_color=None,
+                                  long_overlay=False):
+    """Resolve a keytimes button's render color gated by the last-fired timing class.
+
+    #157 ("sticky long color"): by default the LED reflects only the most recently
+    fired timing class, mirroring the last_fired label rule introduced in #143.
+    Without this gate, a long press leaves state.long_color set indefinitely and
+    compute_keytimes_led_color()'s long>short precedence keeps the LED stuck on the
+    long color across every subsequent short press — the label flips back but the
+    color does not.
+
+    long_overlay=True opts back into the latching-modifier behavior: the long layer
+    decorates short persistently (full two-layer composition), so a long color stays
+    lit across subsequent short presses. Useful as a status indicator (e.g. a
+    shimmer-on light riding over a reverb short cycle).
+
+    With overlay off, this suppresses the inactive layer (passing its color as None,
+    dim as False) so the active class owns the render, then defers to
+    compute_keytimes_led_color() for the kill-switch / precedence / dim /
+    button-fallback rules. last_fired == None (before the first press) passes both
+    layers unsuppressed, falling through to the button-level color.
+
+    Args:
+        last_fired: "short", "long", or None — the timing class that owns the render
+        short_color, short_dim, long_color, long_dim, button_color: see
+            compute_keytimes_led_color()
+        long_overlay: True to keep long decorating short persistently (no last_fired
+            gating); default False gives last-press-wins.
+
+    Returns:
+        RGB tuple (r, g, b) with values 0-255
+    """
+    if not long_overlay:
+        if last_fired == "short":
+            long_color, long_dim = None, False
+        elif last_fired == "long":
+            short_color, short_dim = None, False
+    return compute_keytimes_led_color(short_color, short_dim,
+                                      long_color, long_dim, button_color)

--- a/firmware/dev/core/colors.py
+++ b/firmware/dev/core/colors.py
@@ -153,10 +153,12 @@ def resolve_keytimes_render_color(last_fired, short_color, short_dim,
     long color across every subsequent short press — the label flips back but the
     color does not.
 
-    long_overlay=True opts back into the latching-modifier behavior: the long layer
-    decorates short persistently (full two-layer composition), so a long color stays
-    lit across subsequent short presses. Useful as a status indicator (e.g. a
-    shimmer-on light riding over a reverb short cycle).
+    long_overlay=True opts back into the full two-layer composition: the long-press
+    color is used in place of the short-press color (long>short precedence), so the
+    long color persists across subsequent short presses. The short cycle still
+    operates — a short "off" entry is a kill-switch that turns the LED off even with
+    overlay on. Useful when the long color marks a mode (e.g. a shimmer-on color
+    riding over a reverb short cycle).
 
     With overlay off, this suppresses the inactive layer (passing its color as None,
     dim as False) so the active class owns the render, then defers to

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -193,6 +193,11 @@ def _validate_keytimes_button(btn, index, default_channel):
     if "long_press_threshold_ms" in btn:
         validated["long_press_threshold_ms"] = _clamp_threshold_ms(btn.get("long_press_threshold_ms"))
 
+    # #157: latch the long color over short (status-indicator behavior) instead of
+    # the default last-press-wins. Persist only when truthy to keep configs clean.
+    if btn.get("long_overlay"):
+        validated["long_overlay"] = True
+
     short = btn.get("short")
     if short is not None:
         validated["short"] = _validate_keytimes_cycle(short)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -890,6 +890,25 @@ class TestKeytimesMode:
         assert len(btn["long"]) == 1
         assert btn["long"][0]["down"][0]["cc"] == 21
 
+    def test_long_overlay_true_persisted(self):
+        """#157: long_overlay=True (latching-modifier opt-in) is preserved."""
+        btn = validate_button({
+            "label": "REV", "color": "blue", "mode": "keytimes", "long_overlay": True,
+        }, index=0)
+        assert btn["long_overlay"] is True
+
+    def test_long_overlay_default_absent(self):
+        """Default (last-press-wins) stores no long_overlay key."""
+        btn = validate_button({"label": "X", "color": "red", "mode": "keytimes"}, index=0)
+        assert "long_overlay" not in btn
+
+    def test_long_overlay_false_dropped(self):
+        """Explicit False is the default; not persisted (mirrors dim=False)."""
+        btn = validate_button({
+            "label": "X", "color": "red", "mode": "keytimes", "long_overlay": False,
+        }, index=0)
+        assert "long_overlay" not in btn
+
     def test_short_and_long_independent_lengths(self):
         btn = validate_button({
             "label": "X", "color": "red", "mode": "keytimes",

--- a/tests/test_keytimes_color.py
+++ b/tests/test_keytimes_color.py
@@ -14,7 +14,7 @@ from pathlib import Path
 FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
 sys.path.insert(0, str(FIRMWARE_DIR))
 
-from core.colors import compute_keytimes_led_color, get_color, dim_color, COLORS
+from core.colors import compute_keytimes_led_color, resolve_keytimes_render_color, get_color, dim_color, COLORS
 
 OFF = COLORS["off"]
 
@@ -199,3 +199,73 @@ class TestIssue143LabelColorRegression:
         assert led_rgb != label_rgb, "dim LED color must differ from full-brightness label color"
         assert led_rgb == dim_color(get_color("yellow"))
         assert label_rgb == get_color("yellow")
+
+
+class TestResolveKeytimesRenderColor:
+    """resolve_keytimes_render_color gates the render on last_fired (#157).
+
+    Regression for the "sticky long color" bug: once a long press set
+    state.long_color, compute_keytimes_led_color()'s long>short precedence kept the
+    LED on the long color across every subsequent short press. Gating on last_fired
+    suppresses the inactive layer so the active class's color wins — mirroring the
+    last_fired label rule from #143.
+    """
+
+    def test_short_after_long_flips_color_back(self):
+        # The user's PUP config: short color green, long color blue. State holds both
+        # colors at once (long never clears short and vice versa); last_fired decides.
+        # last_fired == "long" -> blue; last_fired == "short" -> green (not stuck blue).
+        assert resolve_keytimes_render_color("long", "green", False, "blue", False) == get_color("blue")
+        assert resolve_keytimes_render_color("short", "green", False, "blue", False) == get_color("green")
+
+    def test_long_suppresses_short(self):
+        assert resolve_keytimes_render_color("long", "white", False, "blue", False) == get_color("blue")
+
+    def test_short_suppresses_long(self):
+        # Without gating this would return blue (long precedence); gated -> white.
+        assert resolve_keytimes_render_color("short", "white", False, "blue", False) == get_color("white")
+
+    def test_short_kill_switch_survives_gating(self):
+        # short color "off" is a kill switch; with last_fired == "short" the long
+        # layer is suppressed and the LED goes off.
+        assert resolve_keytimes_render_color("short", "off", False, "blue", False) == COLORS["off"]
+
+    def test_long_off_is_transparent_when_long_fired(self):
+        # long color "off" suppresses short and falls through to button fallback.
+        assert resolve_keytimes_render_color("long", "green", False, "off", False, "red") == get_color("red")
+
+    def test_none_before_first_press_uses_button_fallback(self):
+        # last_fired == None passes both layers (both unset here) -> button color.
+        assert resolve_keytimes_render_color(None, None, False, None, False, "red") == get_color("red")
+
+    def test_suppressed_layer_dim_does_not_leak(self):
+        # last_fired == "short" with short color inherited (None) + long_dim True must
+        # not dim the button fallback — the suppressed long layer's dim is dropped.
+        assert resolve_keytimes_render_color("short", None, False, None, True, "red") == get_color("red")
+
+
+class TestResolveKeytimesRenderColorOverlay:
+    """long_overlay=True opts back into latching-modifier behavior (#157 option).
+
+    The long layer decorates short persistently, so a long color stays lit across
+    subsequent short presses — the shimmer-status-light use case. With overlay on,
+    last_fired no longer gates the render: it behaves like compute_keytimes_led_color
+    on both raw layers.
+    """
+
+    def test_long_color_latches_across_short_press(self):
+        # Shimmer scenario: short reverb (white), long shimmer (blue). After shimmer
+        # latches, a short reverb tap must NOT drop the blue — overlay keeps it lit.
+        assert resolve_keytimes_render_color("long", "white", False, "blue", False, long_overlay=True) == get_color("blue")
+        assert resolve_keytimes_render_color("short", "white", False, "blue", False, long_overlay=True) == get_color("blue")
+
+    def test_overlay_matches_raw_composition(self):
+        # Overlay is exactly compute_keytimes_led_color on both layers, regardless of
+        # last_fired — the pre-#157 behavior.
+        for lf in (None, "short", "long"):
+            assert (resolve_keytimes_render_color(lf, "white", False, "blue", True, "red", long_overlay=True)
+                    == compute_keytimes_led_color("white", False, "blue", True, "red"))
+
+    def test_overlay_short_kill_switch_still_applies(self):
+        # short "off" kill switch overrides long even in overlay mode.
+        assert resolve_keytimes_render_color("long", "off", False, "blue", False, long_overlay=True) == COLORS["off"]


### PR DESCRIPTION
## Summary

The behavior #157 reported as a bug (sticky long-press color) is now the **non-default**, reachable via a new per-button `long_overlay` option. The behavior the reporter **expected** — LED color follows the last press, consistent with the label — is the **default**. So #157 is fixed for the reporter out of the box, while the old behavior is preserved as an opt-in.

It's worth reading the discussion in #157 to understand _why_ the reported behavior was there - it's not a bug, it's the desired behavior. With this PR change, _both_ behaviors are now available.

Closes #157.

## Root cause

In `keytimes` mode the render was asymmetric:
- **Label TEXT** was gated on `state.last_fired` (flips back to the short value on a short tap — the #143 fix).
- **LED color** used full two-layer composition in `compute_keytimes_led_color` (long>short precedence). A long press sets `state.long_color`; a subsequent short press only touches `state.short_color` and never clears `long_color`, so long precedence kept winning — color stuck, label didn't.

## Fix

New pure helper `resolve_keytimes_render_color(last_fired, …, long_overlay)` unifies the two axes:

- **Default (last-press-wins):** suppresses the inactive timing layer so the most recently fired class owns **both** LED and label color — matching the label rule. The reporter's config needs no changes, just the firmware update.
- **`long_overlay: true` (opt-in):** keeps the pre-#157 behavior — the long-press color is used in place of the short-press color (long>short composition). Useful when the long color marks a mode (e.g. a shimmer-on color riding over a reverb short cycle). The short cycle still operates: a short "off" entry remains a kill-switch that turns the LED off even with overlay on, and short presses always send their messages.

Per-button, since one device can mix both styles. Label TEXT is unchanged (still `last_fired`, from #143).

## Plumbing

`long_overlay` threaded through every layer so it round-trips and is editable:

- `firmware/dev/core/colors.py` — helper + `long_overlay` param
- `firmware/dev/code.py` — passes `btn_config.get("long_overlay")` to LED + label
- `firmware/dev/core/config.py` — validator persists `true` only
- `config.schema.json` — new boolean field
- `config-editor/src/lib/types.generated.ts` — regenerated type
- `config-editor/src-tauri/src/config.rs` — `ButtonConfig.long_overlay` (no `deny_unknown_fields`; would otherwise be dropped on save)
- `config-editor/src/lib/components/KeytimesEditor.svelte` — checkbox: "Long-press color overrides short-press color" (tooltip: "When set, the long-press color is used instead of the short-press color. Short presses send their messages as expected.")

## Tests / verification (all local, all green)

- **Python: 587 passed.** New: `TestResolveKeytimesRenderColor` (PUP repro: short-after-long flips color back), `TestResolveKeytimesRenderColorOverlay` (latch + raw-composition equivalence + kill-switch survives), `test_long_overlay_*` validator passthrough + schema-sync.
- **Rust: 85 passed** (`cargo test`, after staging firmware/CP resources).
- **Svelte: 0 errors, 0 warnings** (`npm run check`); `types.generated.ts` regen produced no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)