### PR TITLE
Fix phantom startup edge: init Switch.last_state to False (#112)

### DIFF
--- a/firmware/dev/core/button.py
+++ b/firmware/dev/core/button.py
@@ -25,7 +25,11 @@ class Switch:
         self.io = digitalio_module.DigitalInOut(pin)
         self.io.direction = digitalio_module.Direction.INPUT
         self.io.pull = digitalio_module.Pull.UP
-        self.last_state = True  # Pull-up: True = not pressed
+        # Initialize to the not-pressed state. `pressed` is `not io.value`, so an
+        # unpressed switch (pull-up high, io.value=True) reads pressed=False at boot.
+        # Matching last_state to that avoids a phantom "release" edge on the first
+        # changed() poll (which fired startup CC=0 on momentary/encoder buttons, #112).
+        self.last_state = False
 
     @property
     def pressed(self):

--- a/tests/test_switch_mock.py
+++ b/tests/test_switch_mock.py
@@ -3,6 +3,15 @@ Tests for the switch/digitalio mock.
 """
 
 import pytest
+import sys
+from pathlib import Path
+
+# Add firmware/dev to path
+FIRMWARE_DIR = Path(__file__).parent.parent / "firmware" / "dev"
+sys.path.insert(0, str(FIRMWARE_DIR))
+from core.button import Switch
+from tests.mocks import digitalio as mock_digitalio
+from tests.mocks import board
 
 
 class TestSwitchMock:
@@ -45,3 +54,41 @@ class TestButtonDebounce:
         """Placeholder test - implement when debounce is extracted."""
         # TODO: Extract ButtonState class from code.py and test here
         assert True
+
+
+class TestSwitchEdgeDetection:
+    """Regression tests for Switch.changed() startup behavior (issue #112)."""
+
+    def _make_switch(self):
+        return Switch(board.GP0, digitalio_module=mock_digitalio)
+
+    def test_no_phantom_edge_at_boot(self):
+        """First poll of an untouched switch reports no change (#112).
+
+        Previously last_state initialized to True while pressed=False, so the
+        first changed() reported a phantom release edge that fired startup CC=0
+        on momentary/encoder buttons.
+        """
+        sw = self._make_switch()
+        changed, pressed = sw.changed()
+        assert changed is False
+        assert pressed is False
+
+    def test_first_press_registers(self):
+        """A press landing before the first poll still produces a press edge."""
+        sw = self._make_switch()
+        sw.io.simulate_press()
+        changed, pressed = sw.changed()
+        assert changed is True
+        assert pressed is True
+
+    def test_press_release_cycle(self):
+        """Normal press then release produces two edges."""
+        sw = self._make_switch()
+        sw.changed()  # boot poll, no edge
+
+        sw.io.simulate_press()
+        assert sw.changed() == (True, True)
+
+        sw.io.simulate_release()
+        assert sw.changed() == (True, False)


### PR DESCRIPTION
Closes #112.

## Problem

On startup, the device always fired CC=0 on momentary and encoder buttons — with no input from the performer.

## Root cause

`Switch.__init__` set `last_state = True`, but `pressed` returns `not io.value`. An unpressed switch (pull-up high, `io.value=True`) reads `pressed=False` at boot. The first `changed()` poll saw `current(False) != last_state(True)` and reported a phantom release edge, which the momentary/encoder dispatch path turned into CC=0. (Toggle buttons were silent — they dispatch only on `pressed`.)

## Fix

Initialize `last_state = False` to match the actual not-pressed boot state. No phantom edge → no startup CC=0.

Also removes a related race: with `last_state=True`, a press landing before the firmware's first poll was absorbed (current==last → no edge → never fired). `last_state=False` makes the first press register regardless of timing.

## Tests

Added regression tests in `tests/test_switch_mock.py`:
- boot poll reports no edge
- press before first poll still registers
- normal press/release cycle produces two edges

Full suite: **601 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)