### PR TITLE
Add MIDI-IN CC page control (#15 P3b)

### DIFF
--- a/config-editor/src-tauri/src/config.rs
+++ b/config-editor/src-tauri/src/config.rs
@@ -422,6 +422,41 @@ pub struct DisplayConfig {
     pub expression_text_size: Option<String>,
 }
 
+/// Jump slot: incoming CC value is the absolute target page index (0-based), clamped
+/// to range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageControlJump {
+    pub cc: u8,
+}
+
+/// Inc/dec slot: fires only when the incoming value equals `value` (a trigger gate,
+/// not a page number); moves the active page by page_step and wraps.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageControlStep {
+    pub cc: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_step: Option<u8>,
+}
+
+/// MIDI-IN CC page control (device-level, #15 P3b): let an inbound Control Change
+/// switch the active page. Checked jump -> inc -> dec, first match wins.
+/// `channel: None` means any channel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageControl {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jump: Option<PageControlJump>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inc: Option<PageControlStep>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dec: Option<PageControlStep>,
+}
+
 /// One page (bank): a full control-surface snapshot. The device renders one
 /// page at a time. Buttons are required; encoder/expression are per-page and
 /// STD10-only. `global_channel`/`display` are optional per-page overrides,
@@ -485,6 +520,10 @@ pub struct MidiCaptainConfig {
     /// Per-button overrides allowed via ButtonConfig.long_press_threshold_ms.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub long_press_threshold_ms: Option<u16>,
+    /// MIDI-IN CC page control (#15 P3b): let an inbound Control Change switch the
+    /// active page. Absent or enabled=false means no inbound CC affects pages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_control: Option<PageControl>,
 }
 
 impl MidiCaptainConfig {
@@ -673,6 +712,50 @@ impl MidiCaptainConfig {
                 if let Some(ch) = exp.exp2.channel {
                     if ch > 15 {
                         errors.push(format!("{}EXP2 channel {} is invalid (must be 1-16)", pfx, ch + 1));
+                    }
+                }
+            }
+        }
+
+        // MIDI-IN CC page control (#15 P3b).
+        if let Some(ref pc) = self.page_control {
+            if let Some(ch) = pc.channel {
+                if ch > 15 {
+                    errors.push(format!("page_control channel {} is invalid (must be 1-16)", ch + 1));
+                }
+            }
+            if let Some(ref jump) = pc.jump {
+                if jump.cc > 127 {
+                    errors.push(format!("page_control.jump CC {} exceeds 127", jump.cc));
+                }
+            }
+            if let Some(ref inc) = pc.inc {
+                if inc.cc > 127 {
+                    errors.push(format!("page_control.inc CC {} exceeds 127", inc.cc));
+                }
+                if let Some(val) = inc.value {
+                    if val > 127 {
+                        errors.push(format!("page_control.inc value {} exceeds 127", val));
+                    }
+                }
+                if let Some(step) = inc.page_step {
+                    if step < 1 {
+                        errors.push(format!("page_control.inc page_step {} must be >= 1", step));
+                    }
+                }
+            }
+            if let Some(ref dec) = pc.dec {
+                if dec.cc > 127 {
+                    errors.push(format!("page_control.dec CC {} exceeds 127", dec.cc));
+                }
+                if let Some(val) = dec.value {
+                    if val > 127 {
+                        errors.push(format!("page_control.dec value {} exceeds 127", val));
+                    }
+                }
+                if let Some(step) = dec.page_step {
+                    if step < 1 {
+                        errors.push(format!("page_control.dec page_step {} must be >= 1", step));
                     }
                 }
             }
@@ -1245,6 +1328,7 @@ mod tests {
             active_page: 0,
             display: None,
             long_press_threshold_ms: None,
+            page_control: None,
         }
     }
 
