### PR TITLE
Auto-retry transient Pages deployment failures

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment-retry.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
       # Refresh the Kanban snapshot; if the token can't read the org project,
@@ -36,5 +36,15 @@ jobs:
       - uses: actions/upload-pages-artifact@v5
         with:
           path: site/
+      # deploy-pages intermittently fails with a transient "Deployment failed,
+      # try again later" from the Pages backend; a single retry after a pause
+      # has recovered it every time.
       - id: deployment
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+      - name: Pause before retry
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 30
+      - id: deployment-retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Both production deploys so far (first-ever run, and the PR #171 merge) failed on the first attempt with `deploy-pages`' generic transient error — `Deployment failed, try again later` — and succeeded on manual rerun. This PR makes that retry automatic.

## Changes

- `actions/deploy-pages@v5` step gets `continue-on-error: true`; on failure the job sleeps 30s and runs a second `deploy-pages` attempt.
- The `github-pages` environment URL falls back to the retry step's output (`page_url || page_url`) when the first attempt failed.
- A failure of both attempts still fails the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)