### PR TITLE
GUI migration path for PaintAudio OEM FW5+ pedals (#186)

### DIFF
--- a/config-editor/src-tauri/src/commands.rs
+++ b/config-editor/src-tauri/src/commands.rs
@@ -564,12 +564,96 @@ fn enter_bootloader_via_serial(path: &Path) -> Result<(), ConfigError> {
 /// its RP2040 ROM bootloader. Used by the GUI recovery flow so the user
 /// doesn't have to open a serial terminal and type the reset script
 /// themselves.
+/// Strategy order (issue #186): the 1200-baud touch is primary — it's
+/// handled by the USB stack below any application code, so it also works
+/// when `boot.py`/`code.py` crashed before the REPL came up, and it's
+/// bench-confirmed on CircuitPython 7.3.1 (Nano 4, 2026-08-24). The REPL
+/// script path is retained only as a fallback and is considered deprecated.
 #[command]
 pub fn enter_bootloader(path: String) -> Result<(), ConfigError> {
     validate_device_path(&path)?;
     let path_obj = Path::new(&path);
     verify_device_connected(path_obj)?;
+
+    if let Ok(port) = find_device_serial_port(path_obj) {
+        if enter_bootloader_via_1200_touch(&port).is_ok() {
+            return Ok(());
+        }
+    }
+    // Deprecated fallback: drive the CircuitPython REPL.
     enter_bootloader_via_serial(path_obj)
+}
+
+/// Reboot an RP2040 into the ROM bootloader via the 1200-baud touch: open the
+/// CDC port at 1200 baud, hold briefly, close. Handled by the USB stack below
+/// any application code — bench-confirmed working on both CircuitPython 7.3.1
+/// and PaintAudio's OEM FW5+ arduino-pico firmware (it's the same mechanism
+/// PaintAudio's own MIDICAPTAINBOOT.HTML uses). Caller polls for RPI-RP2.
+fn enter_bootloader_via_1200_touch(port_name: &str) -> Result<(), ConfigError> {
+    let port = serialport::new(port_name, 1200)
+        .timeout(Duration::from_millis(500))
+        .open()
+        .map_err(|e| ConfigError {
+            message: format!("Failed to open {} at 1200 baud: {}", port_name, e),
+            details: None,
+        })?;
+    // Match PaintAudio's MIDICAPTAINBOOT.HTML timing (800 ms hold), then
+    // close → bootrom jump. The device may already be resetting on drop;
+    // teardown errors are irrelevant.
+    std::thread::sleep(Duration::from_millis(800));
+    drop(port);
+    Ok(())
+}
+
+/// Tauri command: detect a *possible* PaintAudio OEM FW5+ device.
+///
+/// FW5+ runs a C (arduino-pico) firmware: no CircuitPython drive ever mounts,
+/// so `scan_devices` can't see it — but its CDC serial port can be seen, and
+/// it presents CircuitPython's exact USB identity (bench-confirmed 2026-08-24
+/// on a Nano 4: same 0x239A VID as CP, same "Raspberry Pi"/"Pico" strings),
+/// so USB descriptors cannot distinguish v5 from a CP device. Heuristic:
+/// no device volume mounted + exactly one candidate port → possibly OEM v5.
+/// A CP device with a wedged filesystem looks the same; both want the same
+/// remedy (bootloader → reflash). The UI MUST require explicit user
+/// confirmation before acting — the port could also be an unrelated
+/// Pico-class dev board, and the 1200-baud touch reboots whatever it hits.
+#[command]
+pub fn detect_oem_v5_port() -> Result<Option<String>, ConfigError> {
+    if !crate::device::scan_devices().is_empty() {
+        return Ok(None);
+    }
+    let ports = serialport::available_ports().map_err(|e| ConfigError {
+        message: format!("Failed to enumerate serial ports: {}", e),
+        details: None,
+    })?;
+    // Same VID filter + macOS cu/tty dedupe as find_device_serial_port.
+    let mut names: Vec<String> = ports
+        .iter()
+        .filter(|p| {
+            matches!(
+                &p.port_type,
+                serialport::SerialPortType::UsbPort(info) if info.vid == ADAFRUIT_VID
+            )
+        })
+        .map(|p| p.port_name.clone())
+        .collect();
+    if names.iter().any(|n| n.contains("/cu.")) {
+        names.retain(|n| !n.contains("/tty."));
+    }
+    Ok(match names.len() {
+        1 => Some(names.remove(0)),
+        _ => None, // zero, or ambiguous multiple — don't guess.
+    })
+}
+
+/// Tauri command: put a (confirmed-by-user) OEM FW5+ device into the RP2040
+/// bootloader via the 1200-baud touch. Caller then polls `rpi_rp2_mount_path`.
+/// No flash erase is needed before reflashing CircuitPython: CP auto-formats
+/// an invalid filesystem region on first boot (bench-verified — a direct
+/// FW5.12 → CP 7.3.1 reflash produced a clean CIRCUITPY).
+#[command]
+pub fn enter_bootloader_oem_v5(port_name: String) -> Result<(), ConfigError> {
+    enter_bootloader_via_1200_touch(&port_name)
 }
 
 /// Safely eject/unmount the device volume.

--- a/config-editor/src-tauri/src/installer.rs
+++ b/config-editor/src-tauri/src/installer.rs
@@ -51,6 +51,12 @@ const MAX_SUPPORTED_CP_MAJOR: u8 = 7;
 /// `FirmwareInstaller.svelte`. `details` is otherwise unused by the install path.
 pub const CP_VERSION_UNSUPPORTED_CODE: &str = "cp_version_unsupported";
 
+/// Stamped on the install error when the device has no config.json to detect
+/// the model from (bare CircuitPython — e.g. right after an OEM FW5+
+/// migration, issue #186). The UI reveals a model picker and retries with
+/// `device_type_override`.
+pub const DEVICE_TYPE_UNKNOWN_CODE: &str = "device_type_unknown";
+
 /// Bundled filename of the default config template for this device type.
 fn config_source_name(dt: DeviceType) -> &'static str {
     match dt {
@@ -447,6 +453,7 @@ pub fn install_firmware_from(
     firmware_src: &Path,
     device_path: &Path,
     reset_config: bool,
+    device_type_override: Option<DeviceType>,
     progress: &mut dyn FnMut(InstallProgress),
 ) -> Result<InstallReport, ConfigError> {
     for required in &["boot.py", "code.py"] {
@@ -465,13 +472,16 @@ pub fn install_firmware_from(
     // diagnostic. See issue #132.
     check_cp_version_supported(device_path)?;
 
-    let device_type = detect_device_type(device_path).ok_or_else(|| {
-        ConfigError::msg(
-            "Could not detect device type from config.json on the device. \
-             Ensure the device has a valid config.json declaring a recognized \
-             'device' field (std10, mini6, nano4, duo2, one1).",
-        )
-    })?;
+    // Override wins (bare-CP devices — e.g. fresh OEM FW5+ migrations — have
+    // no config.json to detect from; the user picks the model in the UI).
+    let device_type = device_type_override
+        .or_else(|| detect_device_type(device_path))
+        .ok_or_else(|| ConfigError {
+            message: "Could not detect device type from config.json on the device. \
+                 Select your pedal model to install."
+                .to_string(),
+            details: Some(vec![DEVICE_TYPE_UNKNOWN_CODE.to_string()]),
+        })?;
 
     progress(InstallProgress {
         phase: InstallPhase::Planning,
@@ -663,8 +673,16 @@ pub async fn install_firmware(
     app: AppHandle,
     device_path: String,
     reset_config: bool,
+    device_type_override: Option<String>,
     on_progress: Channel<InstallProgress>,
 ) -> Result<InstallReport, ConfigError> {
+    // Parse the override up front so a bad string errors before any device IO.
+    let override_dt = match &device_type_override {
+        Some(name) => Some(DeviceType::from_name(name).ok_or_else(|| {
+            ConfigError::msg(format!("Unrecognized device type: {name}"))
+        })?),
+        None => None,
+    };
     validate_device_path(&device_path)?;
     let device = PathBuf::from(&device_path);
     verify_device_connected(&device)?;
@@ -691,7 +709,7 @@ pub async fn install_firmware(
         let mut emit = |p: InstallProgress| {
             let _ = on_progress.send(p);
         };
-        let report = install_firmware_from(&firmware_src, &device, reset_config, &mut emit)?;
+        let report = install_firmware_from(&firmware_src, &device, reset_config, override_dt, &mut emit)?;
 
         // Best-effort: a soft-reboot failure here is non-fatal — the firmware
         // is already on disk, user can power-cycle. We swallow the error.
@@ -756,7 +774,7 @@ mod tests {
 
     fn install(bundle: &Path, device: &Path, reset: bool) -> InstallReport {
         let mut sink = |_p: InstallProgress| {};
-        install_firmware_from(bundle, device, reset, &mut sink).unwrap()
+        install_firmware_from(bundle, device, reset, None, &mut sink).unwrap()
     }
 
     #[test]
@@ -923,7 +941,7 @@ mod tests {
         fs::remove_file(bundle.path().join("boot.py")).unwrap();
 
         let mut sink = |_p: InstallProgress| {};
-        let err = install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
+        let err = install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap_err();
         assert!(err.message.contains("boot.py"), "got: {}", err.message);
         assert!(!device.path().join("code.py").exists());
     }
@@ -936,7 +954,7 @@ mod tests {
         fs::write(device.path().join("config.json"), br#"{"device":"unknown"}"#).unwrap();
 
         let mut sink = |_p: InstallProgress| {};
-        let err = install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
+        let err = install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap_err();
         assert!(err.message.to_lowercase().contains("device type"));
         assert!(!device.path().join("boot.py").exists());
     }
@@ -1008,7 +1026,7 @@ mod tests {
         let mut events: Vec<InstallProgress> = Vec::new();
         {
             let mut sink = |p: InstallProgress| events.push(p);
-            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap();
+            install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap();
         }
 
         // For the lib subdir: the Delete event for `lib/adafruit_st7789.py`
@@ -1104,7 +1122,7 @@ mod tests {
         let mut events: Vec<InstallProgress> = Vec::new();
         {
             let mut sink = |p: InstallProgress| events.push(p);
-            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap();
+            install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap();
         }
 
         assert!(matches!(events.first().unwrap().phase, InstallPhase::Planning));
@@ -1292,7 +1310,7 @@ mod tests {
 
         let mut sink = |_p: InstallProgress| {};
         let err =
-            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
+            install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap_err();
         assert!(
             err.message.contains("CircuitPython"),
             "expected CP-version error, got: {}",
@@ -1318,7 +1336,7 @@ mod tests {
 
         let mut sink = |_p: InstallProgress| {};
         let err =
-            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
+            install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap_err();
         assert!(err.message.contains("9.2.7"));
         assert!(!device.path().join("boot.py").exists());
     }
@@ -1365,7 +1383,7 @@ mod tests {
 
         let mut sink = |_p: InstallProgress| {};
         let err =
-            install_firmware_from(bundle.path(), device.path(), false, &mut sink).unwrap_err();
+            install_firmware_from(bundle.path(), device.path(), false, None, &mut sink).unwrap_err();
         assert!(
             err.message.contains("CircuitPython"),
             "CP preflight should fire before device_type check; got: {}",

--- a/config-editor/src-tauri/src/lib.rs
+++ b/config-editor/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod installer;
 mod reflash;
 mod templates;
 
-use commands::{eject_device, enter_bootloader, read_config, read_config_raw, restart_device, validate_config, write_config, write_config_raw};
+use commands::{detect_oem_v5_port, eject_device, enter_bootloader, enter_bootloader_oem_v5, read_config, read_config_raw, restart_device, validate_config, write_config, write_config_raw};
 use device::{scan_devices, start_device_watcher, stop_device_watcher};
 use installer::{get_firmware_versions, install_firmware};
 use reflash::{reflash_circuitpython, rpi_rp2_mount_path};
@@ -26,6 +26,8 @@ pub fn run() {
             restart_device,
             eject_device,
             enter_bootloader,
+            enter_bootloader_oem_v5,
+            detect_oem_v5_port,
             scan_devices,
             start_device_watcher,
             stop_device_watcher,

--- a/config-editor/src-tauri/src/reflash.rs
+++ b/config-editor/src-tauri/src/reflash.rs
@@ -1,9 +1,12 @@
 //! "Reflash CircuitPython 7.3.1" feature (issue #134).
 //!
 //! Recovery flow for devices on a CircuitPython newer than this firmware
-//! supports (see issue #132 preflight). The user is walked through the
-//! one manual step we can't automate (unplug → hold Switch 1 / KEY0 → replug
-//! to enter the RP2040 ROM bootloader). Once `RPI-RP2` mounts, this module
+//! supports (see issue #132 preflight), and — via 1200-baud-touch bootloader
+//! entry (see `commands`) — the migration path off PaintAudio's OEM FW5+ C
+//! firmware (issue #186; no flash erase needed — CircuitPython auto-formats
+//! an invalid filesystem region on first boot, bench-verified). Note that
+//! Switch 1 / KEY0 does NOT enter the bootloader; it only exposes a running
+//! CP firmware's USB drive. Once `RPI-RP2` mounts, this module
 //! copies the bundled `.uf2` onto it. The bootloader handles the flash + reboot
 //! into the freshly written firmware on its own — we just wait for `CIRCUITPY`
 //! to remount and tell the UI.
@@ -195,9 +198,10 @@ pub async fn reflash_circuitpython(
     tauri::async_runtime::spawn_blocking(move || {
         let bootloader = detect_rpi_rp2().ok_or_else(|| {
             ConfigError::msg(
-                "RPI-RP2 bootloader drive not found. Unplug the device, hold \
-                 Switch 1 / KEY0, then plug USB back in. The RPI-RP2 drive should \
-                 appear within a few seconds — re-try once it does.",
+                "RPI-RP2 bootloader drive not found. Use the editor's automatic \
+                 bootloader entry or see docs/recovery-bootloader-entry.md. \
+                 (Holding Switch 1 / KEY0 does NOT enter the bootloader — it only \
+                 exposes a running CircuitPython firmware's USB drive.)",
             )
         })?;
 

--- a/config-editor/src/lib/api.ts
+++ b/config-editor/src/lib/api.ts
@@ -70,12 +70,14 @@ export async function installFirmware(
   devicePath: string,
   resetConfig: boolean,
   onProgress: (p: InstallProgress) => void,
+  deviceTypeOverride: string | null = null,
 ): Promise<InstallReport> {
   const channel = new Channel<InstallProgress>();
   channel.onmessage = onProgress;
   return invoke('install_firmware', {
     devicePath,
     resetConfig,
+    deviceTypeOverride,
     onProgress: channel,
   });
 }
@@ -104,6 +106,20 @@ export async function reflashCircuitpython(
   const channel = new Channel<ReflashProgress>();
   channel.onmessage = onProgress;
   return invoke('reflash_circuitpython', { onProgress: channel });
+}
+
+/**
+ * Detect a *possible* PaintAudio OEM FW5+ device: a MIDI-Captain-class CDC
+ * port with no device volume mounted. Heuristic — UI must get explicit user
+ * confirmation before acting (could be an unrelated Pico-class board).
+ */
+export async function detectOemV5Port(): Promise<string | null> {
+  return invoke('detect_oem_v5_port');
+}
+
+/** 1200-baud-touch the given CDC port into the RP2040 ROM bootloader. */
+export async function enterBootloaderOemV5(portName: string): Promise<void> {
+  return invoke('enter_bootloader_oem_v5', { portName });
 }
 
 // Event listeners

--- a/config-editor/src/lib/components/FirmwareInstaller.svelte
+++ b/config-editor/src/lib/components/FirmwareInstaller.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ask, message } from '@tauri-apps/plugin-dialog';
   import { getFirmwareVersions, installFirmware } from '$lib/api';
+  import { config } from '$lib/formStore';
   import ReflashCircuitPython from './ReflashCircuitPython.svelte';
   import type {
     DetectedDevice,
@@ -27,6 +28,12 @@
   // code in ConfigError.details[0], not the human message. Gates the inline
   // "Reflash CircuitPython 7.3.1" CTA so the fix is one click from the refusal.
   let cpMismatch = $state(false);
+  // Backend couldn't detect the model (bare CircuitPython — e.g. right after
+  // an OEM FW5 migration, #186): reveal a model picker and retry with it.
+  let needsDeviceType = $state(false);
+  // Pre-select whatever Device Settings has (falls back to std10, the form
+  // store's default) — still user-changeable in the picker.
+  let deviceTypeOverride = $state($config.device ?? 'std10');
   let versions = $state<FirmwareVersions | null>(null);
 
   // Re-fetch versions whenever the selected device changes or after a fresh
@@ -86,15 +93,29 @@
     cpMismatch = false;
 
     try {
-      report = await installFirmware(device.path, resetConfig, (p) => {
-        progress = p;
-      });
+      report = await installFirmware(
+        device.path,
+        resetConfig,
+        (p) => {
+          progress = p;
+        },
+        needsDeviceType ? deviceTypeOverride : null,
+      );
+      needsDeviceType = false;
       onInstalled?.();
       await refreshVersions(device);
     } catch (e: any) {
       errorMsg = e?.message ?? String(e);
       // Backend stamps this code on the CP-version preflight refusal (#132).
       cpMismatch = Array.isArray(e?.details) && e.details[0] === 'cp_version_unsupported';
+      const typeUnknown = Array.isArray(e?.details) && e.details[0] === 'device_type_unknown';
+      if (typeUnknown) {
+        // Skip the error dialog: the inline picker below IS the remedy.
+        // Sync to the Device Settings selection at reveal time.
+        deviceTypeOverride = $config.device ?? deviceTypeOverride;
+        needsDeviceType = true;
+        return;
+      }
       await message(`Firmware install failed:\n\n${errorMsg}`, { title: 'Install Failed', kind: 'error' });
     } finally {
       installing = false;
@@ -179,6 +200,25 @@
     <div class="result error">
       <strong>Error:</strong> {errorMsg}
     </div>
+    {#if needsDeviceType}
+      <!-- #186: bare-CP device (e.g. fresh OEM FW5 migration) has no
+           config.json to detect the model from — user picks it here. -->
+      <div class="device-type-picker">
+        <label>
+          Pedal model:
+          <select bind:value={deviceTypeOverride}>
+            <option value="std10">STD 10-switch</option>
+            <option value="mini6">Mini 6</option>
+            <option value="nano4">Nano 4</option>
+            <option value="duo2">Duo</option>
+            <option value="one1">One</option>
+          </select>
+        </label>
+        <button onclick={startInstall} disabled={installing}>
+          Install for this model
+        </button>
+      </div>
+    {/if}
     {#if cpMismatch}
       <!-- #132 refusal → reflash CTA, surfaced right at the error so the fix
            is one click away rather than buried in Advanced / Recovery below. -->
@@ -217,6 +257,13 @@
 </section>
 
 <style>
+  .device-type-picker {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 0.5rem;
+  }
+
   .installer {
     display: flex;
     flex-direction: column;

--- a/config-editor/src/lib/components/ReflashCircuitPython.svelte
+++ b/config-editor/src/lib/components/ReflashCircuitPython.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { enterBootloader, reflashCircuitpython, rpiRp2MountPath, scanDevices } from '$lib/api';
+  import { enterBootloader, enterBootloaderOemV5, reflashCircuitpython, rpiRp2MountPath, scanDevices } from '$lib/api';
   import type { DetectedDevice, ReflashProgress } from '$lib/types';
 
   interface Props {
@@ -16,9 +16,22 @@
      *  themselves. Without this prop the flow assumes RPI-RP2 is already
      *  mounted (used by the top-level banner). */
     device?: DetectedDevice | null;
+    /** CDC port of a detected (possible) OEM FW5+ device. When set, the flow
+     *  enters the bootloader via the 1200-baud touch on this port; the rest
+     *  of the reflash is unchanged (CircuitPython auto-formats FW5's leftover
+     *  filesystem region on first boot). Mutually exclusive with `device`. */
+    oemV5Port?: string | null;
+    /** Trigger-button label override (migration banner uses its own copy). */
+    triggerLabel?: string;
   }
 
-  let { highlight = false, onComplete, device = null }: Props = $props();
+  let {
+    highlight = false,
+    onComplete,
+    device = null,
+    oemV5Port = null,
+    triggerLabel = 'Reflash CircuitPython 7.3.1',
+  }: Props = $props();
 
   type State =
     | { kind: 'idle' }
@@ -213,7 +226,25 @@
       return;
     }
 
-    // 3. No device prop: just wait for the user to enter bootloader manually.
+    // 3. Migration mode (possible OEM FW5 device): 1200-baud touch on the
+    //    detected CDC port. Same stash-the-error pattern as the REPL path —
+    //    a successful touch drops the port mid-call, so errors are expected;
+    //    the RPI-RP2 poll is the source of truth.
+    if (oemV5Port) {
+      flow = { kind: 'enteringBootloader' };
+      entryError = null;
+      try {
+        await enterBootloaderOemV5(oemV5Port);
+      } catch (e: any) {
+        entryError = e?.message ?? String(e);
+      }
+      flow = { kind: 'awaitingBootloader' };
+      bootloaderPollTimer = setInterval(pollForBootloader, 1000);
+      startBootloaderWatchdog();
+      return;
+    }
+
+    // 4. No device prop: just wait for the user to enter bootloader manually.
     //    Rare — only happens if the banner case loses the RPI-RP2 mount
     //    between detection and modal open.
     flow = { kind: 'awaitingBootloader' };
@@ -241,7 +272,7 @@
 {/if}
 
 <button class="reflash-trigger" onclick={startReflash} disabled={flow.kind !== 'idle'}>
-  Reflash CircuitPython 7.3.1
+  {triggerLabel}
 </button>
 
 {#if flow.kind !== 'idle'}
@@ -252,7 +283,9 @@
     aria-labelledby="reflash-title"
   >
     <div class="modal">
-      <h3 id="reflash-title">Reflash CircuitPython 7.3.1</h3>
+      <h3 id="reflash-title">
+        {oemV5Port ? 'Migrate to MIDI Captain MAX' : 'Reflash CircuitPython 7.3.1'}
+      </h3>
 
       {#if flow.kind === 'enteringBootloader'}
         <div class="status">
@@ -260,9 +293,9 @@
           Telling the device to reboot into the RP2040 bootloader…
         </div>
         <p class="hint">
-          Sending <code>microcontroller.on_next_reset(RunMode.UF2)</code> over
-          the device's serial REPL. The <code>CIRCUITPY</code> drive will
-          disappear and <code>RPI-RP2</code> should mount within ~3 s.
+          Triggering the reboot over the device's serial port. The
+          <code>CIRCUITPY</code> drive will disappear and
+          <code>RPI-RP2</code> should mount within ~3 s.
         </p>
       {:else if flow.kind === 'awaitingBootloader'}
         <p>Waiting for the device to reboot into <code>RPI-RP2</code> bootloader mode.</p>

--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import {
     scanDevices, startDeviceWatcher, readConfigRaw, writeConfigRaw,
     onDeviceConnected, onDeviceDisconnected, restartDevice, ejectDevice,
-    rpiRp2MountPath
+    rpiRp2MountPath, detectOemV5Port
   } from '$lib/api';
   import type { DetectedDevice } from '$lib/types';
   import ConfigForm from '$lib/components/ConfigForm.svelte';
@@ -34,6 +34,9 @@ import PageControlSection from '$lib/components/PageControlSection.svelte';
   // the reflash affordance only surfaces when the user has actually staged
   // the device into bootloader mode — no clutter in the normal UI.
   let rpiRp2DetectedPath = $state<string | null>(null);
+  // Possible OEM FW5+ device (CDC port present, no device volume mounted).
+  // Heuristic — the banner requires explicit user action; never auto-touch.
+  let oemV5Port = $state<string | null>(null);
   let rpiRp2PollTimer: ReturnType<typeof setInterval> | null = null;
 
   // Event listener cleanup functions
@@ -135,6 +138,12 @@ import PageControlSection from '$lib/components/PageControlSection.svelte';
       const pollRpiRp2 = async () => {
         try {
           rpiRp2DetectedPath = await rpiRp2MountPath();
+          // Only look for the OEM-v5 signature when there's nothing better
+          // to show: no bootloader mounted and no device detected.
+          oemV5Port =
+            !rpiRp2DetectedPath && $devices.length === 0
+              ? await detectOemV5Port()
+              : null;
         } catch {
           // Transient — keep polling on next tick.
         }
@@ -389,6 +398,28 @@ import PageControlSection from '$lib/components/PageControlSection.svelte';
     </div>
   {/if}
 
+  {#if !rpiRp2DetectedPath && oemV5Port}
+    <div class="rpi-banner oem-v5" role="status">
+      <span class="label">
+        <strong>Possible PaintAudio OEM FW5 device</strong> on
+        <code>{oemV5Port}</code>. FW5 pedals can't be configured here, but
+        they can be migrated to MIDI Captain MAX.
+        <strong>Migration replaces the OEM firmware and erases its on-pedal
+        configs</strong> — to back up first, power on holding Switch&nbsp;1
+        and copy the pedal's drive to your computer. Only proceed if this
+        port is your MIDI Captain, not another Pico-based device.
+      </span>
+      <ReflashCircuitPython
+        oemV5Port={oemV5Port}
+        triggerLabel="Migrate to MIDI Captain MAX"
+        onComplete={async () => {
+          $devices = await scanDevices();
+          oemV5Port = null;
+        }}
+      />
+    </div>
+  {/if}
+
 
   <div class="editor-container">
     {#if $selectedDevice && !$isLoading}
@@ -553,6 +584,12 @@ import PageControlSection from '$lib/components/PageControlSection.svelte';
   .no-device {
     color: var(--text-secondary);
     font-style: italic;
+  }
+
+  .rpi-banner.oem-v5 {
+    /* Red-shifted variant: heuristic detection + firmware-replacing action. */
+    background: rgba(220, 82, 82, 0.12);
+    border-color: var(--danger, #c0605c);
   }
 
   .rpi-banner {

--- a/config-editor/src/routes/+page.svelte
+++ b/config-editor/src/routes/+page.svelte
@@ -415,6 +415,12 @@ import PageControlSection from '$lib/components/PageControlSection.svelte';
         onComplete={async () => {
           $devices = await scanDevices();
           oemV5Port = null;
+          // The reflash renames the volume (e.g. MIDICAPTAIN → CIRCUITPY),
+          // so name-based reselection can't match — pick the device up
+          // directly when it's unambiguous.
+          if ($devices.length === 1) {
+            await selectDevice($devices[0]);
+          }
         }}
       />
     </div>

--- a/docs/recovery-bootloader-entry.md
+++ b/docs/recovery-bootloader-entry.md
@@ -75,6 +75,20 @@ fresh CP install. The bundled `.uf2` is the CODE_ONLY variant, so your
 existing config and Max firmware files are preserved across the
 CircuitPython reflash where possible.
 
+## Coming from PaintAudio OEM FW5+?
+
+FW5+ replaced the CircuitPython application with a C firmware (arduino-pico
+core), so there is no REPL and Option A cannot work. Both FW5+ and
+CircuitPython 7.3.1 support the **1200-baud touch** instead: opening the
+device's serial port at 1200 baud and closing it reboots the chip into the
+RP2040 ROM bootloader. The Config Editor detects FW5 pedals and does this for
+you (banner → Migrate). Manual equivalent:
+`stty -f /dev/cu.usbmodemXXXX 1200`, or PaintAudio's own
+`MIDICAPTAINBOOT.HTML` (shipped on the FW5 pedal's drive) in Chrome/Edge.
+No flash erase is needed before reflashing CircuitPython — CP auto-formats
+FW5's leftover filesystem region on first boot (bench-verified). Back up the
+pedal's drive first if you may want to return to OEM firmware.
+
 ## Still stuck?
 
 Open an issue at


### PR DESCRIPTION
## Summary

OEM FW5+ replaced the CircuitPython application with a C firmware (arduino-pico + TinyUSB) that never mounts a CircuitPython drive, so MIDI Captain MAX had no install path onto it (#186). This adds a GUI-only migration flow: detect a v5 pedal, reboot it into the RP2040 bootloader, reflash CircuitPython, and install MCM — no terminal required.

## Root cause

Bench investigation (Nano 4, FW5.12) found:
- FW5+'s CDC port presents CircuitPython's *exact* USB identity (0x239A / "Raspberry Pi" / "Pico"), so descriptors can't distinguish v5 from a CP device — detection has to be behavioral.
- Both firmwares honor the 1200-baud touch (open the CDC port at 1200 baud, close it → reboots into the RP2040 ROM bootloader) — the same mechanism PaintAudio's own `MIDICAPTAINBOOT.HTML` uses.
- CircuitPython auto-formats FW5's leftover filesystem region on first boot — no flash erase step needed before reflashing CP.

## Changes

- `enter_bootloader`: 1200-baud touch as the primary strategy (works below application code, so it also covers a crashed `boot.py`); the REPL script is kept as a deprecated fallback.
- `detect_oem_v5_port` + a confirmation banner: surfaced when a candidate CDC port is present but no device volume is mounted. Heuristic by design — requires explicit user action before touching the port (could be an unrelated Pico-class board).
- `install_firmware`: optional `device_type_override`; the UI shows a model picker (pre-filled from Device Settings) when the device has no `config.json` to detect the model from the state right after a migration reflash.
- Auto-select the device after a migration reflash completes (the volume is often renamed, e.g. `MIDICAPTAIN` → `CIRCUITPY`, so name-based reselection doesn't match).
- Fixed reflash error text that incorrectly told users Switch 1 / KEY0 enters the bootloader (it only exposes a running firmware's drive).
- Documented the FW5 migration path in `docs/recovery-bootloader-entry.md`.

## Testing

Verified on physical hardware (Nano 4, FW5.12):
- Confirmed v1.13.0 cannot detect or install onto an FW5.12 device.
- 1200-baud touch confirmed working on both CircuitPython 7.3.1 and FW5.12.
- Direct FW5.12 → CP 7.3.1 reflash produces a clean `CIRCUITPY` (no flash erase needed — ruled out via a controlled bench test before building any erase logic).
- Full GUI-only round-trip: OEM v5 → banner → migrate → reflash → model picker → install → working MCM pedal, including a "dirty" device with leftover MCM + OEM files, which the install cleanly wiped.

## Follow-ups (not in this PR)

- First install onto a bare-CP device ends with a soft reset; CP only runs `boot.py` on hard reset, so the freshly installed `boot.py` never executes until the user power-cycles. Should use `microcontroller.reset()` after a first install specifically.
- Consider `picotool`/PICOBOOT-based direct flashing to replace the FAT-drive UF2 copy — faster and removes a class of mount-timing fragility.