@@ -1367,5 +1451,99 @@ mod tests {
         cfg.pages[0].buttons[0].message_type = MessageType::PageInc;
         cfg.pages[0].buttons[0].page_step = Some(1);
         assert!(cfg.validate().is_ok());
+    }
+
+    // --- page_control (MIDI-IN CC page control, #15 P3b) ---
+
+    #[test]
+    fn test_page_control_roundtrips() {
+        let json = r#"{
+            "buttons": [],
+            "page_control": {
+                "enabled": true,
+                "channel": 2,
+                "jump": {"cc": 20},
+                "inc": {"cc": 21, "value": 127, "page_step": 1},
+                "dec": {"cc": 22, "value": 0, "page_step": 2}
+            }
+        }"#;
+        let config = parse_migrated(json);
+        let pc = config.page_control.as_ref().unwrap();
+        assert_eq!(pc.enabled, Some(true));
+        assert_eq!(pc.channel, Some(2));
+        assert_eq!(pc.jump.as_ref().unwrap().cc, 20);
+        assert_eq!(pc.inc.as_ref().unwrap().cc, 21);
+        assert_eq!(pc.inc.as_ref().unwrap().value, Some(127));
+        assert_eq!(pc.dec.as_ref().unwrap().page_step, Some(2));
+
+        let reserialized = serde_json::to_string(&config).unwrap();
+        let config2: MidiCaptainConfig = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(config2.page_control.as_ref().unwrap().jump.as_ref().unwrap().cc, 20);
+    }
+
+    #[test]
+    fn test_page_control_valid_block_validates_ok() {
+        let mut cfg = _std10_minimal();
+        cfg.page_control = Some(PageControl {
+            enabled: Some(true),
+            channel: Some(2),
+            jump: Some(PageControlJump { cc: 20 }),
+            inc: Some(PageControlStep { cc: 21, value: Some(127), page_step: Some(1) }),
+            dec: Some(PageControlStep { cc: 22, value: Some(0), page_step: Some(1) }),
+        });
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_page_control_absent_validates_ok() {
+        let cfg = _std10_minimal();
+        assert!(cfg.page_control.is_none());
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_page_control_rejects_out_of_range_channel() {
+        let mut cfg = _std10_minimal();
+        cfg.page_control = Some(PageControl {
+            enabled: None, channel: Some(16), jump: None, inc: None, dec: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("page_control channel 17")));
+    }
+
+    #[test]
+    fn test_page_control_rejects_out_of_range_jump_cc() {
+        let mut cfg = _std10_minimal();
+        cfg.page_control = Some(PageControl {
+            enabled: None, channel: None,
+            jump: Some(PageControlJump { cc: 200 }),
+            inc: None, dec: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("page_control.jump CC 200")));
+    }
+
+    #[test]
+    fn test_page_control_rejects_out_of_range_inc_value_and_page_step() {
+        let mut cfg = _std10_minimal();
+        cfg.page_control = Some(PageControl {
+            enabled: None, channel: None, jump: None,
+            inc: Some(PageControlStep { cc: 21, value: Some(200), page_step: Some(0) }),
+            dec: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("page_control.inc value 200")));
+        assert!(err.iter().any(|e| e.contains("page_control.inc page_step 0")));
+    }
+
+    #[test]
+    fn test_page_control_rejects_out_of_range_dec_cc() {
+        let mut cfg = _std10_minimal();
+        cfg.page_control = Some(PageControl {
+            enabled: None, channel: None, jump: None, inc: None,
+            dec: Some(PageControlStep { cc: 128, value: None, page_step: None }),
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(err.iter().any(|e| e.contains("page_control.dec CC 128")));
     }
 }

--- a/config-editor/src/lib/types.generated.ts
+++ b/config-editor/src/lib/types.generated.ts
@@ -121,6 +121,7 @@ export interface MIDICaptainConfig {
    * MIDI Thru: echo messages received on USB MIDI back to the USB output (host loopback). Default false; enabling can cause duplicate notes or feedback when the DAW has MIDI echo enabled.
    */
   midi_thru_usb_to_usb?: boolean;
+  page_control?: PageControl;
 }
 /**
  * One page (bank): a full control-surface snapshot. The device renders one page at a time.
@@ -452,4 +453,63 @@ export interface DisplayConfig1 {
    * Expression pedal text size.
    */
   expression_text_size?: "small" | "medium" | "large";
+}
+/**
+ * Device-level: let an inbound MIDI Control Change switch the active page (jump/inc/dec). Absent or enabled=false means no inbound CC affects pages.
+ */
+export interface PageControl {
+  /**
+   * Enable/disable the whole block.
+   */
+  enabled?: boolean;
+  /**
+   * MIDI channel filter shared by all 3 slots. null = any channel; int = that channel only.
+   */
+  channel?: number | null;
+  jump?: PageControlJump;
+  inc?: PageControlStep;
+  dec?: PageControlStep1;
+}
+/**
+ * Absolute page jump slot. Omitted = disabled.
+ */
+export interface PageControlJump {
+  /**
+   * Standard MIDI byte value (0-127).
+   */
+  cc: number;
+}
+/**
+ * Page advance (wrap) slot. Omitted = disabled.
+ */
+export interface PageControlStep {
+  /**
+   * Standard MIDI byte value (0-127).
+   */
+  cc: number;
+  /**
+   * Standard MIDI byte value (0-127).
+   */
+  value?: number;
+  /**
+   * Number of pages to advance/retreat. Wraps at the ends.
+   */
+  page_step?: number;
+}
+/**
+ * Page retreat (wrap) slot. Omitted = disabled.
+ */
+export interface PageControlStep1 {
+  /**
+   * Standard MIDI byte value (0-127).
+   */
+  cc: number;
+  /**
+   * Standard MIDI byte value (0-127).
+   */
+  value?: number;
+  /**
+   * Number of pages to advance/retreat. Wraps at the ends.
+   */
+  page_step?: number;
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -72,6 +72,10 @@
       "type": "boolean",
       "default": false,
       "description": "MIDI Thru: echo messages received on USB MIDI back to the USB output (host loopback). Default false; enabling can cause duplicate notes or feedback when the DAW has MIDI echo enabled."
+    },
+    "page_control": {
+      "$ref": "#/definitions/PageControl",
+      "description": "Device-level: let an inbound MIDI Control Change switch the active page (jump/inc/dec). Absent or enabled=false means no inbound CC affects pages."
     }
   },
   "additionalProperties": false,
@@ -624,6 +628,72 @@
         "expression_text_size": {
           "$ref": "#/definitions/TextSize",
           "description": "Expression pedal text size."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PageControlJump": {
+      "type": "object",
+      "required": ["cc"],
+      "description": "Jump slot: incoming CC value is the absolute target page index (0-based), clamped to range.",
+      "properties": {
+        "cc": {
+          "$ref": "#/definitions/MidiByte",
+          "description": "CC number that triggers a jump. Incoming value is the 0-based target page index."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PageControlStep": {
+      "type": "object",
+      "required": ["cc"],
+      "description": "Inc/dec slot: fires only when the incoming value equals 'value' (a trigger gate, not a page number); moves the active page by page_step and wraps.",
+      "properties": {
+        "cc": {
+          "$ref": "#/definitions/MidiByte",
+          "description": "CC number that triggers this step."
+        },
+        "value": {
+          "$ref": "#/definitions/MidiByte",
+          "default": 127,
+          "description": "Trigger gate: fires only when the incoming CC value equals this. Default 127."
+        },
+        "page_step": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1,
+          "description": "Number of pages to advance/retreat. Wraps at the ends."
+        }
+      },
+      "additionalProperties": false
+    },
+    "PageControl": {
+      "type": "object",
+      "description": "MIDI-IN CC page control (device-level). Checked jump -> inc -> dec, first match wins. A matching CC short-circuits button-CC processing (MIDI THRU still forwards it). channel=null (default) means any channel.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the whole block."
+        },
+        "channel": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 15,
+          "default": null,
+          "description": "MIDI channel filter shared by all 3 slots. null = any channel; int = that channel only."
+        },
+        "jump": {
+          "$ref": "#/definitions/PageControlJump",
+          "description": "Absolute page jump slot. Omitted = disabled."
+        },
+        "inc": {
+          "$ref": "#/definitions/PageControlStep",
+          "description": "Page advance (wrap) slot. Omitted = disabled."
+        },
+        "dec": {
+          "$ref": "#/definitions/PageControlStep",
+          "description": "Page retreat (wrap) slot. Omitted = disabled."
         }
       },
       "additionalProperties": false

--- a/docs/plans/2026-07-02-issue-15-P3b-midi-in-cc-page-control.md
+++ b/docs/plans/2026-07-02-issue-15-P3b-midi-in-cc-page-control.md
@@ -19,10 +19,15 @@ deferred-switch `pending_page_target` global drained by `handle_switches()`.
 |---|---|---|
 | Schema shape | **Structured `jump`/`inc`/`dec` slots** (Option B) | Covers full scope (jump + inc/dec) in one device-level block. Fixed 3-slot shape → clean editor UI later (3 rows, no list management). Matches the existing `page_jump`/`page_inc`/`page_dec` action vocabulary from P3. |
 | Scope | **jump + inc/dec** | Full issue scope. inc/dec are nearly free — they reuse `resolve_page_target`. |
-| `jump` value semantics | **Incoming CC value = absolute page index**, clamped | OEM parity (`CC 20 XX` → jump to page `XX`). |
+| `jump` value semantics | **Incoming CC value = absolute page index (0-based)**, clamped | OEM parity (`CC 20 XX` → jump to page `XX`). **⚠ Confirm on hardware:** value is treated as a 0-based index (`val 1` → second page). If the OEM numbers pages 1-based, the jump path needs a `-1` offset. Verify against a real controller before shipping. |
+| Slot precedence within page_control | **Checked `jump` → `inc` → `dec`; first match wins** | Deterministic order. If two slots share a `cc` with the same gate, the earlier one wins and the later is unreachable — that's a config error, not a supported mode. |
+| Shared `cc`, different gates | **Supported** (`inc {cc:21,value:127}` + `dec {cc:21,value:0}`) | The fall-through structure lets one CC drive both directions via distinct value gates — encoder-style up/down on a single CC. Deliberate, tested. |
 | `inc`/`dec` value semantics | **Value is a trigger gate**, not a page number | Fires only when the incoming value equals the slot's `value` (default 127). Without a gate, `inc` would fire on *every* value including 0. Moves by `page_step`, wraps. |
 | Channel filter | **`channel: null` (or omitted) = any channel**; int = that channel only | DAWs blast CCs on many channels; opt-in filtering. Consistent with device `in_channel=None`. |
-| Precedence vs button CCs | **page_control wins; short-circuit** | A CC that matches a page_control slot switches the page and returns — it is NOT also processed as a button CC. Page CCs are dedicated control inputs. |
+| Precedence vs button CCs | **page_control wins; short-circuit button processing** | A CC that matches a page_control slot switches the page and returns from `_process_midi_msg` — it is NOT also processed as a button CC. Page CCs are dedicated control inputs. **Note:** short-circuit only skips button matching; `handle_midi()` still forwards the raw CC downstream via MIDI THRU (`code.py:1037-1065`) — THRU stays transparent. |
+| Same-page jump | **No-op (guard in wiring), but still short-circuit** | `switch_page()` never no-ops — it rebuilds `buttons[]` and resets latch/keytimes/encoder state even for the current page. A DAW re-sending `CC20=<current>` (scene recall, snapshot spam) would wipe latch state on every message. Wiring skips setting `pending_page_target` when target == current, but still `return`s: the CC matched a dedicated page slot either way. |
+| Malformed `cc` in a slot | **Drop the slot** (with `[CONFIG WARN]`), never clamp | Clamping `cc: 300` → 127 would make the device silently listen on CC 127 — a wrong CC number means wrong behavior, not degraded behavior. (`value`/`page_step` ARE clamped: same intent, degraded range.) |
+| Malformed `channel` | **Disable the whole block** (with `[CONFIG WARN]`) | `channel: null` means "any channel" — so coercing a bad value to `None` would *widen* matching from one channel to all channels, the opposite of a safe fallback. A malformed channel likely means the user meant to scope to one channel and mistyped it; silently defaulting to "any channel" turns a scoping typo into every CC on every channel jumping pages (risk during a live set). `channel` is shared by all 3 slots, so a bad value can't be dropped per-slot without ambiguity — the disable blast radius is the whole block, one tier stricter than the per-slot `cc` drop below. This has no direct precedent elsewhere in the `core/config.py` loader (existing fields clamp-to-default, e.g. bad `page_step` → 1); it's a new fail-closed convention introduced here, not a reused pattern. |
 | Editor form UI | **Deferred to P4** | Same split P3 used (per-field `page_step`/`page` inputs also deferred to P4). P3b ships schema + generated types + firmware + validation; the editor widget lands in P4. |
 
 ## Config shape
@@ -48,6 +53,8 @@ Behavior (2-page device shown; wrap/clamp per `resolve_page_target`):
 | `CC21 val 127` | page +1 (wrap past last → 0) |
 | `CC22 val 127` | page −1 (wrap past first → last) |
 | `CC21 val 0` | ignored (value ≠ gate) |
+| shared `cc`: `inc{cc:21,val:127}` + `dec{cc:21,val:0}`, `CC21 val 127` | page +1 (inc gate matches) |
+| shared `cc` (as above), `CC21 val 0` | page −1 (dec gate matches) |
 | any CC on filtered-out channel | ignored |
 | omitted slot | that action disabled |
 | `enabled: false` or block absent | no inbound CC affects pages |
@@ -89,14 +96,20 @@ tgt = resolve_page_control(
     config.get("page_control"), cc, val, msg_channel,
     config.get("active_page", 0), len(config.get("pages", [])))
 if tgt is not None:
-    pending_page_target = tgt
-    print(f"[PAGE] CC{cc}={val} -> page {tgt}")
-    update_status(f"PAGE {tgt + 1}")
+    # Same-page guard: switch_page() has no no-op path — it rebuilds buttons[]
+    # and resets latch/keytimes state. Skip the switch when already there, but
+    # still return: a matched page CC is a dedicated input either way.
+    if tgt != config.get("active_page", 0):
+        pending_page_target = tgt
+        print(f"[PAGE] CC{cc}={val} -> page {tgt}")
+        update_status(f"PAGE {tgt + 1}")
     return
 ```
 
+(`resolve_page_control` needs adding to the `core.config` import list at `code.py:49`.)
+
 **Deferred-switch invariant holds.** Main loop order is `handle_midi()` →
-`handle_switches()` (`code.py:1597`). `handle_midi()` only *sets*
+`handle_switches()` (`code.py:1599`). `handle_midi()` only *sets*
 `pending_page_target`; `handle_switches()` drains it after its scan loop the same
 iteration. Never call `switch_page()` inline — it rebuilds `buttons[]` and would
 corrupt the button-match loop `_process_midi_msg` is mid-way through.
@@ -104,9 +117,12 @@ corrupt the button-match loop `_process_midi_msg` is mid-way through.
 ## Validation
 
 - **`core/config.py`** loader: sanitize `page_control` — `enabled` bool (default
-  True); `channel` int 0–15 or None; each slot's `cc` clamped 0–127; `value`
-  clamped 0–127 (default 127); `page_step` int ≥1 (default 1). Drop malformed
-  slots rather than crash (firmware never rewrites disk).
+  True); `channel` must be int 0–15 or None, anything else **disables the block**
+  with `[CONFIG WARN]` (fail closed — coercing to None would widen matching to
+  all channels); each slot's `cc` must be int 0–127, otherwise **drop the slot**
+  with `[CONFIG WARN]` (never clamp — a wrong CC number is wrong behavior, not
+  degraded behavior); `value` clamped 0–127 (default 127); `page_step` int ≥1
+  (default 1). Firmware never rewrites disk.
 - **`config.rs`** `MidiCaptainConfig`: add `page_control: Option<PageControl>` with
   `#[serde(skip_serializing_if = "Option::is_none")]`; add `PageControl` /
   `PageControlJump` / `PageControlStep` structs; extend `validate()` with the same
@@ -130,6 +146,15 @@ corrupt the button-match loop `_process_midi_msg` is mid-way through.
 - `resolve_page_control` unit tests: jump absolute+clamp; inc/dec wrap; value gate
   reject; channel filter (match / mismatch / null=any); `enabled:false` → None;
   absent block → None; `num_pages<=1` → 0 (delegated to `resolve_page_target`).
+- Loader sanitize tests: slot with non-int / out-of-range `cc` dropped (not
+  clamped); malformed `channel` disables block; valid slots survive alongside a
+  dropped one.
+- Precedence: `jump.cc == inc.cc` (same gate) → jump wins, inc unreachable.
+- Shared `cc`, different gates: `inc{cc:21,value:127}` + `dec{cc:21,value:0}` —
+  `val 127` → inc target, `val 0` → dec target (locks in the encoder-style mode).
+- `enabled` key absent → defaults true (block active).
+- Wiring/behavior: jump to the current page leaves `pending_page_target` unset
+  (same-page guard) — assert via `resolve_page_control` + guard condition.
 - Rust: valid block round-trips; out-of-range cc/channel/page_step rejected.
 - On-device (manual, deferred to hardware pass): 2-page config, send `CC20 XX` from a
   MIDI monitor → page jumps; `CC21 127` → +1; verify screen/LEDs repaint.

--- a/docs/plans/2026-07-02-issue-15-P3b-midi-in-cc-page-control.md
+++ b/docs/plans/2026-07-02-issue-15-P3b-midi-in-cc-page-control.md
@@ -1,0 +1,141 @@
+# Issue #15 P3b — MIDI-IN CC Page Control (Design + Plan)
+
+**Date:** 2026-07-02
+**Branch:** `15-pages-p3b`
+**Phase:** P3b. Follows P2 (runtime `switch_page()` mechanism) and P3 (button-triggered
+`page_inc`/`page_dec`/`page_jump`). Delivers the last page-switch trigger the issue
+names: an inbound MIDI **Control Change** from a host/DAW/foot controller changes the
+active page.
+
+## Goal
+
+Let an external device switch the active page by sending a CC. Reuse the P2/P3
+machinery unchanged: pure index math in `resolve_page_target`, and the
+deferred-switch `pending_page_target` global drained by `handle_switches()`.
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Schema shape | **Structured `jump`/`inc`/`dec` slots** (Option B) | Covers full scope (jump + inc/dec) in one device-level block. Fixed 3-slot shape → clean editor UI later (3 rows, no list management). Matches the existing `page_jump`/`page_inc`/`page_dec` action vocabulary from P3. |
+| Scope | **jump + inc/dec** | Full issue scope. inc/dec are nearly free — they reuse `resolve_page_target`. |
+| `jump` value semantics | **Incoming CC value = absolute page index**, clamped | OEM parity (`CC 20 XX` → jump to page `XX`). |
+| `inc`/`dec` value semantics | **Value is a trigger gate**, not a page number | Fires only when the incoming value equals the slot's `value` (default 127). Without a gate, `inc` would fire on *every* value including 0. Moves by `page_step`, wraps. |
+| Channel filter | **`channel: null` (or omitted) = any channel**; int = that channel only | DAWs blast CCs on many channels; opt-in filtering. Consistent with device `in_channel=None`. |
+| Precedence vs button CCs | **page_control wins; short-circuit** | A CC that matches a page_control slot switches the page and returns — it is NOT also processed as a button CC. Page CCs are dedicated control inputs. |
+| Editor form UI | **Deferred to P4** | Same split P3 used (per-field `page_step`/`page` inputs also deferred to P4). P3b ships schema + generated types + firmware + validation; the editor widget lands in P4. |
+
+## Config shape
+
+Device-level (top-level) optional block:
+
+```json
+"page_control": {
+  "enabled": true,
+  "channel": null,
+  "jump": { "cc": 20 },
+  "inc":  { "cc": 21, "value": 127, "page_step": 1 },
+  "dec":  { "cc": 22, "value": 127, "page_step": 1 }
+}
+```
+
+Behavior (2-page device shown; wrap/clamp per `resolve_page_target`):
+
+| Inbound | Result |
+|---|---|
+| `CC20 val 1` | jump to page 1 (clamp to range) |
+| `CC20 val 99` | jump clamped to last page |
+| `CC21 val 127` | page +1 (wrap past last → 0) |
+| `CC22 val 127` | page −1 (wrap past first → last) |
+| `CC21 val 0` | ignored (value ≠ gate) |
+| any CC on filtered-out channel | ignored |
+| omitted slot | that action disabled |
+| `enabled: false` or block absent | no inbound CC affects pages |
+
+## Firmware design
+
+New pure helper in `core/config.py`, unit-tested, no device deps:
+
+```python
+def resolve_page_control(pc, cc, value, channel, current, num_pages):
+    """Target page index for an inbound CC under page_control, or None.
+
+    None when page_control is absent/disabled, the channel is filtered out, or no
+    slot matches (caller leaves the page unchanged). jump uses `value` as the
+    absolute target; inc/dec fire only when value == the slot's gate `value`.
+    """
+    if not pc or not pc.get("enabled", True):
+        return None
+    ch = pc.get("channel", None)
+    if ch is not None and ch != channel:
+        return None
+    jump = pc.get("jump")
+    if jump and jump.get("cc") == cc:
+        return resolve_page_target(current, num_pages, "jump", value)
+    inc = pc.get("inc")
+    if inc and inc.get("cc") == cc and value == inc.get("value", 127):
+        return resolve_page_target(current, num_pages, "inc", inc.get("page_step", 1))
+    dec = pc.get("dec")
+    if dec and dec.get("cc") == cc and value == dec.get("value", 127):
+        return resolve_page_target(current, num_pages, "dec", dec.get("page_step", 1))
+    return None
+```
+
+Wiring in `code.py::_process_midi_msg`, top of the `ControlChange` branch (before the
+button-match loop), declaring `global pending_page_target` at function scope:
+
+```python
+tgt = resolve_page_control(
+    config.get("page_control"), cc, val, msg_channel,
+    config.get("active_page", 0), len(config.get("pages", [])))
+if tgt is not None:
+    pending_page_target = tgt
+    print(f"[PAGE] CC{cc}={val} -> page {tgt}")
+    update_status(f"PAGE {tgt + 1}")
+    return
+```
+
+**Deferred-switch invariant holds.** Main loop order is `handle_midi()` →
+`handle_switches()` (`code.py:1597`). `handle_midi()` only *sets*
+`pending_page_target`; `handle_switches()` drains it after its scan loop the same
+iteration. Never call `switch_page()` inline — it rebuilds `buttons[]` and would
+corrupt the button-match loop `_process_midi_msg` is mid-way through.
+
+## Validation
+
+- **`core/config.py`** loader: sanitize `page_control` — `enabled` bool (default
+  True); `channel` int 0–15 or None; each slot's `cc` clamped 0–127; `value`
+  clamped 0–127 (default 127); `page_step` int ≥1 (default 1). Drop malformed
+  slots rather than crash (firmware never rewrites disk).
+- **`config.rs`** `MidiCaptainConfig`: add `page_control: Option<PageControl>` with
+  `#[serde(skip_serializing_if = "Option::is_none")]`; add `PageControl` /
+  `PageControlJump` / `PageControlStep` structs; extend `validate()` with the same
+  range checks (CC 0–127, channel 0–15, page_step ≥1).
+
+## Files (3-layer schema tax + firmware + tests)
+
+1. `config.schema.json` — add `page_control` to top-level `properties`; add
+   `PageControl` / `PageControlJump` / `PageControlStep` to `definitions`.
+2. `config-editor/src/lib/types.generated.ts` — regenerate from schema.
+3. `config-editor/src-tauri/src/config.rs` — structs + `validate()`.
+4. `firmware/dev/core/config.py` — `resolve_page_control()` + loader sanitize.
+5. `firmware/dev/code.py` — wire into `_process_midi_msg` ControlChange branch.
+6. `tests/test_config.py` — unit tests for `resolve_page_control` (jump clamp,
+   inc/dec wrap, gate mismatch, channel filter, disabled, absent block).
+7. Rust tests in `config.rs` — validation range coverage.
+8. `firmware/AGENTS.md` — replace the "deferred to P3b" note with the shipped design.
+
+## Test plan
+
+- `resolve_page_control` unit tests: jump absolute+clamp; inc/dec wrap; value gate
+  reject; channel filter (match / mismatch / null=any); `enabled:false` → None;
+  absent block → None; `num_pages<=1` → 0 (delegated to `resolve_page_target`).
+- Rust: valid block round-trips; out-of-range cc/channel/page_step rejected.
+- On-device (manual, deferred to hardware pass): 2-page config, send `CC20 XX` from a
+  MIDI monitor → page jumps; `CC21 127` → +1; verify screen/LEDs repaint.
+- `test-all.sh` green (pytest, cargo test, svelte-check, ruff, mpy-cross, clippy).
+
+## Deferred to P4
+
+- Editor form widget for `page_control` (CC/value/channel/page_step inputs).
+- Per-field `page_step`/`page` inputs on button page types (already P4).

--- a/firmware/AGENTS.md
+++ b/firmware/AGENTS.md
@@ -241,7 +241,32 @@ Pure index math lives in `core/config.py::resolve_page_target(current, num_pages
 
 Modes (`toggle`/`momentary`/`flash`) are accepted on page buttons but cosmetically irrelevant — `switch_page()` repaints every button immediately, so the trigger button shows whatever the *new* page defines for its position (build matching nav buttons on every page for a stable UI). `select` mode stays restricted to `pc`/`cc`, so page types are naturally excluded.
 
-MIDI-IN CC page control is deferred to **P3b** (device-level `page_control` block, reuses `resolve_page_target` + `pending_page_target`).
+### MIDI-IN CC Page Control (#15 P3b)
+
+Device-level `page_control` block lets an inbound MIDI Control Change switch the active page — the last page-switch trigger the issue names, alongside on-device buttons above. Structured `jump`/`inc`/`dec` slots (fixed 3-slot shape):
+
+```json
+"page_control": {
+  "enabled": true,
+  "channel": null,
+  "jump": { "cc": 20 },
+  "inc":  { "cc": 21, "value": 127, "page_step": 1 },
+  "dec":  { "cc": 22, "value": 127, "page_step": 1 }
+}
+```
+
+- `jump` — incoming CC **value** is the absolute target page index (0-based), clamped to range.
+- `inc`/`dec` — value is a **trigger gate** (default 127), not a page number; fires only when the incoming value equals it. Moves by `page_step`, wraps. A shared `cc` with distinct gates (`inc{cc:21,value:127}` + `dec{cc:21,value:0}`) drives both directions off one CC (encoder-style).
+- `channel: null` (or omitted) = any channel; int = that channel only.
+- Precedence: checked `jump` → `inc` → `dec`, first match wins.
+
+`core/config.py::resolve_page_control(pc, cc, value, channel, current, num_pages)` is the pure helper (unit-tested); it delegates the actual index math to `resolve_page_target`. Wiring lives at the top of `_process_midi_msg`'s `ControlChange` branch in `code.py`, **before** the button-match loop: a matching page_control CC sets `pending_page_target` (same deferred-switch invariant as button triggers) and **returns** — it short-circuits button-CC processing entirely, never falling through to also match a button. MIDI THRU is unaffected: `handle_midi()` forwards the raw CC downstream regardless of what `_process_midi_msg` did with it.
+
+Same-page guard: jumping/stepping to the *current* page skips setting `pending_page_target` (avoids wiping latch/keytimes state via a no-op `switch_page()`), but still `return`s — a matched page CC is a dedicated input either way, never also processed as a button CC.
+
+Loader sanitize (`core/config.py::validate_config`): malformed `channel` **disables the whole block** (fail-closed — coercing to None would widen matching to every channel); a slot's malformed `cc` **drops that slot** (never clamped — a wrong CC number is wrong behavior, not degraded behavior); `value`/`page_step` clamp to range like other MIDI byte fields.
+
+Editor form widget is deferred to P4 (schema + generated types + firmware + validation ship in P3b).
 
 ### PC Button LED Modes
 

--- a/firmware/dev/code.py
+++ b/firmware/dev/code.py
@@ -47,6 +47,7 @@ from core.config import (
     validate_config,
     get_active_page,
     resolve_page_target,
+    resolve_page_control,
     get_display_config,
     get_button_state_config,
     get_long_press_threshold_ms,
@@ -964,6 +965,7 @@ def update_pc_flash_timers():
 
 def _process_midi_msg(msg, source="USB"):
     """Process a received MIDI message — update LED/button state."""
+    global pending_page_target
     if not msg:
         return
 
@@ -973,6 +975,22 @@ def _process_midi_msg(msg, source="USB"):
         cc = msg.control
         val = msg.value
         print(f"[MIDI RX {source}] Ch{msg_channel+1} CC{cc}={val}")
+
+        # MIDI-IN CC page control (#15 P3b): a matching page_control CC short-circuits
+        # button-CC processing entirely (MIDI THRU still forwards it downstream).
+        tgt = resolve_page_control(
+            config.get("page_control"), cc, val, msg_channel,
+            config.get("active_page", 0), len(config.get("pages", [])))
+        if tgt is not None:
+            # Same-page guard: switch_page() has no no-op path — it rebuilds buttons[]
+            # and resets latch/keytimes state. Skip the switch when already there, but
+            # still return: a matched page CC is a dedicated input either way.
+            if tgt != config.get("active_page", 0):
+                pending_page_target = tgt
+                print(f"[PAGE] CC{cc}={val} -> page {tgt}")
+                update_status(f"PAGE {tgt + 1}")
+            return
+
         for i, btn_config in enumerate(buttons):
             if btn_config.get("type", "cc") == "cc" and btn_config.get("cc") == cc and btn_config.get("channel", 0) == msg_channel:
                 # Select-mode: activate this button and deactivate group siblings

--- a/firmware/dev/core/config.py
+++ b/firmware/dev/core/config.py
@@ -141,6 +141,90 @@ def resolve_page_target(current, num_pages, action, amount=1):
     return max(0, min(num_pages - 1, amount))
 
 
+def resolve_page_control(pc, cc, value, channel, current, num_pages):
+    """Target page index for an inbound CC under page_control, or None.
+
+    None when page_control is absent/disabled, the channel is filtered out, or no
+    slot matches (caller leaves the page unchanged). jump uses `value` as the
+    absolute target; inc/dec fire only when value == the slot's gate `value`.
+    Checked jump -> inc -> dec; first match wins.
+    """
+    if not pc or not pc.get("enabled", True):
+        return None
+    ch = pc.get("channel", None)
+    if ch is not None and ch != channel:
+        return None
+    jump = pc.get("jump")
+    if jump and jump.get("cc") == cc:
+        return resolve_page_target(current, num_pages, "jump", value)
+    inc = pc.get("inc")
+    if inc and inc.get("cc") == cc and value == inc.get("value", 127):
+        return resolve_page_target(current, num_pages, "inc", inc.get("page_step", 1))
+    dec = pc.get("dec")
+    if dec and dec.get("cc") == cc and value == dec.get("value", 127):
+        return resolve_page_target(current, num_pages, "dec", dec.get("page_step", 1))
+    return None
+
+
+def _sanitize_page_control_slot(slot, is_jump):
+    """Sanitize a page_control jump/inc/dec slot.
+
+    Returns a sanitized dict, or None if the slot is missing/not a dict or its `cc`
+    is malformed. `cc` is DROPPED (never clamped) on malformed input — a wrong CC
+    number is wrong behavior, not degraded behavior. `value`/`page_step` (inc/dec
+    only) ARE clamped: same intent, degraded range.
+    """
+    if not isinstance(slot, dict):
+        return None
+    cc = slot.get("cc")
+    if not isinstance(cc, int) or isinstance(cc, bool) or cc < 0 or cc > 127:
+        print("[CONFIG WARN] page_control slot has invalid cc " + str(cc) + "; dropping slot")
+        return None
+    out = {"cc": cc}
+    if is_jump:
+        return out
+    value = slot.get("value", 127)
+    if not isinstance(value, int) or isinstance(value, bool):
+        value = 127
+    out["value"] = max(0, min(127, value))
+    page_step = slot.get("page_step", 1)
+    if not isinstance(page_step, int) or isinstance(page_step, bool):
+        page_step = 1
+    out["page_step"] = max(1, page_step)
+    return out
+
+
+def _sanitize_page_control(pc):
+    """Sanitize the device-level page_control block.
+
+    Returns a sanitized dict, or None if absent/not a dict, or `channel` is
+    malformed — a malformed channel DISABLES THE WHOLE BLOCK (fail closed):
+    coercing a bad channel to None would widen matching from one channel to
+    every channel, turning a scoping typo into every CC on every channel
+    jumping pages.
+    """
+    if not isinstance(pc, dict):
+        return None
+    channel = pc.get("channel", None)
+    if channel is not None and (not isinstance(channel, int) or isinstance(channel, bool) or channel < 0 or channel > 15):
+        print("[CONFIG WARN] page_control channel " + str(channel) + " invalid; disabling page_control block")
+        return None
+    enabled = pc.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = True
+    out = {"enabled": enabled, "channel": channel}
+    jump = _sanitize_page_control_slot(pc.get("jump"), True)
+    if jump is not None:
+        out["jump"] = jump
+    inc = _sanitize_page_control_slot(pc.get("inc"), False)
+    if inc is not None:
+        out["inc"] = inc
+    dec = _sanitize_page_control_slot(pc.get("dec"), False)
+    if dec is not None:
+        out["dec"] = dec
+    return out
+
+
 _MIDI_BYTE_FIELDS = ("cc", "cc_on", "cc_off", "note", "velocity_on", "velocity_off", "program")
 
 def _clamp_state_field(field, value):
@@ -513,6 +597,14 @@ def validate_config(cfg, button_count=10):
     result["pages"] = validated_pages
     result["global_channel"] = global_channel
     result["long_press_threshold_ms"] = long_press_threshold_ms
+
+    if "page_control" in result:
+        sanitized_pc = _sanitize_page_control(result.get("page_control"))
+        if sanitized_pc is None:
+            del result["page_control"]
+        else:
+            result["page_control"] = sanitized_pc
+
     return result
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1462,6 +1462,22 @@ class TestPageControlSanitize:
         out = validate_config(cfg, button_count=1)
         assert out["page_control"]["enabled"] is True
 
+    def test_enabled_false_survives(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"enabled": False, "jump": {"cc": 20}},
+        }
+        out = validate_config(cfg, button_count=1)
+        assert out["page_control"]["enabled"] is False
+
+    def test_malformed_enabled_defaults_true(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"enabled": "yes", "jump": {"cc": 20}},
+        }
+        out = validate_config(cfg, button_count=1)
+        assert out["page_control"]["enabled"] is True
+
     def test_slot_with_out_of_range_cc_dropped_not_clamped(self):
         cfg = {
             "pages": [{"buttons": [{"label": "A", "cc": 20}]}],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ from core.config import (
     to_pages,
     get_active_page,
     resolve_page_target,
+    resolve_page_control,
 )
 
 
@@ -1342,3 +1343,170 @@ class TestPerPageChannel:
         }
         out = validate_config(cfg, button_count=1)
         assert out["pages"][0]["buttons"][0]["channel"] == 2
+
+
+class TestResolvePageControl:
+    """MIDI-IN CC page control (#15 P3b): resolve_page_control pure helper."""
+
+    def test_jump_absolute(self):
+        pc = {"jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 0, 0, 3) == 1
+
+    def test_jump_clamps_high(self):
+        pc = {"jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 99, 0, 0, 3) == 2
+
+    def test_inc_wraps(self):
+        pc = {"inc": {"cc": 21, "value": 127, "page_step": 1}}
+        assert resolve_page_control(pc, 21, 127, 0, 2, 3) == 0
+
+    def test_dec_wraps(self):
+        pc = {"dec": {"cc": 22, "value": 127, "page_step": 1}}
+        assert resolve_page_control(pc, 22, 127, 0, 0, 3) == 2
+
+    def test_inc_value_gate_reject(self):
+        pc = {"inc": {"cc": 21, "value": 127, "page_step": 1}}
+        assert resolve_page_control(pc, 21, 0, 0, 0, 3) is None
+
+    def test_inc_default_gate_is_127(self):
+        pc = {"inc": {"cc": 21}}
+        assert resolve_page_control(pc, 21, 127, 0, 0, 3) == 1
+        assert resolve_page_control(pc, 21, 126, 0, 0, 3) is None
+
+    def test_no_matching_cc_returns_none(self):
+        pc = {"jump": {"cc": 20}, "inc": {"cc": 21}, "dec": {"cc": 22}}
+        assert resolve_page_control(pc, 99, 1, 0, 0, 3) is None
+
+    def test_channel_filter_match(self):
+        pc = {"channel": 2, "jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 2, 0, 3) == 1
+
+    def test_channel_filter_mismatch(self):
+        pc = {"channel": 2, "jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 3, 0, 3) is None
+
+    def test_channel_null_matches_any(self):
+        pc = {"channel": None, "jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 7, 0, 3) == 1
+
+    def test_channel_omitted_matches_any(self):
+        pc = {"jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 7, 0, 3) == 1
+
+    def test_disabled_returns_none(self):
+        pc = {"enabled": False, "jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 0, 0, 3) is None
+
+    def test_enabled_absent_defaults_true(self):
+        pc = {"jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 0, 0, 3) == 1
+
+    def test_absent_block_returns_none(self):
+        assert resolve_page_control(None, 20, 1, 0, 0, 3) is None
+        assert resolve_page_control({}, 20, 1, 0, 0, 3) is None
+
+    def test_single_page_delegates_to_resolve_page_target(self):
+        pc = {"jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 5, 0, 0, 1) == 0
+
+    def test_precedence_jump_wins_over_inc_on_shared_cc(self):
+        # jump and inc share cc=20; jump is checked first, so inc is unreachable.
+        pc = {"jump": {"cc": 20}, "inc": {"cc": 20, "value": 5}}
+        # value 5 would be inc's gate, but jump matches cc=20 first and treats
+        # value as the absolute target index.
+        assert resolve_page_control(pc, 20, 5, 0, 0, 10) == 5
+
+    def test_shared_cc_different_gates_encoder_style(self):
+        # One CC drives both directions via distinct value gates.
+        pc = {
+            "inc": {"cc": 21, "value": 127, "page_step": 1},
+            "dec": {"cc": 21, "value": 0, "page_step": 1},
+        }
+        assert resolve_page_control(pc, 21, 127, 0, 1, 3) == 2  # inc gate matches
+        assert resolve_page_control(pc, 21, 0, 0, 1, 3) == 0    # dec gate matches
+
+    def test_same_page_jump_still_resolves(self):
+        # Wiring applies the same-page no-op guard; the pure helper itself just
+        # returns the (possibly unchanged) target.
+        pc = {"jump": {"cc": 20}}
+        assert resolve_page_control(pc, 20, 1, 0, 1, 3) == 1
+
+
+class TestPageControlSanitize:
+    """validate_config sanitization of the device-level page_control block."""
+
+    def test_valid_block_survives(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {
+                "enabled": True,
+                "channel": 2,
+                "jump": {"cc": 20},
+                "inc": {"cc": 21, "value": 127, "page_step": 1},
+                "dec": {"cc": 22, "value": 127, "page_step": 1},
+            },
+        }
+        out = validate_config(cfg, button_count=1)
+        pc = out["page_control"]
+        assert pc["enabled"] is True
+        assert pc["channel"] == 2
+        assert pc["jump"] == {"cc": 20}
+        assert pc["inc"] == {"cc": 21, "value": 127, "page_step": 1}
+        assert pc["dec"] == {"cc": 22, "value": 127, "page_step": 1}
+
+    def test_enabled_absent_defaults_true(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"jump": {"cc": 20}},
+        }
+        out = validate_config(cfg, button_count=1)
+        assert out["page_control"]["enabled"] is True
+
+    def test_slot_with_out_of_range_cc_dropped_not_clamped(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"jump": {"cc": 300}, "inc": {"cc": 21}},
+        }
+        out = validate_config(cfg, button_count=1)
+        pc = out["page_control"]
+        assert "jump" not in pc
+        assert pc["inc"]["cc"] == 21
+
+    def test_slot_with_non_int_cc_dropped(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"dec": {"cc": "twenty"}},
+        }
+        out = validate_config(cfg, button_count=1)
+        assert "dec" not in out["page_control"]
+
+    def test_malformed_channel_disables_whole_block(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"channel": 99, "jump": {"cc": 20}},
+        }
+        out = validate_config(cfg, button_count=1)
+        assert "page_control" not in out
+
+    def test_null_channel_is_valid_any_channel(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"channel": None, "jump": {"cc": 20}},
+        }
+        out = validate_config(cfg, button_count=1)
+        assert out["page_control"]["channel"] is None
+
+    def test_value_and_page_step_clamped_not_dropped(self):
+        cfg = {
+            "pages": [{"buttons": [{"label": "A", "cc": 20}]}],
+            "page_control": {"inc": {"cc": 21, "value": 999, "page_step": 0}},
+        }
+        out = validate_config(cfg, button_count=1)
+        inc = out["page_control"]["inc"]
+        assert inc["value"] == 127
+        assert inc["page_step"] == 1
+
+    def test_absent_block_stays_absent(self):
+        cfg = {"pages": [{"buttons": [{"label": "A", "cc": 20}]}]}
+        out = validate_config(cfg, button_count=1)
+        assert "page_control" not in out


### PR DESCRIPTION
## Summary
- Device-level `page_control` block lets an inbound MIDI CC (host/DAW/foot controller) switch the active page — the last page-switch trigger issue #15 names, after P2 (`switch_page()`) and P3 (button-triggered `page_inc`/`page_dec`/`page_jump`).
- Structured `jump`/`inc`/`dec` slots: `jump` treats the incoming CC value as an absolute page index (clamped); `inc`/`dec` treat it as a trigger gate (default 127) and step by `page_step` (wrapped). Precedence: jump → inc → dec, first match wins. A matching CC short-circuits button-CC processing but MIDI THRU still forwards it downstream. `channel: null` (or omitted) matches any channel.
- Fail-closed sanitize: malformed `channel` disables the whole block (coercing to `None` would widen matching to every channel); a slot's malformed `cc` drops just that slot (never clamped).
- 3-layer schema tax: `config.schema.json`, regenerated `types.generated.ts`, `config.rs` structs + `validate()`. Editor form widget deferred to P4.

## Test plan
- [x] `python3 -m pytest tests/test_config.py -q` — 216 passed (26 new: `resolve_page_control` jump/inc/dec/gates/channel/precedence/shared-cc, sanitize drop/disable/enabled cases)
- [x] `cargo test config::` — 40 passed (7 new: valid roundtrip, absent-ok, out-of-range channel/cc/value/page_step rejected)
- [x] `cargo clippy --all-targets` — clean
- [x] `ruff check firmware/ tests/` — clean
- [x] `tools/check-circuitpython-parse.sh` (mpy-cross CP 7.x syntax guard) — clean
- [x] `svelte-check` + `generate:types` freshness — clean, zero diff
- [x] Independent code review (superpowers:code-reviewer) — Ready to merge, no critical/important issues
- [x] On-device manual pass (std10, firmware v1.13.0-beta.3-6-g31ce2d3, 3-page config): `CC20` jump works and `CC20 0` lands on the first page — OEM page numbering confirmed 0-based; out-of-range `CC20 9` clamps to the last page; `CC21 127` increments with wrap; `CC21 64` correctly gated (received, no page switch); screen/LED repaint on every switch; `channel: 0` filter passes matching-channel CCs and ignores others. Serial `[PAGE]` log lines match expectations throughout. DIN input path verified via USB-DIN interface: `CC20` jump switches pages through 5-pin DIN IN and the channel filter is honored. Observed intermittent message loss (~1 in 5) on the DIN link with a budget interface — pre-existing DIN RX behavior, not specific to page control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
